### PR TITLE
bump ring-related dependencies, and url/ascii

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ charset = ["encoding"]
 tls = ["rustls", "webpki", "webpki-roots"]
 
 [dependencies]
-ascii = "0.9"
+ascii = "1"
 base64 = "0.10"
 chunked_transfer = "1"
 cookie = { version = "0.12", features = ["percent-encode"] }
 lazy_static = "1"
 qstring = "0.6"
-url = "1"
+url = "2"
 rustls = { version = "0.16", optional = true, features = [] }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.17", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ cookie = { version = "0.12", features = ["percent-encode"] }
 lazy_static = "1"
 qstring = "0.6"
 url = "1"
-rustls = { version = "0.15", optional = true, features = [] }
-webpki = { version = "0.19", optional = true }
-webpki-roots = { version = "0.16", optional = true }
+rustls = { version = "0.16", optional = true, features = [] }
+webpki = { version = "0.21", optional = true }
+webpki-roots = { version = "0.17", optional = true }
 serde_json = { version = "1", optional = true }
 encoding = { version = "0.2", optional = true }


### PR DESCRIPTION
Fixes #7 

It looks like `rustls` and `webpki` have been updated together, and everything works together now?