### PR TITLE
Add SOCKS5 feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ json = ["serde_json"]
 charset = ["encoding"]
 tls = ["rustls", "webpki", "webpki-roots"]
 cookies = ["cookie"]
+socks-proxy = ["socks"]
 
 [dependencies]
 base64 = "0.12"
@@ -27,6 +28,7 @@ cookie = { version = "0.13", features = ["percent-encode"], optional = true}
 lazy_static = "1"
 qstring = "0.7"
 url = "2"
+socks = { version = "0.3.2", optional = true }
 rustls = { version = "0.17", optional = true, features = [] }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.19", optional = true }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -61,6 +61,17 @@ impl Proxy {
         self.user.is_some() && self.password.is_some()
     }
 
+    /// Create a proxy from a format string.
+    /// # Arguments:
+    /// * `proxy` - a str of format `<protocol>://<user>:<password>@<host>:port` . All parts except host are optional.
+    /// # Protocols
+    /// * `http`: HTTP Connect
+    /// * `socks`, `socks5`: SOCKS5 (requires socks feature)
+    /// # Examples
+    /// * `http://127.0.0.1:8080`
+    /// * `socks5://john:smith@socks.google.com`
+    /// * `john:smith@socks.google.com:8000`
+    /// * `localhost`
     pub fn new<S: AsRef<str>>(proxy: S) -> Result<Self, Error> {
         let mut proxy_parts = proxy
             .as_ref()

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -283,6 +283,7 @@ fn connect_socks5(
     // 3) an exception is thrown.
     // # Defects
     // 1) In the event of a timeout, a thread may be left running in the background.
+    // TODO: explore supporting timeouts upstream in Socks5Proxy.
     let stream = if timeout_connect > 0 {
         let master_signal = Arc::new((Mutex::new(false), Condvar::new()));
         let slave_signal = master_signal.clone();


### PR DESCRIPTION
Adds support for SOCKS5 proxying via the socks crate.

Despite a few attempts I was not able to get the existing Proxy functionality working. I think it's intended to be an HTTP Connect proxy. If it worked before, I think it should still work, but I've not been able to test it.

I also marked the Proxy connect function as (crate) as it returns a string which is only useful to ureq internally. I don't think it makes sense to expose it publically.