### PR TITLE
Make features to use for docs.rs build explicit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["web-programming::http-client"]
 edition = "2018"
 
 [package.metadata.docs.rs]
-all-features = true
+features = [ "tls", "json", "charset", "cookies", "socks-proxy" ]
 
 [features]
 default = ["tls", "cookies"]


### PR DESCRIPTION
Since tls and native-tls are mutually exclusive, we can't use
all-features anymore. Instead we enumerate the features needed to
build the docs for docs.rs.