### PR TITLE
Add Write support for sending request bodies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ mod request;
 mod response;
 mod stream;
 mod unit;
+mod write;
 
 #[cfg(feature = "json")]
 mod serde_macros;
@@ -141,6 +142,7 @@ pub use crate::header::Header;
 pub use crate::proxy::Proxy;
 pub use crate::request::Request;
 pub use crate::response::Response;
+pub use crate::write::RequestWrite;
 
 // re-export
 #[cfg(feature = "cookie")]

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,0 +1,71 @@
+use crate::body::copy_chunked;
+use crate::error::Error;
+use crate::response::Response;
+use crate::stream::Stream;
+use crate::unit::{self, Unit};
+use std::io::{Result as IoResult, Write};
+
+pub struct RequestWrite {
+    unit: Unit,
+    stream: Stream,
+    finished: bool,
+}
+
+impl RequestWrite {
+    pub(crate) fn new(unit: Unit) -> Result<Self, Error> {
+        let (stream, _is_recycled) = unit::connect_and_send_prelude(&unit, true, false)?;
+        Ok(RequestWrite {
+            unit,
+            stream,
+            finished: false,
+        })
+    }
+
+    // This should only ever be called once either explicitly in finish() or when dropped
+    fn do_finish(&mut self) -> Response {
+        assert!(!self.finished);
+        self.finished = true;
+        if self.unit.is_chunked {
+            // send empty chunk to signal end of chunks
+            let mut empty: &[u8] = &[];
+            let _ = copy_chunked(&mut empty, &mut self.stream, true);
+        }
+        let resp = Response::from_read(&mut self.stream);
+        // squirrel away cookies
+        unit::save_cookies(&self.unit, &resp);
+
+        resp
+    }
+    pub fn finish(mut self) -> Response {
+        self.do_finish()
+    }
+}
+
+impl Write for RequestWrite {
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        if self.unit.is_chunked {
+            let mut chunk = buf;
+            copy_chunked(&mut chunk, &mut self.stream, false).map(|s| s as usize)
+        } else {
+            self.stream.write(buf)
+        }
+    }
+
+    fn flush(&mut self) -> std::result::Result<(), std::io::Error> {
+        self.stream.flush()
+    }
+}
+
+impl Drop for RequestWrite {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.do_finish();
+        }
+    }
+}
+
+impl ::std::fmt::Debug for RequestWrite {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+        write!(f, "RequestWrite({} {})", self.unit.method, self.unit.url)
+    }
+}


### PR DESCRIPTION
Some crates for exampe `tar` take a `Write` object to send their data to instead of creating a `Read` implemntation where data can be polled from. This adds an `into_write` method to `Request` which returns a Writer that can be used to write the body of the request.

Implements feature request algesten/ureq#117