### PR TITLE
Set chunked Transfer-Encoding when using `send`

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -65,7 +65,7 @@ impl SizedReader {
 impl Payload {
     pub fn into_read(self) -> SizedReader {
         match self {
-            Payload::Empty => SizedReader::new(None, Box::new(empty())),
+            Payload::Empty => SizedReader::new(Some(0), Box::new(empty())),
             Payload::Text(text, _charset) => {
                 #[cfg(feature = "charset")]
                 let bytes = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //! which follows a build pattern. The builders are finished using:
 //!
 //! * [`.call()`](struct.Request.html#method.call) without a request body.
-//! * [`.send()`](struct.Request.html#method.send) with a request body as `Read` (chunked encoding).
+//! * [`.send()`](struct.Request.html#method.send) with a request body as `Read` (chunked encoding support for non-known sized readers).
 //! * [`.send_string()`](struct.Request.html#method.send_string) body as string.
 //! * [`.send_bytes()`](struct.Request.html#method.send_bytes) body as bytes.
 //! * [`.send_form()`](struct.Request.html#method.send_form) key-value pairs as application/x-www-form-urlencoded.

--- a/src/request.rs
+++ b/src/request.rs
@@ -10,6 +10,7 @@ use url::{form_urlencoded, Url};
 use std::fmt;
 
 use crate::agent::{self, Agent, AgentState};
+use crate::body::BodySize;
 use crate::body::{Payload, SizedReader};
 use crate::error::Error;
 use crate::header::{self, Header};
@@ -619,8 +620,14 @@ impl Request {
         // Sized bodies are retryable only if they are zero-length because of
         // coincidences of the current implementation - the function responsible
         // for retries doesn't have a way to replay a Payload.
-        let no_body = body.size.is_none() || body.size.unwrap() > 0;
-        idempotent && no_body
+        let retryable_body = match body.size {
+            BodySize::Unknown => false,
+            BodySize::Known(0) => true,
+            BodySize::Known(_) => false,
+            BodySize::Empty => true,
+        };
+
+        idempotent && retryable_body
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -214,8 +214,10 @@ impl Request {
 
     /// Send data from a reader.
     ///
-    /// This uses [chunked transfer encoding](https://tools.ietf.org/html/rfc7230#section-4.1).
-    /// The caller is responsible for setting the Transfer-Encoding: chunked header.
+    /// If no Content-Length and Transfer-Encoding header has been set, it uses the [chunked transfer encoding](https://tools.ietf.org/html/rfc7230#section-4.1).
+    ///
+    /// The caller may set the Content-Length header to the expected byte size of the reader if is
+    /// known.
     ///
     /// The input from the reader is buffered into chunks of size 16,384, the max size of a TLS fragment.
     ///
@@ -226,7 +228,6 @@ impl Request {
     ///
     /// let resp = ureq::post("http://localhost/example-upload")
     ///     .set("Content-Type", "text/plain")
-    ///     .set("Transfer-Encoding", "chunked")
     ///     .send(read);
     /// ```
     pub fn send(&mut self, reader: impl Read + 'static) -> Response {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -47,12 +47,12 @@ impl Unit {
     pub(crate) fn new(req: &Request, url: &Url, mix_queries: bool, body: &SizedReader) -> Self {
         //
 
-        let is_chunked = req
+        let (is_transfer_encoding_set, mut is_chunked) = req
             .header("transfer-encoding")
             // if the user has set an encoding header, obey that.
-            .map(|enc| !enc.is_empty())
+            .map(|enc| (!enc.is_empty(), enc == "chunked"))
             // otherwise, no chunking.
-            .unwrap_or(false);
+            .unwrap_or((false, false));
 
         let query_string = combine_query(&url, &req.query, mix_queries);
 
@@ -64,8 +64,19 @@ impl Unit {
             // chunking and Content-Length headers are mutually exclusive
             // also don't write this if the user has set it themselves
             if !is_chunked && !req.has("content-length") {
+                // if the payload is of known size (everything beside an unsized reader), set
+                // Content-Length,
+                // otherwise, use the chunked Transfer-Encoding (only if no other Transfer-Encoding
+                // has been set
                 if let Some(size) = body.size {
-                    extra.push(Header::new("Content-Length", &format!("{}", size)));
+                    if size != 0 {
+                        extra.push(Header::new("Content-Length", &format!("{}", size)));
+                    }
+                } else {
+                    if !is_transfer_encoding_set {
+                        extra.push(Header::new("Transfer-Encoding", "chunked"));
+                        is_chunked = true;
+                    }
                 }
             }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -50,7 +50,14 @@ impl Unit {
         let (is_transfer_encoding_set, mut is_chunked) = req
             .header("transfer-encoding")
             // if the user has set an encoding header, obey that.
-            .map(|enc| (!enc.is_empty(), enc == "chunked"))
+            .map(|enc| {
+                let is_transfer_encoding_set = !enc.is_empty();
+                let last_encoding = enc.split(',').last();
+                let is_chunked = last_encoding
+                    .map(|last_enc| last_enc.trim() == "chunked")
+                    .unwrap_or(false);
+                (is_transfer_encoding_set, is_chunked)
+            })
             // otherwise, no chunking.
             .unwrap_or((false, false));
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -9,7 +9,7 @@ use url::Url;
 use cookie::{Cookie, CookieJar};
 
 use crate::agent::AgentState;
-use crate::body::{self, Payload, SizedReader};
+use crate::body::{self, BodySize, Payload, SizedReader};
 use crate::header;
 use crate::stream::{self, connect_test, Stream};
 use crate::Proxy;
@@ -68,15 +68,17 @@ impl Unit {
                 // Content-Length,
                 // otherwise, use the chunked Transfer-Encoding (only if no other Transfer-Encoding
                 // has been set
-                if let Some(size) = body.size {
-                    if size != 0 {
-                        extra.push(Header::new("Content-Length", &format!("{}", size)));
+                match body.size {
+                    BodySize::Known(size) => {
+                        extra.push(Header::new("Content-Length", &format!("{}", size)))
                     }
-                } else {
-                    if !is_transfer_encoding_set {
-                        extra.push(Header::new("Transfer-Encoding", "chunked"));
-                        is_chunked = true;
+                    BodySize::Unknown => {
+                        if !is_transfer_encoding_set {
+                            extra.push(Header::new("Transfer-Encoding", "chunked"));
+                            is_chunked = true;
+                        }
                     }
+                    BodySize::Empty => {}
                 }
             }
 


### PR DESCRIPTION
Related issue: #43 

Previously, using `.send()` on `Request` would require to set either the Transfer-Encoding or the Content-Length header.

In an effort to provide better ergonomics for this library and to avoid making users fall in a not-so obvious pitfall, the library should build a valid Request without asking the user to mess around with the headers.

This PR attempts to fix this issue: if the user use `.send()` to provide an unknown sized reader, the chunked Transfer-Encoding will be used. Of course, there are prior checks to ensure we do not override the user wish, like if the user already set a Content-Length or a Transfer-Encoding.

This PR also fix an edge case where the Content-Length would not be automatically set if the Transfer-Encoding is set but not chunked.