### PR TITLE
Bump rustls + co

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ cookie = { version = "0.12", features = ["percent-encode"], optional = true}
 lazy_static = "1"
 qstring = "0.7"
 url = "2"
-rustls = { version = "0.16", optional = true, features = [] }
+rustls = { version = "0.17", optional = true, features = [] }
 webpki = { version = "0.21", optional = true }
-webpki-roots = { version = "0.18", optional = true }
+webpki-roots = { version = "0.19", optional = true }
 serde_json = { version = "1", optional = true }
 encoding = { version = "0.2", optional = true }


### PR DESCRIPTION
Hopefully this isn't as urgent as an upgrade, as rustls 0.17 didn't switch major ring versions -- but I figured I'd send a PR to keep on top of dependencies anyways.