### PR TITLE
Disable the native system timeout for socket

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -181,14 +181,24 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
     .map_err(|err| Error::ConnectionFailed(format!("{}", err)))?;
 
     // rust's absurd api returns Err if we set 0.
+    // Setting it to None will disable the native system timeout
     if unit.timeout_read > 0 {
         stream
             .set_read_timeout(Some(Duration::from_millis(unit.timeout_read as u64)))
             .ok();
+    } else {
+        stream
+            .set_read_timeout(None)
+            .ok();
     }
+
     if unit.timeout_write > 0 {
         stream
             .set_write_timeout(Some(Duration::from_millis(unit.timeout_write as u64)))
+            .ok();
+    } else {
+        stream
+            .set_write_timeout(None)
             .ok();
     }
 


### PR DESCRIPTION
Fix for https://github.com/algesten/ureq/issues/30

Based on the document of TcdStream to disable timeout we need to pass None to TcpSocket::set_read_timeout/TcpSocket::set_write_timeout

https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout