### PR TITLE
Remove last `unsafe` usage and forbid further usages (builds on #31)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ socks-proxy = ["socks"]
 
 [dependencies]
 base64 = "0.12"
-chunked_transfer = "1"
+chunked_transfer = "1.2.0"
 cookie = { version = "0.13", features = ["percent-encode"], optional = true}
 lazy_static = "1"
 qstring = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cookies = ["cookie"]
 
 [dependencies]
 base64 = "0.11"
-chunked_transfer = "1"
+chunked_transfer = { version = "1", path = "rust-chunked-transfer" }
 cookie = { version = "0.12", features = ["percent-encode"], optional = true}
 lazy_static = "1"
 qstring = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cookies = ["cookie"]
 
 [dependencies]
 base64 = "0.11"
-chunked_transfer = { version = "1", path = "rust-chunked-transfer" }
+chunked_transfer = "1"
 cookie = { version = "0.12", features = ["percent-encode"], optional = true}
 lazy_static = "1"
 qstring = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![warn(clippy::all)]
 //! ureq is a minimal request library.
 //!

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,7 +6,7 @@ use chunked_transfer::Decoder as ChunkDecoder;
 use crate::error::Error;
 use crate::header::Header;
 use crate::pool::PoolReturnRead;
-use crate::stream::{ReclaimStream, Stream};
+use crate::stream::Stream;
 use crate::unit::Unit;
 
 #[cfg(feature = "json")]
@@ -582,9 +582,12 @@ impl<R: Read> Read for LimitedRead<R> {
     }
 }
 
-impl<R: ReclaimStream> ReclaimStream for LimitedRead<R> {
-    fn reclaim_stream(self) -> Stream {
-        self.reader.reclaim_stream()
+impl<R> From<LimitedRead<R>> for Stream
+where
+    Stream: From<R>
+{
+    fn from(limited_read: LimitedRead<R>) -> Stream {
+        limited_read.reader.into()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -77,7 +77,7 @@ impl<R> From<ChunkDecoder<R>> for Stream
 where
     Stream : From<R> {
     fn from(chunk_decoder: ChunkDecoder<R>) -> Stream {
-        chunk_decoder.unwrap().into()
+        chunk_decoder.into_inner().into()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,6 +4,8 @@ use std::net::TcpStream;
 use std::net::ToSocketAddrs;
 use std::time::Duration;
 
+use chunked_transfer::Decoder as ChunkDecoder;
+
 #[cfg(feature = "tls")]
 use rustls::ClientSession;
 #[cfg(feature = "tls")]
@@ -68,6 +70,22 @@ impl Read for Stream {
             #[cfg(test)]
             Stream::Test(reader, _) => reader.read(buf),
         }
+    }
+}
+
+pub(crate) trait ReclaimStream {
+    fn reclaim_stream(self) -> Stream;
+}
+
+impl ReclaimStream for Stream {
+    fn reclaim_stream(self) -> Stream {
+        self
+    }
+}
+
+impl<R: ReclaimStream> ReclaimStream for ChunkDecoder<R> {
+    fn reclaim_stream(self) -> Stream {
+        self.unwrap().reclaim_stream()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -73,19 +73,11 @@ impl Read for Stream {
     }
 }
 
-pub(crate) trait ReclaimStream {
-    fn reclaim_stream(self) -> Stream;
-}
-
-impl ReclaimStream for Stream {
-    fn reclaim_stream(self) -> Stream {
-        self
-    }
-}
-
-impl<R: ReclaimStream> ReclaimStream for ChunkDecoder<R> {
-    fn reclaim_stream(self) -> Stream {
-        self.unwrap().reclaim_stream()
+impl<R> From<ChunkDecoder<R>> for Stream
+where
+    Stream : From<R> {
+    fn from(chunk_decoder: ChunkDecoder<R>) -> Stream {
+        chunk_decoder.unwrap().into()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -78,7 +78,7 @@ impl Read for Stream {
     }
 }
 
-impl<R> From<ChunkDecoder<R>> for Stream
+impl<R: Read> From<ChunkDecoder<R>> for Stream
 where
     Stream : From<R> {
     fn from(chunk_decoder: ChunkDecoder<R>) -> Stream {


### PR DESCRIPTION
This builds on @EkardNT's excellent work on #31. All I've done is merged the latest code and bumped the version dependency. @algesten, [your comment](https://github.com/algesten/ureq/pull/31#issuecomment-619492748) mentions that some tidying is needed because a commit message "talks about .unwrap() which was renamed to into_inner()." Would you like me to try and rebase @EkardNT's commits into a single commit that talks about the correct method?