### PR TITLE
Set a default content type for JSON requests

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -132,6 +132,9 @@ impl Request {
     /// ```
     #[cfg(feature = "json")]
     pub fn send_json(&mut self, data: SerdeValue) -> Response {
+        if let None = self.header("Content-Type") {
+            self.set("Content-Type", "application/json");
+        }
         self.do_call(Payload::JSON(data))
     }
 

--- a/src/test/body_send.rs
+++ b/src/test/body_send.rs
@@ -73,3 +73,39 @@ fn str_with_encoding() {
         [72, 228, 108, 108, 111, 32, 87, 246, 114, 108, 100, 33, 33, 33]
     );
 }
+
+#[test]
+#[cfg(feature = "json")]
+fn content_type_on_json() {
+    test::set_handler("/content_type_on_json", |_unit| {
+        test::make_response(200, "OK", vec![], vec![])
+    });
+    let mut json = SerdeMap::new();
+    json.insert(
+        "Hello".to_string(),
+        SerdeValue::String("World!!!".to_string()),
+    );
+    let resp = post("test://host/content_type_on_json").send_json(SerdeValue::Object(json));
+    let vec = resp.to_write_vec();
+    let s = String::from_utf8_lossy(&vec);
+    assert!(s.contains("\r\nContent-Type: application/json\r\n"));
+}
+
+#[test]
+#[cfg(feature = "json")]
+fn content_type_not_overriden_on_json() {
+    test::set_handler("/content_type_not_overriden_on_json", |_unit| {
+        test::make_response(200, "OK", vec![], vec![])
+    });
+    let mut json = SerdeMap::new();
+    json.insert(
+        "Hello".to_string(),
+        SerdeValue::String("World!!!".to_string()),
+    );
+    let resp = post("test://host/content_type_not_overriden_on_json")
+        .set("content-type", "text/plain")
+        .send_json(SerdeValue::Object(json));
+    let vec = resp.to_write_vec();
+    let s = String::from_utf8_lossy(&vec);
+    assert!(s.contains("\r\ncontent-type: text/plain\r\n"));
+}


### PR DESCRIPTION
When sending a JSON request a Content-Type of `application/json` is usually wanted. This is often set as a default for JSON methods by HTTP clients so can be confusing when it is not set. However, we do not want to prevent the user from setting their own Content-Type.