### PR TITLE
Fix a couple of feature flag uses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //!
 //! ```
 //! // requires feature: `ureq = { version = "*", features = ["json"] }`
+//! # #[cfg(feature = "json")] {
 //! use ureq::json;
 //!
 //! // sync post request of some json.
@@ -22,6 +23,7 @@
 //! if resp.ok() {
 //!   // ....
 //! }
+//! # }
 //! ```
 //!
 //! # Plain requests

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -14,6 +14,7 @@ use crate::stream::{self, connect_https, connect_test, Stream};
 use crate::Proxy;
 use crate::{Error, Header, Request, Response};
 
+#[cfg(feature = "cookie")]
 use crate::pool::DEFAULT_HOST;
 
 /// It's a "unit of work". Maybe a bad name for it?


### PR DESCRIPTION
Wrap a json doc-test in cfg block to stop in failing when tests are run with `--no-default-features`

