### PR TITLE
Add README badges for crates.io and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ureq
 
 ![](https://github.com/algesten/ureq/workflows/CI/badge.svg)
+[![CratesIO](https://img.shields.io/crates/v/ureq.svg)](https://crates.io/crates/ureq)
+[![Documentation](https://docs.rs/ureq/badge.svg)](https://docs.rs/ureq)
+
 
 > Minimal request library in rust.
 


### PR DESCRIPTION
Add convenient shortcuts to commonly used links in rust projects.

This is particularly useful for the documentation badge as the README doesn't provide the same level of detail that the documentation on docs.rs 