### PR TITLE
Fix reference to Instant in socks feature.

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -467,7 +467,7 @@ fn socks5_local_nslookup(hostname: &str, port: u16) -> Result<TargetAddr, std::i
 #[cfg(feature = "socks-proxy")]
 fn connect_socks5(
     proxy: Proxy,
-    deadline: Option<time::Instant>,
+    deadline: Option<Instant>,
     proxy_addr: SocketAddr,
     host: &str,
     port: u16,


### PR DESCRIPTION
The reference to time::Instant under feature = socks-proxy was
incorrectly scoped, and should have been just Instant. This breaks the
doc build and any builds that use feature = socks-proxy.