### PR TITLE
Remove compile error on native-tls / tls conflict.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,12 +180,6 @@ pub fn patch(path: &str) -> Request {
     request("PATCH", path)
 }
 
-// Compilation error when both tls and native-tls features are enabled
-#[cfg(all(feature = "tls", feature = "native-tls"))]
-std::compile_error!(
-    "You have both the \"tls\" and \"native-tls\" features enabled on ureq. Please disable one of these features."
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The docs.rs build uses the --all-features flag, which causes its
documentation builds to fail when this macro is present.

Fixes #71.