### PR TITLE
Added method to set the TLS connection builder

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -51,7 +51,7 @@ pub struct Request {
     #[cfg(feature = "tls")]
     pub(crate) tls_config: Option<TLSClientConfig>,
     #[cfg(all(feature = "native-tls", not(feature = "tls")))]
-    pub(crate) tls_builder: Option<TLSBuilder>,
+    pub(crate) tls_connector: Option<TLSConnector>,
 }
 
 impl ::std::fmt::Debug for Request {
@@ -604,17 +604,17 @@ impl Request {
         self
     }
 
-    /// Sets the TLS connection builder that will be used for the connection.
+    /// Sets the TLS connector that will be used for the connection.
     ///
     /// Example:
     /// ```
-    /// let tls_builder = std::sync::Arc::new(native_tls::TlsConnector::builder());
+    /// let tls_connector = std::sync::Arc::new(native_tls::TlsConnector::new());
     /// let req = ureq::post("https://cool.server")
-    ///     .set_tls_builder(tls_builder.clone());
+    ///     .set_tls_connector(tls_connector.clone());
     /// ```
     #[cfg(all(feature = "native-tls", not(feature = "tls")))]
-    pub fn set_tls_builder(&mut self, tls_builder: Arc<native_tls::TlsConnectorBuilder>) -> &mut Request {
-        self.tls_builder = Some(TLSBuilder(tls_builder));
+    pub fn set_tls_connector(&mut self, tls_connector: Arc<native_tls::TlsConnector>) -> &mut Request {
+        self.tls_connector = Some(TLSConnector(tls_connector));
         self
     }
 
@@ -648,11 +648,11 @@ impl fmt::Debug for TLSClientConfig {
 
 #[cfg(all(feature = "native-tls", not(feature = "tls")))]
 #[derive(Clone)]
-pub(crate) struct TLSBuilder(pub(crate) Arc<native_tls::TlsConnectorBuilder>);
+pub(crate) struct TLSConnector(pub(crate) Arc<native_tls::TlsConnector>);
 
 #[cfg(all(feature = "native-tls", not(feature = "tls")))]
-impl fmt::Debug for TLSBuilder {
+impl fmt::Debug for TLSConnector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TLSBuilder").finish()
+        f.debug_struct("TLSConnector").finish()
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -8,6 +8,9 @@ use url::{form_urlencoded, Url};
 #[cfg(feature = "tls")]
 use std::fmt;
 
+#[cfg(all(feature = "native-tls", not(feature = "tls")))]
+use std::fmt;
+
 use crate::agent::{self, Agent, AgentState};
 use crate::body::{Payload, SizedReader};
 use crate::error::Error;
@@ -47,6 +50,8 @@ pub struct Request {
     pub(crate) proxy: Option<crate::proxy::Proxy>,
     #[cfg(feature = "tls")]
     pub(crate) tls_config: Option<TLSClientConfig>,
+    #[cfg(all(feature = "native-tls", not(feature = "tls")))]
+    pub(crate) tls_builder: Option<TLSBuilder>,
 }
 
 impl ::std::fmt::Debug for Request {
@@ -599,6 +604,20 @@ impl Request {
         self
     }
 
+    /// Sets the TLS connection builder that will be used for the connection.
+    ///
+    /// Example:
+    /// ```
+    /// let tls_builder = std::sync::Arc::new(native_tls::TlsConnector::builder());
+    /// let req = ureq::post("https://cool.server")
+    ///     .set_tls_builder(tls_builder.clone());
+    /// ```
+    #[cfg(all(feature = "native-tls", not(feature = "tls")))]
+    pub fn set_tls_builder(&mut self, tls_builder: Arc<native_tls::TlsConnectorBuilder>) -> &mut Request {
+        self.tls_builder = Some(TLSBuilder(tls_builder));
+        self
+    }
+
     // Returns true if this request, with the provided body, is retryable.
     pub(crate) fn is_retryable(&self, body: &SizedReader) -> bool {
         // Per https://tools.ietf.org/html/rfc7231#section-8.1.3
@@ -624,5 +643,16 @@ pub(crate) struct TLSClientConfig(pub(crate) Arc<rustls::ClientConfig>);
 impl fmt::Debug for TLSClientConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TLSClientConfig").finish()
+    }
+}
+
+#[cfg(all(feature = "native-tls", not(feature = "tls")))]
+#[derive(Clone)]
+pub(crate) struct TLSBuilder(pub(crate) Arc<native_tls::TlsConnectorBuilder>);
+
+#[cfg(all(feature = "native-tls", not(feature = "tls")))]
+impl fmt::Debug for TLSBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TLSBuilder").finish()
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -312,29 +312,21 @@ pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
 #[cfg(all(feature = "native-tls", not(feature = "tls")))]
 pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
     use std::sync::Arc;
-    use lazy_static::lazy_static;
-
-    lazy_static! {
-        static ref TLS_BUILDER: Arc<native_tls::TlsConnectorBuilder> = {
-            let builder = native_tls::TlsConnector::builder();
-            Arc::new(builder)
-        };
-    }
 
     let hostname = unit.url.host_str().unwrap();
     let port = unit.url.port().unwrap_or(443);
     let sock = connect_host(unit, hostname, port)?;
 
-    let tls_builder: &Arc<native_tls::TlsConnectorBuilder> =
-        unit.tls_builder
-            .as_ref()
-            .map(|c| &c.0)
-            .unwrap_or(&*TLS_BUILDER);
-    let tls_connector = tls_builder.build().map_err(|e| Error::TlsError(e))?;
-    let stream = tls_connector.connect(&hostname.trim_matches(|c| c == '[' || c == ']'), sock).map_err(|e| match e {
-        HandshakeError::Failure(err) => Error::TlsError(err),
-        _ => Error::BadStatusRead,
-    })?;
+    let tls_connector: Arc<native_tls::TlsConnector> = match &unit.tls_connector {
+        Some(connector) => connector.0.clone(),
+        None => Arc::new(native_tls::TlsConnector::new().map_err(|e| Error::TlsError(e))?),
+    };
+    let stream = tls_connector
+        .connect(&hostname.trim_matches(|c| c == '[' || c == ']'), sock)
+        .map_err(|e| match e {
+            HandshakeError::Failure(err) => Error::TlsError(err),
+            _ => Error::BadStatusRead,
+        })?;
 
     Ok(Stream::Https(stream))
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -15,7 +15,7 @@ use rustls::StreamOwned;
 use socks::{TargetAddr, ToTargetAddr};
 
 #[cfg(feature = "native-tls")]
-use native_tls::{HandshakeError, TlsConnector, TlsStream};
+use native_tls::{HandshakeError, TlsStream};
 
 use crate::proxy::Proto;
 use crate::proxy::Proxy;
@@ -311,11 +311,26 @@ pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
 
 #[cfg(all(feature = "native-tls", not(feature = "tls")))]
 pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
+    use std::sync::Arc;
+    use lazy_static::lazy_static;
+
+    lazy_static! {
+        static ref TLS_BUILDER: Arc<native_tls::TlsConnectorBuilder> = {
+            let builder = native_tls::TlsConnector::builder();
+            Arc::new(builder)
+        };
+    }
+
     let hostname = unit.url.host_str().unwrap();
     let port = unit.url.port().unwrap_or(443);
     let sock = connect_host(unit, hostname, port)?;
 
-    let tls_connector = TlsConnector::new().map_err(|e| Error::TlsError(e))?;
+    let tls_builder: &Arc<native_tls::TlsConnectorBuilder> =
+        unit.tls_builder
+            .as_ref()
+            .map(|c| &c.0)
+            .unwrap_or(&*TLS_BUILDER);
+    let tls_connector = tls_builder.build().map_err(|e| Error::TlsError(e))?;
     let stream = tls_connector.connect(&hostname.trim_matches(|c| c == '[' || c == ']'), sock).map_err(|e| match e {
         HandshakeError::Failure(err) => Error::TlsError(err),
         _ => Error::BadStatusRead,

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -18,6 +18,9 @@ use crate::{Error, Header, Request, Response};
 #[cfg(feature = "tls")]
 use crate::request::TLSClientConfig;
 
+#[cfg(all(feature = "native-tls", not(feature = "tls")))]
+use crate::request::TLSBuilder;
+
 #[cfg(feature = "cookie")]
 use crate::pool::DEFAULT_HOST;
 
@@ -39,6 +42,8 @@ pub(crate) struct Unit {
     pub proxy: Option<Proxy>,
     #[cfg(feature = "tls")]
     pub tls_config: Option<TLSClientConfig>,
+    #[cfg(all(feature = "native-tls", not(feature = "tls")))]
+    pub tls_builder: Option<TLSBuilder>,
 }
 
 impl Unit {
@@ -108,6 +113,8 @@ impl Unit {
             proxy: req.proxy.clone(),
             #[cfg(feature = "tls")]
             tls_config: req.tls_config.clone(),
+            #[cfg(all(feature = "native-tls", not(feature = "tls")))]
+            tls_builder: req.tls_builder.clone(),
         }
     }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -19,7 +19,7 @@ use crate::{Error, Header, Request, Response};
 use crate::request::TLSClientConfig;
 
 #[cfg(all(feature = "native-tls", not(feature = "tls")))]
-use crate::request::TLSBuilder;
+use crate::request::TLSConnector;
 
 #[cfg(feature = "cookie")]
 use crate::pool::DEFAULT_HOST;
@@ -43,7 +43,7 @@ pub(crate) struct Unit {
     #[cfg(feature = "tls")]
     pub tls_config: Option<TLSClientConfig>,
     #[cfg(all(feature = "native-tls", not(feature = "tls")))]
-    pub tls_builder: Option<TLSBuilder>,
+    pub tls_connector: Option<TLSConnector>,
 }
 
 impl Unit {
@@ -114,7 +114,7 @@ impl Unit {
             #[cfg(feature = "tls")]
             tls_config: req.tls_config.clone(),
             #[cfg(all(feature = "native-tls", not(feature = "tls")))]
-            tls_builder: req.tls_builder.clone(),
+            tls_connector: req.tls_connector.clone(),
         }
     }
 


### PR DESCRIPTION
This allows configuring the accepted certs, client authentication,
etc, when using the native TLS crate.