### PR TITLE
Fix building with socks-proxy feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
         feature:
           - charset
           - cookies
+          - socks-proxy
     env:
       RUST_BACKTRACE: "1"
     steps:

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -523,8 +523,9 @@ fn connect_socks5(
         let (lock, cvar) = &*master_signal;
         let done = lock.lock().unwrap();
 
+        let timeout_connect = time_until_deadline(deadline)?;
         let done_result = cvar
-            .wait_timeout(done, time_until_deadline(deadline)?)
+            .wait_timeout(done, timeout_connect)
             .unwrap();
         let done = done_result.0;
         if *done {
@@ -534,7 +535,7 @@ fn connect_socks5(
                 ErrorKind::TimedOut,
                 format!(
                     "SOCKS5 proxy: {}:{} timed out connecting after {}ms.",
-                    host, port, timeout_connect
+                    host, port, timeout_connect.as_millis()
                 ),
             ));
         }


### PR DESCRIPTION
When preparing for cargo publish, I tried building with all (relevant) features enabled, and found a bug that wasn't covered by our test setup.

This PR fixes the problem and ensure we test the `socks-proxy` feature as part of the test matrix.