### PR TITLE
Remove default base URL of http://localhost/

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -518,7 +518,7 @@ impl Request {
     ///     .build();
     /// assert_eq!(req1.get_host().unwrap(), "cool.server");
     ///
-    /// let req2 = ureq::post("/some/path")
+    /// let req2 = ureq::post("http://localhost/some/path")
     ///     .build();
     /// assert_eq!(req2.get_host().unwrap(), "localhost");
     /// ```

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,7 +2,6 @@ use std::io::Read;
 use std::sync::{Arc, Mutex};
 use std::time;
 
-use lazy_static::lazy_static;
 use qstring::QString;
 use url::{form_urlencoded, Url};
 
@@ -19,10 +18,6 @@ use crate::Response;
 
 #[cfg(feature = "json")]
 use super::SerdeValue;
-
-lazy_static! {
-    static ref URL_BASE: Url = Url::parse("http://localhost/").expect("Failed to parse URL_BASE");
-}
 
 /// Request instances are builders that creates a request.
 ///
@@ -571,9 +566,7 @@ impl Request {
     }
 
     fn to_url(&self) -> Result<Url, Error> {
-        URL_BASE
-            .join(&self.url)
-            .map_err(|e| Error::BadUrl(format!("{}", e)))
+        Url::parse(&self.url).map_err(|e| Error::BadUrl(format!("{}", e)))
     }
 
     /// Set the proxy server to use for the connection.

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -122,7 +122,7 @@ fn escape_path() {
 
 #[test]
 fn request_debug() {
-    let req = get("/my/page")
+    let req = get("http://localhost/my/page")
         .set("Authorization", "abcdef")
         .set("Content-Length", "1234")
         .set("Content-Type", "application/json")
@@ -136,7 +136,7 @@ fn request_debug() {
          Content-Length: 1234, Content-Type: application/json])"
     );
 
-    let req = get("/my/page?q=z")
+    let req = get("http://localhost/my/page?q=z")
         .query("foo", "bar baz")
         .set("Authorization", "abcdef")
         .build();


### PR DESCRIPTION
This doesn't change the API at all, since it delays any errors until do_call.
Since there was already an `Into<Response> for Error`, and do_call already
had a `.unwrap_or_else(|e| e.into())`, nothing in do_call needed to change.
The only visible effect of this is that code that was previously relying on
`get("/path")` to fetch something from localhost will now get an error. I think
most of those cases would probably actually be accidents, possibly caused
by typos, e.g. `get("example.com/path")` (forgetting the https: prefix).

Fixes #105