### PR TITLE
Use #[cfg(feature = "cookie")] for some functions.

### DIFF
--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -100,6 +100,7 @@ fn connection_reuse() {
     assert_eq!(resp.status(), 200);
 }
 
+#[cfg(feature = "cookie")]
 #[cfg(test)]
 fn cookie_and_redirect(mut stream: TcpStream) -> io::Result<()> {
     let headers = read_headers(&stream);

--- a/src/test/testserver.rs
+++ b/src/test/testserver.rs
@@ -13,6 +13,7 @@ pub struct TestHeaders(Vec<String>);
 
 impl TestHeaders {
     // Return the path for a request, e.g. /foo from "GET /foo HTTP/1.1"
+    #[cfg(feature = "cookie")]
     pub fn path(&self) -> &str {
         if self.0.len() == 0 {
             ""
@@ -21,6 +22,7 @@ impl TestHeaders {
         }
     }
 
+    #[cfg(feature = "cookie")]
     pub fn headers(&self) -> &[String] {
         &self.0[1..]
     }


### PR DESCRIPTION
Some helper functions introduced as part of the cookies_on_redirect
test are only used by that test, which means they are only used when the
cookie feature is enabled. This causes clippy warnings for some of the
other feature combinations in CI.