### PR TITLE
Map CloseNotify to EOF

### DIFF
--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -1,0 +1,11 @@
+use std::io::Read;
+
+#[test]
+fn connection_close() {
+    let agent = ureq::Agent::default().build();
+    let resp = agent.get("https://example.com/404")
+        .set("Connection", "close")
+        .call();
+    assert_eq!(resp.status(), 404);
+    resp.into_reader().read_to_end(&mut vec![]).unwrap();
+}


### PR DESCRIPTION
rustls informs us about a clean EOF by causing an error. Handle this case.

The test does fail for me without the fix, but it's not guaranteed to be a good test long-term, maybe something else should be considered.