### PR TITLE
Un-deprecate read/write timeouts.

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -369,7 +369,6 @@ impl Request {
     ///     .call();
     /// println!("{:?}", r);
     /// ```
-    #[deprecated(note = "Please use the timeout() function instead")]
     pub fn timeout_read(&mut self, millis: u64) -> &mut Request {
         self.timeout_read = millis;
         self
@@ -387,7 +386,6 @@ impl Request {
     ///     .call();
     /// println!("{:?}", r);
     /// ```
-    #[deprecated(note = "Please use the timeout() function instead")]
     pub fn timeout_write(&mut self, millis: u64) -> &mut Request {
         self.timeout_write = millis;
         self


### PR DESCRIPTION
In https://github.com/algesten/ureq/pull/67#issuecomment-647112883,
Shnatsel points out that there are uses for read_timeout vs timeout. For
instance, when downloading a large file it's useful to have a read
timouet in case the download stalls, but it would be hard to pick a good
overall timeout without knowing the size of the file and the bandwidth
of the connection.