### PR TITLE
Make Response::into_json deserialize into a serde DeserializeOwned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 
 [features]
 default = ["tls", "cookies"]
-json = ["serde_json"]
+json = ["serde", "serde_json"]
 charset = ["encoding"]
 tls = ["rustls", "webpki", "webpki-roots"]
 native-certs = ["rustls-native-certs"]
@@ -34,5 +34,9 @@ rustls = { version = "0.17", optional = true, features = [] }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.19", optional = true }
 rustls-native-certs = { version = "0.3", optional = true }
+serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding = { version = "0.2", optional = true }
+
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }

--- a/src/body.rs
+++ b/src/body.rs
@@ -10,8 +10,6 @@ use encoding::EncoderTrap;
 
 #[cfg(feature = "json")]
 use super::SerdeValue;
-#[cfg(feature = "json")]
-use serde_json;
 
 /// The different kinds of bodies to send.
 ///

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -61,6 +61,22 @@ fn body_as_text() {
 #[test]
 #[cfg(feature = "json")]
 fn body_as_json() {
+    test::set_handler("/body_as_json", |_unit| {
+        test::make_response(
+            200,
+            "OK",
+            vec![],
+            "{\"hello\":\"world\"}".to_string().into_bytes(),
+        )
+    });
+    let resp = get("test://host/body_as_json").call();
+    let json = resp.into_json().unwrap();
+    assert_eq!(json["hello"], "world");
+}
+
+#[test]
+#[cfg(feature = "json")]
+fn body_as_json_deserialize() {
     use serde::Deserialize;
 
     #[derive(Deserialize)]
@@ -77,7 +93,7 @@ fn body_as_json() {
         )
     });
     let resp = get("test://host/body_as_json").call();
-    let json = resp.into_json::<Hello>().unwrap();
+    let json = resp.into_json_deserialize::<Hello>().unwrap();
     assert_eq!(json.hello, "world");
 }
 

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -61,6 +61,13 @@ fn body_as_text() {
 #[test]
 #[cfg(feature = "json")]
 fn body_as_json() {
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct Hello {
+        hello: String,
+    }
+
     test::set_handler("/body_as_json", |_unit| {
         test::make_response(
             200,
@@ -70,8 +77,8 @@ fn body_as_json() {
         )
     });
     let resp = get("test://host/body_as_json").call();
-    let json = resp.into_json().unwrap();
-    assert_eq!(json["hello"], "world");
+    let json = resp.into_json::<Hello>().unwrap();
+    assert_eq!(json.hello, "world");
 }
 
 #[test]

--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -17,6 +17,14 @@ fn tls_connection_close() {
 #[cfg(feature = "json")]
 #[test]
 fn agent_set_cookie() {
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    #[derive(Deserialize)]
+    struct HttpBin {
+        headers: HashMap<String, String>,
+    }
+
     let agent = ureq::Agent::default().build();
     let cookie = ureq::Cookie::build("name", "value")
         .domain("httpbin.org")
@@ -30,10 +38,9 @@ fn agent_set_cookie() {
     assert_eq!(resp.status(), 200);
     assert_eq!(
         "name=value",
-        resp.into_json()
+        resp.into_json::<HttpBin>()
             .unwrap()
-            .get("headers")
-            .unwrap()
+            .headers
             .get("Cookie")
             .unwrap()
     );

--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -38,7 +38,7 @@ fn agent_set_cookie() {
     assert_eq!(resp.status(), 200);
     assert_eq!(
         "name=value",
-        resp.into_json::<HttpBin>()
+        resp.into_json_deserialize::<HttpBin>()
             .unwrap()
             .headers
             .get("Cookie")


### PR DESCRIPTION
This removes the necessity to take the result of Response::into_json and having to convert it into a struct by using serde_json::from_value

This adds no new dependencies since serde_json already depends on serde. Users of ureq will have to include `serde_derive` either by importing it directly or by using serde with the `derive` feature, unless they want to manually implement `Deserialize` on their structs.