### PR TITLE
Fix up cargo test --no-default-features.

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -249,11 +249,6 @@ impl Agent {
     pub fn patch(&self, path: &str) -> Request {
         self.request("PATCH", path)
     }
-
-    #[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
-    pub(crate) fn state(&self) -> &Arc<Mutex<Option<AgentState>>> {
-        &self.state
-    }
 }
 
 pub(crate) fn basic_auth(user: &str, pass: &str) -> String {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -29,7 +29,7 @@ impl ConnectionPool {
         self.recycle.remove(&PoolKey::new(url))
     }
 
-    #[cfg(all(test, any(feature = "tls", feature = "native-tls")))]
+    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.recycle.len()
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -216,9 +216,11 @@ impl Response {
     /// Example:
     ///
     /// ```
+    /// # #[cfg(feature = "tls")] {
     /// let resp = ureq::get("https://www.google.com/").call();
     /// assert_eq!("text/html; charset=ISO-8859-1", resp.header("content-type").unwrap());
     /// assert_eq!("text/html", resp.content_type());
+    /// # }
     /// ```
     pub fn content_type(&self) -> &str {
         self.header("content-type")
@@ -236,9 +238,11 @@ impl Response {
     /// Example:
     ///
     /// ```
+    /// # #[cfg(feature = "tls")] {
     /// let resp = ureq::get("https://www.google.com/").call();
     /// assert_eq!("text/html; charset=ISO-8859-1", resp.header("content-type").unwrap());
     /// assert_eq!("ISO-8859-1", resp.charset());
+    /// # }
     /// ```
     pub fn charset(&self) -> &str {
         charset_from_content_type(self.header("content-type"))
@@ -255,6 +259,7 @@ impl Response {
     /// Example:
     ///
     /// ```
+    /// # #[cfg(feature = "tls")] {
     /// use std::io::Read;
     ///
     /// let resp =
@@ -270,6 +275,7 @@ impl Response {
     /// reader.read_to_end(&mut bytes);
     ///
     /// assert_eq!(bytes.len(), len);
+    /// # }
     /// ```
     pub fn into_reader(self) -> impl Read {
         //
@@ -328,6 +334,7 @@ impl Response {
     /// Example:
     ///
     /// ```
+    /// # #[cfg(feature = "tls")] {
     /// let resp =
     ///     ureq::get("https://ureq.s3.eu-central-1.amazonaws.com/hello_world.json")
     ///         .call();
@@ -335,6 +342,7 @@ impl Response {
     /// let text = resp.into_string().unwrap();
     ///
     /// assert!(text.contains("hello"));
+    /// # }
     /// ```
     ///
     /// ## Charset support

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -79,6 +79,7 @@ impl Stream {
     pub(crate) fn server_closed(&self) -> IoResult<bool> {
         match self {
             Stream::Http(tcpstream) => Stream::serverclosed_stream(tcpstream),
+            #[cfg(all(feature = "tls", not(feature = "native-tls")))]
             Stream::Https(rustls_stream) => Stream::serverclosed_stream(&rustls_stream.sock),
             _ => Ok(false),
         }
@@ -130,6 +131,7 @@ where
     }
 }
 
+#[cfg(all(feature = "tls", not(feature = "native-tls")))]
 fn read_https(
     stream: &mut StreamOwned<ClientSession, TcpStream>,
     buf: &mut [u8],

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -102,7 +102,7 @@ fn connection_reuse() {
     resp.into_reader().read_to_end(&mut buf).unwrap();
 
     {
-        let mut guard_state = agent.state().lock().unwrap();
+        let mut guard_state = agent.state.lock().unwrap();
         let mut state = guard_state.take().unwrap();
         assert!(state.pool().len() > 0);
     }

--- a/src/test/range.rs
+++ b/src/test/range.rs
@@ -39,7 +39,7 @@ fn agent_pool() {
     assert_eq!(len, 1000);
 
     {
-        let mut lock = agent.state().lock().unwrap();
+        let mut lock = agent.state.lock().unwrap();
         let state = lock.as_mut().unwrap();
         let pool = state.pool();
         assert_eq!(pool.len(), 1);

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -10,11 +10,6 @@ use cookie::{Cookie, CookieJar};
 use crate::agent::AgentState;
 use crate::body::{self, Payload, SizedReader};
 use crate::header;
-#[cfg(any(
-    all(feature = "tls", not(feature = "native-tls")),
-    all(feature = "native-tls", not(feature = "tls")),
-))]
-use crate::stream::connect_https;
 use crate::stream::{self, connect_test, Stream};
 use crate::Proxy;
 use crate::{Error, Header, Request, Response};
@@ -291,11 +286,7 @@ fn connect_socket(unit: &Unit, use_pooled: bool) -> Result<(Stream, bool), Error
     }
     let stream = match unit.url.scheme() {
         "http" => stream::connect_http(&unit),
-        #[cfg(any(
-            all(feature = "tls", not(feature = "native-tls")),
-            all(feature = "native-tls", not(feature = "tls")),
-        ))]
-        "https" => connect_https(&unit),
+        "https" => stream::connect_https(&unit),
         "test" => connect_test(&unit),
         _ => Err(Error::UnknownScheme(unit.url.scheme().to_string())),
     };


### PR DESCRIPTION
Adds some feature guards, and removes an unnecessary feature guard
around a call to connect_https (there's an implementation available for
non-TLS that returns UnknownScheme).

Also, remove unnecessary agent.state() method that was only available in
TLS builds. The state field is directly accessible within the crate, and
can be used in both TLS and non-TLS builds.