### PR TITLE
Correctly pass --all-features flag to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["web", "request", "http", "rest", "client"]
 categories = ["web-programming::http-client"]
 edition = "2018"
 
-[package.metadata."docs.rs"]
+[package.metadata.docs.rs]
 all-features = true
 
 [features]


### PR DESCRIPTION
Looking at [ureq on docs.rs](https://docs.rs/ureq/1.0.0/ureq/?search=json) it doesn't look like the `--all-features` flag is getting enabled correctly. I think this should fix it.

[docs.rs Metadata for custom builds](https://docs.rs/about#metadata)