### PR TITLE
Normalize timeout ErrorKind::WouldBlock to be TimedOut

### DIFF
--- a/src/test/timeout.rs
+++ b/src/test/timeout.rs
@@ -32,7 +32,6 @@ fn get_and_expect_timeout(url: String) {
 
     match resp.into_string() {
         Err(io_error) => match io_error.kind() {
-            io::ErrorKind::WouldBlock => Ok(()),
             io::ErrorKind::TimedOut => Ok(()),
             _ => Err(format!("{:?}", io_error)),
         },


### PR DESCRIPTION
`set_read_timeout` and `set_write_timeout` can cause `ErrorKind::WouldBlock` on unix-y platforms.

This PR normalize those cases to `ErrorKind::TimedOut`. This will make it simpler higher up in the stack to deal with timeouts.

This PR should land before #123 