### PR TITLE
Validate header field names.

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -103,13 +103,10 @@ fn valid_name(name: &str) -> bool {
 #[inline]
 fn is_tchar(b: u8) -> bool {
     match b {
-        b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*' | b'+' | b'-' | b'.' | b'^' | b'_'
-        | b'`' | b'|' | b'~' | b'A' | b'B' | b'C' | b'D' | b'E' | b'F' | b'G' | b'H' | b'I'
-        | b'J' | b'K' | b'L' | b'M' | b'N' | b'O' | b'P' | b'Q' | b'R' | b'S' | b'T' | b'U'
-        | b'V' | b'W' | b'X' | b'Y' | b'Z' | b'a' | b'b' | b'c' | b'd' | b'e' | b'f' | b'g'
-        | b'h' | b'i' | b'j' | b'k' | b'l' | b'm' | b'n' | b'o' | b'p' | b'q' | b'r' | b's'
-        | b't' | b'u' | b'v' | b'w' | b'x' | b'y' | b'z' | b'0' | b'1' | b'2' | b'3' | b'4'
-        | b'5' | b'6' | b'7' | b'8' | b'9' => true,
+        b'!' | b'#' | b'$' | b'%' | b'&' => true,
+        b'\'' | b'*' | b'+' | b'-' | b'.' => true,
+        b'^' | b'_' | b'`' | b'|' | b'~' => true,
+        b if b.is_ascii_alphanumeric() => true,
         _ => false,
     }
 }


### PR DESCRIPTION
This rejects spaces after field names as well as various other invalid
characters.

Fixes #96 