### PR TITLE
Fix compilation errors with the cookies feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
       matrix:
         feature:
           - charset
-          - tls
           - cookies
     env:
       RUST_BACKTRACE: "1"
@@ -25,4 +24,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features json  ${{ matrix.feature }}
+          args: --no-default-features --features json tls ${{ matrix.feature }}

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -25,6 +25,7 @@ fn agent_reuse_headers() {
     assert_eq!(resp.header("X-Call").unwrap(), "2");
 }
 
+#[cfg(feature = "cookie")]
 #[test]
 fn agent_cookies() {
     let agent = agent();
@@ -53,6 +54,7 @@ fn agent_cookies() {
 }
 
 #[test]
+#[cfg(feature = "tls")]
 fn connection_reuse() {
     use std::io::Read;
     use std::time::Duration;

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,5 +1,5 @@
 use std::io::{Result as IoResult, Write};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use base64;
 #[cfg(feature = "cookie")]
@@ -44,19 +44,11 @@ impl Unit {
             // otherwise, no chunking.
             .unwrap_or(false);
 
-        let is_secure = url.scheme().eq_ignore_ascii_case("https");
-
-        let hostname = url.host_str().unwrap_or(DEFAULT_HOST).to_string();
-
         let query_string = combine_query(&url, &req.query, mix_queries);
 
-        let cookie_headers: Vec<_> = {
-            let state = req.agent.lock().unwrap();
-            match state.as_ref().map(|state| &state.jar) {
-                None => vec![],
-                Some(jar) => match_cookies(jar, &hostname, url.path(), is_secure),
-            }
-        };
+        let state = req.agent.lock().unwrap();
+        let cookie_headers: Vec<_> = extract_cookies(state, &url);
+
         let extra_headers = {
             let mut extra = vec![];
 
@@ -162,9 +154,7 @@ pub(crate) fn connect(
     }
 
     // squirrel away cookies
-    if cfg!(feature = "cookies") {
-        save_cookies(&unit, &resp);
-    }
+    save_cookies(&unit, &resp);
 
     // handle redirects
     if resp.redirect() && req.redirects > 0 {
@@ -208,6 +198,22 @@ pub(crate) fn connect(
 
     // release the response
     Ok(resp)
+}
+
+#[cfg(feature = "cookie")]
+fn extract_cookies(state: MutexGuard<Option<AgentState>>, url: &Url) -> Vec<Header> {
+    let is_secure = url.scheme().eq_ignore_ascii_case("https");
+    let hostname = url.host_str().unwrap_or(DEFAULT_HOST).to_string();
+
+    match state.as_ref().map(|state| &state.jar) {
+        None => vec![],
+        Some(jar) => match_cookies(jar, &hostname, url.path(), is_secure),
+    }
+}
+
+#[cfg(not(feature = "cookie"))]
+fn extract_cookies(_state: MutexGuard<Option<AgentState>>, url: &Url) -> Vec<Header> {
+    vec![]
 }
 
 // TODO check so cookies can't be set for tld:s
@@ -313,6 +319,9 @@ fn send_prelude(unit: &Unit, stream: &mut Stream, redir: bool) -> IoResult<()> {
 
     Ok(())
 }
+
+#[cfg(not(feature = "cookie"))]
+fn save_cookies(_unit: &Unit, _resp: &Response) {}
 
 /// Investigate a response for "Set-Cookie" headers.
 #[cfg(feature = "cookie")]


### PR DESCRIPTION
Sorry! I thought it was a bit suspicious that the tests passed first time.

I've made the tests run without `default_features`, but they only pass if both `tls` and `json` are enabled. So I've made them always run.