### PR TITLE
Add optional support for native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rustls-native-certs = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding = { version = "0.2", optional = true }
+native-tls = { version = "0.2", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -250,7 +250,7 @@ impl Agent {
         self.request("PATCH", path)
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
     pub(crate) fn state(&self) -> &Arc<Mutex<Option<AgentState>>> {
         &self.state
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,9 @@ pub enum Error {
     ProxyConnect,
     /// Incorrect credentials for proxy
     InvalidProxyCreds,
+    /// TLS Error
+    #[cfg(feature = "native-tls")]
+    TlsError(native_tls::Error),
 }
 
 impl Error {
@@ -59,6 +62,8 @@ impl Error {
             Error::BadProxyCreds => 500,
             Error::ProxyConnect => 500,
             Error::InvalidProxyCreds => 500,
+            #[cfg(feature = "native-tls")]
+            Error::TlsError(_) => 599,
         }
     }
 
@@ -78,6 +83,8 @@ impl Error {
             Error::BadProxyCreds => "Failed to parse proxy credentials",
             Error::ProxyConnect => "Proxy failed to connect",
             Error::InvalidProxyCreds => "Provided proxy credentials are incorrect",
+            #[cfg(feature = "native-tls")]
+            Error::TlsError(_) => "TLS Error",
         }
     }
 
@@ -97,6 +104,8 @@ impl Error {
             Error::BadProxyCreds => "Failed to parse proxy credentials".to_string(),
             Error::ProxyConnect => "Proxy failed to connect".to_string(),
             Error::InvalidProxyCreds => "Provided proxy credentials are incorrect".to_string(),
+            #[cfg(feature = "native-tls")]
+            Error::TlsError(err) => format!("TLS Error: {}", err),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,7 @@ impl Error {
             Error::ProxyConnect => 500,
             Error::InvalidProxyCreds => 500,
             #[cfg(feature = "native-tls")]
-            Error::TlsError(_) => 599,
+            Error::TlsError(_) => 500,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! * Obvious API
 //!
 //! ```
+//! # #[cfg(feature = "json")] {
 //! // requires feature: `ureq = { version = "*", features = ["json"] }`
 //! # #[cfg(feature = "json")] {
 //! use ureq::json;
@@ -195,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
+    #[cfg(any(feature = "tls", feature = "native-tls"))]
     fn connect_https_google() {
         let resp = get("https://www.google.com/").call();
         assert_eq!(
@@ -206,7 +207,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
+    #[cfg(any(feature = "tls", feature = "native-tls"))]
     fn connect_https_invalid_name() {
         let resp = get("https://example.com{REQUEST_URI}/").call();
         assert_eq!(400, resp.status());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //! * Obvious API
 //!
 //! ```
-//! # #[cfg(feature = "json")] {
 //! // requires feature: `ureq = { version = "*", features = ["json"] }`
 //! # #[cfg(feature = "json")] {
 //! use ureq::json;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,12 @@ pub fn patch(path: &str) -> Request {
     request("PATCH", path)
 }
 
+// Compilation error when both tls and native-tls features are enabled
+#[cfg(all(feature = "tls", feature = "native-tls"))]
+std::compile_error!(
+    "You have both the \"tls\" and \"native-tls\" features enabled on ureq. Please disable one of these features."
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -29,12 +29,12 @@ impl ConnectionPool {
         self.recycle.remove(&PoolKey::new(url))
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
     pub fn len(&self) -> usize {
         self.recycle.len()
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
     pub fn get(&self, hostname: &str, port: u16) -> Option<&Stream> {
         let key = PoolKey {
             hostname: hostname.into(),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -12,6 +12,9 @@ use rustls::StreamOwned;
 #[cfg(feature = "socks-proxy")]
 use socks::{TargetAddr, ToTargetAddr};
 
+#[cfg(feature = "native-tls")]
+use native_tls::{TlsConnector, TlsStream, HandshakeError};
+
 use crate::proxy::Proto;
 use crate::proxy::Proxy;
 
@@ -23,6 +26,8 @@ pub enum Stream {
     Http(TcpStream),
     #[cfg(feature = "tls")]
     Https(rustls::StreamOwned<rustls::ClientSession, TcpStream>),
+    #[cfg(feature = "native-tls")]
+    Https(TlsStream<TcpStream>),
     Cursor(Cursor<Vec<u8>>),
     #[cfg(test)]
     Test(Box<dyn Read + Send>, Vec<u8>),
@@ -35,7 +40,7 @@ impl ::std::fmt::Debug for Stream {
             "Stream[{}]",
             match self {
                 Stream::Http(_) => "http",
-                #[cfg(feature = "tls")]
+                #[cfg(any(feature = "tls", feature = "native-tls"))]
                 Stream::Https(_) => "https",
                 Stream::Cursor(_) => "cursor",
                 #[cfg(test)]
@@ -49,7 +54,7 @@ impl Stream {
     pub fn is_poolable(&self) -> bool {
         match self {
             Stream::Http(_) => true,
-            #[cfg(feature = "tls")]
+            #[cfg(any(feature = "tls", feature = "native-tls"))]
             Stream::Https(_) => true,
             _ => false,
         }
@@ -68,7 +73,7 @@ impl Read for Stream {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         match self {
             Stream::Http(sock) => sock.read(buf),
-            #[cfg(feature = "tls")]
+            #[cfg(any(feature = "tls", feature = "native-tls"))]
             Stream::Https(stream) => read_https(stream, buf),
             Stream::Cursor(read) => read.read(buf),
             #[cfg(test)]
@@ -89,7 +94,20 @@ fn read_https(
     }
 }
 
+#[cfg(feature = "native-tls")]
+fn read_https(
+    stream: &mut TlsStream<TcpStream>,
+    buf: &mut [u8],
+) -> IoResult<usize> {
+    match stream.read(buf) {
+        Ok(size) => Ok(size),
+        Err(ref e) if is_close_notify(e) => Ok(0),
+        Err(e) => Err(e),
+    }
+}
+
 #[allow(deprecated)]
+#[cfg(any(feature = "tls", feature = "native-tls"))]
 fn is_close_notify(e: &std::io::Error) -> bool {
     if e.kind() != ErrorKind::ConnectionAborted {
         return false;
@@ -108,7 +126,7 @@ impl Write for Stream {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         match self {
             Stream::Http(sock) => sock.write(buf),
-            #[cfg(feature = "tls")]
+            #[cfg(any(feature = "tls", feature = "native-tls"))]
             Stream::Https(stream) => stream.write(buf),
             Stream::Cursor(_) => panic!("Write to read only stream"),
             #[cfg(test)]
@@ -118,7 +136,7 @@ impl Write for Stream {
     fn flush(&mut self) -> IoResult<()> {
         match self {
             Stream::Http(sock) => sock.flush(),
-            #[cfg(feature = "tls")]
+            #[cfg(any(feature = "tls", feature = "native-tls"))]
             Stream::Https(stream) => stream.flush(),
             Stream::Cursor(_) => panic!("Flush read only stream"),
             #[cfg(test)]
@@ -134,6 +152,7 @@ pub(crate) fn connect_http(unit: &Unit) -> Result<Stream, Error> {
 
     connect_host(unit, hostname, port).map(Stream::Http)
 }
+
 
 #[cfg(all(feature = "tls", feature = "native-certs"))]
 fn configure_certs(config: &mut rustls::ClientConfig) {
@@ -173,6 +192,23 @@ pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
     let sock = connect_host(unit, hostname, port)?;
 
     let stream = rustls::StreamOwned::new(sess, sock);
+
+    Ok(Stream::Https(stream))
+}
+
+#[cfg(feature = "native-tls")]
+pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
+    let hostname = unit.url.host_str().unwrap();
+    let port = unit.url.port().unwrap_or(443);
+    let sock = connect_host(unit, hostname, port)?;
+
+    let tls_connector = TlsConnector::new().map_err(|e| Error::TlsError(e))?;
+    let stream = tls_connector.connect(hostname, sock).map_err(|e| {
+        match e {
+            HandshakeError::Failure(err) => Error::TlsError(err),
+            _ => Error::BadStatusRead,
+        }
+    })?;
 
     Ok(Stream::Https(stream))
 }
@@ -445,7 +481,8 @@ pub(crate) fn connect_test(unit: &Unit) -> Result<Stream, Error> {
     Err(Error::UnknownScheme(unit.url.scheme().to_string()))
 }
 
-#[cfg(not(feature = "tls"))]
+#[cfg(not(any(feature = "tls", feature = "native-tls")))]
 pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
     Err(Error::UnknownScheme(unit.url.scheme().to_string()))
 }
+

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -24,9 +24,9 @@ use crate::unit::Unit;
 #[allow(clippy::large_enum_variant)]
 pub enum Stream {
     Http(TcpStream),
-    #[cfg(feature = "tls")]
+    #[cfg(all(feature = "tls", not(feature = "native-tls")))]
     Https(rustls::StreamOwned<rustls::ClientSession, TcpStream>),
-    #[cfg(feature = "native-tls")]
+    #[cfg(all(feature = "native-tls", not(feature = "tls")))]
     Https(TlsStream<TcpStream>),
     Cursor(Cursor<Vec<u8>>),
     #[cfg(test)]
@@ -40,7 +40,10 @@ impl ::std::fmt::Debug for Stream {
             "Stream[{}]",
             match self {
                 Stream::Http(_) => "http",
-                #[cfg(any(feature = "tls", feature = "native-tls"))]
+                #[cfg(any(
+                    all(feature = "tls", not(feature = "native-tls")),
+                    all(feature = "native-tls", not(feature = "tls")),
+                ))]
                 Stream::Https(_) => "https",
                 Stream::Cursor(_) => "cursor",
                 #[cfg(test)]
@@ -54,7 +57,10 @@ impl Stream {
     pub fn is_poolable(&self) -> bool {
         match self {
             Stream::Http(_) => true,
-            #[cfg(any(feature = "tls", feature = "native-tls"))]
+            #[cfg(any(
+                all(feature = "tls", not(feature = "native-tls")),
+                all(feature = "native-tls", not(feature = "tls")),
+            ))]
             Stream::Https(_) => true,
             _ => false,
         }
@@ -73,7 +79,10 @@ impl Read for Stream {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         match self {
             Stream::Http(sock) => sock.read(buf),
-            #[cfg(any(feature = "tls", feature = "native-tls"))]
+            #[cfg(any(
+                all(feature = "tls", not(feature = "native-tls")),
+                all(feature = "native-tls", not(feature = "tls")),
+            ))]
             Stream::Https(stream) => read_https(stream, buf),
             Stream::Cursor(read) => read.read(buf),
             #[cfg(test)]
@@ -82,7 +91,7 @@ impl Read for Stream {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(all(feature = "tls", not(feature = "native-tls")))]
 fn read_https(
     stream: &mut StreamOwned<ClientSession, TcpStream>,
     buf: &mut [u8],
@@ -94,11 +103,8 @@ fn read_https(
     }
 }
 
-#[cfg(feature = "native-tls")]
-fn read_https(
-    stream: &mut TlsStream<TcpStream>,
-    buf: &mut [u8],
-) -> IoResult<usize> {
+#[cfg(all(feature = "native-tls", not(feature = "tls")))]
+fn read_https(stream: &mut TlsStream<TcpStream>, buf: &mut [u8]) -> IoResult<usize> {
     match stream.read(buf) {
         Ok(size) => Ok(size),
         Err(ref e) if is_close_notify(e) => Ok(0),
@@ -126,7 +132,10 @@ impl Write for Stream {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         match self {
             Stream::Http(sock) => sock.write(buf),
-            #[cfg(any(feature = "tls", feature = "native-tls"))]
+            #[cfg(any(
+                all(feature = "tls", not(feature = "native-tls")),
+                all(feature = "native-tls", not(feature = "tls")),
+            ))]
             Stream::Https(stream) => stream.write(buf),
             Stream::Cursor(_) => panic!("Write to read only stream"),
             #[cfg(test)]
@@ -136,7 +145,10 @@ impl Write for Stream {
     fn flush(&mut self) -> IoResult<()> {
         match self {
             Stream::Http(sock) => sock.flush(),
-            #[cfg(any(feature = "tls", feature = "native-tls"))]
+            #[cfg(any(
+                all(feature = "tls", not(feature = "native-tls")),
+                all(feature = "native-tls", not(feature = "tls")),
+            ))]
             Stream::Https(stream) => stream.flush(),
             Stream::Cursor(_) => panic!("Flush read only stream"),
             #[cfg(test)]
@@ -167,7 +179,7 @@ fn configure_certs(config: &mut rustls::ClientConfig) {
         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 }
 
-#[cfg(feature = "tls")]
+#[cfg(all(feature = "tls", not(feature = "native-tls")))]
 pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
     use lazy_static::lazy_static;
     use std::sync::Arc;
@@ -196,7 +208,7 @@ pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
     Ok(Stream::Https(stream))
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(all(feature = "native-tls", not(feature = "tls")))]
 pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
     let hostname = unit.url.host_str().unwrap();
     let port = unit.url.port().unwrap_or(443);

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -54,7 +54,7 @@ fn agent_cookies() {
 }
 
 #[test]
-#[cfg(feature = "tls")]
+#[cfg(any(feature = "tls", feature = "native-tls"))]
 fn connection_reuse() {
     use std::io::Read;
     use std::time::Duration;

--- a/src/test/range.rs
+++ b/src/test/range.rs
@@ -1,9 +1,11 @@
+#[cfg(any(feature = "tls", feature = "native-tls"))]
 use std::io::Read;
 
+#[cfg(any(feature = "tls", feature = "native-tls"))]
 use super::super::*;
 
 #[test]
-#[cfg(feature = "tls")]
+#[cfg(any(feature = "tls", feature = "native-tls"))]
 fn read_range() {
     let resp = get("https://ureq.s3.eu-central-1.amazonaws.com/sherlock.txt")
         .set("Range", "bytes=1000-1999")
@@ -20,7 +22,7 @@ fn read_range() {
 }
 
 #[test]
-#[cfg(feature = "tls")]
+#[cfg(any(feature = "tls", feature = "native-tls"))]
 fn agent_pool() {
     let agent = agent();
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -11,7 +11,12 @@ use cookie::{Cookie, CookieJar};
 use crate::agent::AgentState;
 use crate::body::{self, Payload, SizedReader};
 use crate::header;
-use crate::stream::{self, connect_https, connect_test, Stream};
+#[cfg(any(
+    all(feature = "tls", not(feature = "native-tls")),
+    all(feature = "native-tls", not(feature = "tls")),
+))]
+use crate::stream::connect_https;
+use crate::stream::{self, connect_test, Stream};
 use crate::Proxy;
 use crate::{Error, Header, Request, Response};
 
@@ -281,6 +286,10 @@ fn connect_socket(unit: &Unit, use_pooled: bool) -> Result<(Stream, bool), Error
     }
     let stream = match unit.url.scheme() {
         "http" => stream::connect_http(&unit),
+        #[cfg(any(
+            all(feature = "tls", not(feature = "native-tls")),
+            all(feature = "native-tls", not(feature = "tls")),
+        ))]
         "https" => connect_https(&unit),
         "test" => connect_test(&unit),
         _ => Err(Error::UnknownScheme(unit.url.scheme().to_string())),

--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -1,7 +1,8 @@
 #[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
 use std::io::Read;
 
-#[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
+#[cfg(any(feature = "tls", feature = "native-tls"))]
+#[test]
 fn tls_connection_close() {
     let agent = ureq::Agent::default().build();
     let resp = agent

--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -1,7 +1,7 @@
+#[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
 use std::io::Read;
 
-#[cfg(feature = "tls")]
-#[test]
+#[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
 fn tls_connection_close() {
     let agent = ureq::Agent::default().build();
     let resp = agent


### PR DESCRIPTION
ureq is a small library, however rustls as a dependency is somewhat heavy. I figured I'd add some optional native-tls support, which shrinks the size of the binaries somewhat.

I've also managed to keep the same API, and have done so in a way that no extra bloat should be added when native-tls is not used.

At the same time, I also cleaned up the warnings that pop up with various feature flag combinations, as well as fixing a doctest that was failing if the json feature flag wasn't enabled.