### PR TITLE
flush during send_prelude

### DIFF
--- a/src/unit.rs
+++ b/src/unit.rs
@@ -292,8 +292,9 @@ fn send_prelude(unit: &Unit, stream: &mut Stream, redir: bool) -> IoResult<()> {
     // finish
     write!(prelude, "\r\n")?;
 
-    // write all to the wire
     stream.write_all(&prelude[..])?;
+    // write all to the wire
+    stream.flush()?;
 
     Ok(())
 }


### PR DESCRIPTION
I'm seeing requests fail with `BadStatus`. A lot. I'm using the Agent API.

I believe it's only after periods of inactivity. I can reproduce it on multiple machines, but am yet to reproduce it with sufficient logging to be certain as to what is happening.

My best guess is that:

 * some time after the first request, but before the second, the server is closing the connection (very reasonable)
 * the second request comes along, through `send_prelude`, which is filling up the TLS buffer, but not actually trying to use the socket, so not seeing an (IO) error
 * `do_from_read` is doing the first actual IO operation on the connection
 * this is getting the `UnexpectedEOF` (which `read_next_line` calls `ConnectionAborted`)
 * ..which is reported as a `BadStatus`

The code already copes with the underlying socket dying... so long as `send_prelude` notices. I suspect that it is not. We can fix this by trying to force some IO inside `send_prelude`, by flushing here.

--

The server this happens most with is https://api.twitter.com, which seems happy for you to reuse a connection ten times, or to leave it data-idle (maybe there are tcp keepalives?) for 25 minutes sometimes, but sometimes will just kill it after five minutes. I'm unclear on how it is killing it, maybe it's confusing `rustls`?

I'm on modern amd64 ubuntu, stable/nightly rust from today, home/datacentre internet.
