### PR TITLE
Clean up unused code and long imports.

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -256,20 +256,21 @@ pub(crate) fn basic_auth(user: &str, pass: &str) -> String {
         Some(idx) => &user[..idx],
         None => user,
     };
-    ::base64::encode(&format!("{}:{}", safe, pass))
+    base64::encode(&format!("{}:{}", safe, pass))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Read;
+    use std::thread;
 
     ///////////////////// AGENT TESTS //////////////////////////////
 
     #[test]
     fn agent_implements_send() {
         let mut agent = Agent::new();
-        ::std::thread::spawn(move || {
+        thread::spawn(move || {
             agent.set("Foo", "Bar");
         });
     }
@@ -309,7 +310,7 @@ mod tests {
     fn request_implements_send() {
         let agent = Agent::new();
         let mut request = Request::new(&agent, "GET".to_string(), "/foo".to_string());
-        ::std::thread::spawn(move || {
+        thread::spawn(move || {
             request.set("Foo", "Bar");
         });
     }

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,4 +1,5 @@
 use crate::stream::Stream;
+use std::fmt;
 use std::io::{copy, empty, Cursor, Read, Result as IoResult, Write};
 
 #[cfg(feature = "charset")]
@@ -23,8 +24,8 @@ pub(crate) enum Payload {
     Bytes(Vec<u8>),
 }
 
-impl ::std::fmt::Debug for Payload {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+impl fmt::Debug for Payload {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Payload::Empty => write!(f, "Empty"),
             Payload::Text(t, _) => write!(f, "{}", t),
@@ -50,8 +51,8 @@ pub(crate) struct SizedReader {
     pub reader: Box<dyn Read + 'static>,
 }
 
-impl ::std::fmt::Debug for SizedReader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+impl fmt::Debug for SizedReader {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SizedReader[size={:?},reader]", self.size)
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use std::fmt;
 use std::str::FromStr;
 
 #[derive(Clone, PartialEq)]
@@ -14,8 +15,8 @@ pub struct Header {
     index: usize,
 }
 
-impl ::std::fmt::Debug for Header {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+impl fmt::Debug for Header {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.line)
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,15 +1,11 @@
+use std::fmt;
 use std::io::Read;
+use std::result::Result;
 use std::sync::{Arc, Mutex};
 use std::time;
 
 use qstring::QString;
 use url::{form_urlencoded, Url};
-
-#[cfg(feature = "tls")]
-use std::fmt;
-
-#[cfg(all(feature = "native-tls", not(feature = "tls")))]
-use std::fmt;
 
 use crate::agent::{self, Agent, AgentState};
 use crate::body::{Payload, SizedReader};
@@ -54,8 +50,8 @@ pub struct Request {
     pub(crate) tls_connector: Option<TLSConnector>,
 }
 
-impl ::std::fmt::Debug for Request {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+impl fmt::Debug for Request {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (path, query) = self
             .to_url()
             .map(|u| {
@@ -461,32 +457,6 @@ impl Request {
         self.redirects = n;
         self
     }
-
-    // pub fn retry(&self, times: u16) -> Request {
-    //     unimplemented!()
-    // }
-    // pub fn sortQuery(&self) -> Request {
-    //     unimplemented!()
-    // }
-    // pub fn sortQueryBy(&self, by: Box<Fn(&str, &str) -> usize>) -> Request {
-    //     unimplemented!()
-    // }
-    // pub fn ca<S>(&self, accept: S) -> Request
-    //     where S: Into<String> {
-    //     unimplemented!()
-    // }
-    // pub fn cert<S>(&self, accept: S) -> Request
-    //     where S: Into<String> {
-    //     unimplemented!()
-    // }
-    // pub fn key<S>(&self, accept: S) -> Request
-    //     where S: Into<String> {
-    //     unimplemented!()
-    // }
-    // pub fn pfx<S>(&self, accept: S) -> Request // TODO what type? u8?
-    //     where S: Into<String> {
-    //     unimplemented!()
-    // }
 
     /// Get the method this request is using.
     ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::io::{Cursor, Error as IoError, ErrorKind, Read, Result as IoResult};
 use std::str::FromStr;
 use std::time::Instant;
@@ -65,8 +66,8 @@ struct ResponseStatusIndex {
     response_code: usize,
 }
 
-impl ::std::fmt::Debug for Response {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+impl fmt::Debug for Response {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "Response[status: {}, status_text: {}]",

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::io::{Cursor, Error as IoError, ErrorKind, Read, Result as IoResult, Write};
 use std::net::SocketAddr;
 use std::net::TcpStream;
@@ -100,8 +101,8 @@ pub(crate) fn io_err_timeout(error: String) -> IoError {
     IoError::new(ErrorKind::TimedOut, error)
 }
 
-impl ::std::fmt::Debug for Stream {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+impl fmt::Debug for Stream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "Stream[{}]",


### PR DESCRIPTION
This removes some commented out methods, and also changes instances of
::std::foo to use a more idiomatic import path.