### PR TITLE
Bump base64 to 0.11; drops `byteorder` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tls = ["rustls", "webpki", "webpki-roots"]
 cookies = ["cookie"]
 
 [dependencies]
-base64 = "0.10"
+base64 = "0.11"
 chunked_transfer = "1"
 cookie = { version = "0.12", features = ["percent-encode"], optional = true}
 lazy_static = "1"


### PR DESCRIPTION
This drops ~220 unsafe expressions from the dependency tree. 

Tests still pass. There is one doc test failing but it fails both before and after this change.

After this the scariest thing remaining is `smallvec` that's pulled in by `unicode-normalization`, but that only uses a small subset of smallvec API, so it should be possible to replace with 100% safe code in less than a day of work.