### PR TITLE
Added the possibility to disable certification checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1"
 qstring = "0.7"
 url = "2"
 socks = { version = "0.3.2", optional = true }
-rustls = { version = "0.18", optional = true, features = [] }
+rustls = { version = "0.18", optional = true, features = ["dangerous_configuration"] }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.20", optional = true }
 rustls-native-certs = { version = "0.4", optional = true }

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -209,3 +209,14 @@ pub fn host_with_port() {
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nHost: myhost:234\r\n"));
 }
+
+#[cfg(feature = "tls")]
+#[test]
+pub fn danger_accept_invalid_certs() {
+    // Without .danger_accept_invalid_certs() we get an 500 error
+    let resp = get("https://self-signed.badssl.com/")
+        .danger_accept_invalid_certs()
+        .call();
+
+    assert_eq!(resp.status(), 200);
+}


### PR DESCRIPTION
Hi @algesten,

I want to replace my actual reqwest implementation for one of my libraries.
The library is used to call some rest information from a local smart home device with TSL encryption but no registered certification.

The reqwest crate allows to disable the certification checks for such cases.
I have implemented the same behavior here as a pull request together with a check to demonstrate it.

Maybe you are interested to merge this addition into ureq?

Thanks,
Robert