### PR TITLE
Remove last `unsafe` usage and forbid further usages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cookies = ["cookie"]
 
 [dependencies]
 base64 = "0.11"
-chunked_transfer = "1"
+chunked_transfer = { version = "1", path = "rust-chunked-transfer" }
 cookie = { version = "0.12", features = ["percent-encode"], optional = true}
 lazy_static = "1"
 qstring = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cookies = ["cookie"]
 
 [dependencies]
 base64 = "0.11"
-chunked_transfer = { version = "1", path = "rust-chunked-transfer" }
+chunked_transfer = "1"
 cookie = { version = "0.12", features = ["percent-encode"], optional = true}
 lazy_static = "1"
 qstring = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![warn(clippy::all)]
 //! ureq is a minimal request library.
 //!

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,7 +6,7 @@ use chunked_transfer::Decoder as ChunkDecoder;
 use crate::error::Error;
 use crate::header::Header;
 use crate::pool::PoolReturnRead;
-use crate::stream::{ReclaimStream, Stream};
+use crate::stream::Stream;
 use crate::unit::Unit;
 
 #[cfg(feature = "json")]
@@ -582,9 +582,12 @@ impl<R: Read> Read for LimitedRead<R> {
     }
 }
 
-impl<R: ReclaimStream> ReclaimStream for LimitedRead<R> {
-    fn reclaim_stream(self) -> Stream {
-        self.reader.reclaim_stream()
+impl<R> From<LimitedRead<R>> for Stream
+where
+    Stream: From<R>
+{
+    fn from(limited_read: LimitedRead<R>) -> Stream {
+        limited_read.reader.into()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -77,7 +77,7 @@ impl<R> From<ChunkDecoder<R>> for Stream
 where
     Stream : From<R> {
     fn from(chunk_decoder: ChunkDecoder<R>) -> Stream {
-        chunk_decoder.unwrap().into()
+        chunk_decoder.into_inner().into()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,6 +4,8 @@ use std::net::TcpStream;
 use std::net::ToSocketAddrs;
 use std::time::Duration;
 
+use chunked_transfer::Decoder as ChunkDecoder;
+
 #[cfg(feature = "tls")]
 use rustls::ClientSession;
 #[cfg(feature = "tls")]
@@ -68,6 +70,22 @@ impl Read for Stream {
             #[cfg(test)]
             Stream::Test(reader, _) => reader.read(buf),
         }
+    }
+}
+
+pub(crate) trait ReclaimStream {
+    fn reclaim_stream(self) -> Stream;
+}
+
+impl ReclaimStream for Stream {
+    fn reclaim_stream(self) -> Stream {
+        self
+    }
+}
+
+impl<R: ReclaimStream> ReclaimStream for ChunkDecoder<R> {
+    fn reclaim_stream(self) -> Stream {
+        self.unwrap().reclaim_stream()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -73,19 +73,11 @@ impl Read for Stream {
     }
 }
 
-pub(crate) trait ReclaimStream {
-    fn reclaim_stream(self) -> Stream;
-}
-
-impl ReclaimStream for Stream {
-    fn reclaim_stream(self) -> Stream {
-        self
-    }
-}
-
-impl<R: ReclaimStream> ReclaimStream for ChunkDecoder<R> {
-    fn reclaim_stream(self) -> Stream {
-        self.unwrap().reclaim_stream()
+impl<R> From<ChunkDecoder<R>> for Stream
+where
+    Stream : From<R> {
+    fn from(chunk_decoder: ChunkDecoder<R>) -> Stream {
+        chunk_decoder.unwrap().into()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -78,7 +78,7 @@ impl Read for Stream {
     }
 }
 
-impl<R> From<ChunkDecoder<R>> for Stream
+impl<R: Read> From<ChunkDecoder<R>> for Stream
 where
     Stream : From<R> {
     fn from(chunk_decoder: ChunkDecoder<R>) -> Stream {


### PR DESCRIPTION
Prompted by [Smoke-testing Rust HTTP clients](https://medium.com/@shnatsel/smoke-testing-rust-http-clients-b8f2ee5db4e6), I looked into whether the `unsafe` code directly present in ureq could be removed and I think it can. The only uses of `unsafe` in ureq today are present because ureq wants to "unwrap" a `ChunkDecoder<Stream>` back into a plain `Stream`, but there's no way of safely doing so. To remove this unsafe usage, I've submitted https://github.com/frewsxcv/rust-chunked-transfer/pull/3 to the chunked_transfer crate, and this PR which makes use of the new ChunkDecoder::unwrap method to remove the need for unsafe. I also added `#![forbid(unsafe_code)]` to prevent further unsafes from sneeking in.

This cannot be merged until the linked rust-chunked-transfer PR is merged and a new version published, as ureq will need to be updated to depend on the new version.