### PR TITLE
Add support for application/x-www-form-urlencoded

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,9 +1,10 @@
+use std::borrow::Borrow;
 use std::io::Read;
 use std::sync::{Arc, Mutex};
 
 use lazy_static::lazy_static;
 use qstring::QString;
-use url::Url;
+use url::{form_urlencoded, Url};
 
 use crate::agent::{self, Agent, AgentState};
 use crate::body::Payload;
@@ -179,6 +180,37 @@ impl Request {
         let charset =
             crate::response::charset_from_content_type(self.header("content-type")).to_string();
         self.do_call(Payload::Text(text, charset))
+    }
+
+    /// Send a sequence of (key, value) pairs as form-urlencoded data.
+    ///
+    /// The `Content-Type` header is implicitly set to application/x-www-form-urlencoded.
+    /// The `Content-Length` header is implicitly set to the length of the serialized value.
+    ///
+    /// ```
+    /// #[macro_use]
+    /// extern crate ureq;
+    ///
+    /// fn main() {
+    /// let r = ureq::post("/my_page")
+    ///     .send_form(&[("foo", "bar"),("foo2", "bar2")]);
+    /// println!("{:?}", r);
+    /// }
+    /// ```
+    pub fn send_form<I, K, V>(&mut self, pairs: I) -> Response
+    where
+        I: IntoIterator,
+        I::Item: Borrow<(K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        if self.header("Content-Type").is_none() {
+            self.set("Content-Type", "application/x-www-form-urlencoded");
+        }
+        let encoded = form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(pairs)
+            .finish();
+        self.do_call(Payload::Bytes(encoded.into_bytes()))
     }
 
     /// Send data from a reader.

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::io::Read;
 use std::sync::{Arc, Mutex};
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -197,18 +197,12 @@ impl Request {
     /// println!("{:?}", r);
     /// }
     /// ```
-    pub fn send_form<I, K, V>(&mut self, pairs: I) -> Response
-    where
-        I: IntoIterator,
-        I::Item: Borrow<(K, V)>,
-        K: AsRef<str>,
-        V: AsRef<str>,
-    {
+    pub fn send_form(&mut self, data: &[(&str, &str)]) -> Response {
         if self.header("Content-Type").is_none() {
             self.set("Content-Type", "application/x-www-form-urlencoded");
         }
         let encoded = form_urlencoded::Serializer::new(String::new())
-            .extend_pairs(pairs)
+            .extend_pairs(data)
             .finish();
         self.do_call(Payload::Bytes(encoded.into_bytes()))
     }


### PR DESCRIPTION
This adds a new method `send_form` with support for `application/x-www-form-urlencoded` content to fix #13. The method takes a sequence of (key, value) pairs.

```rust
//using a slice
let _ = ureq::post("/my_page").send_form(&[("foo", "bar"),("foo2", "bar2")]);
//or a vec
let _ = ureq::post("/my_page").send_form(vec![("foo", "bar"),("foo2", "bar2")]);
```

The `QString` serialization via `percent_encoding` is not fully compliant ([1] and [2]), so the `form_urlencoded` serialization of `url` is used, which is already a dependency. 

`charset` is not supported as only `utf-8` appears to be conforming ([3]) with this `Content-Type`.

This pull request does not add `Serde` support but if someone else want's to take a look `serde_urlencoded` ([4]) would probably be the way to go.

Fixes #13 

[1]: https://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1
[2]: https://github.com/algesten/qstring/issues/3
[3]: https://url.spec.whatwg.org/#application/x-www-form-urlencoded
[4]: https://docs.rs/serde_urlencoded/0.6.1/serde_urlencoded/fn.to_string.html