### PR TITLE
CI: error on dead/unused code for features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,17 +3,46 @@ on: [push, pull_request]
 name: CI
 
 jobs:
+  doc:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          # Keep in sync with Cargo.toml's [package.metadata.docs.rs]
+          args: --no-default-features --no-deps --features "tls json charset cookies socks-proxy"
   build_and_test:
-    name: Rust project
+    name: Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        tls:
+          - ""
+          - tls
+          - native-tls
         feature:
+          - ""
+          - json
           - charset
           - cookies
           - socks-proxy
+        what:
+          - "--doc"
+          - "--tests"
+        exclude:
+          - tls: ""
+            what: "--doc"
     env:
       RUST_BACKTRACE: "1"
+      RUSTFLAGS: "-D dead_code -D unused-variables -D unused"
     steps:
       - uses: actions/checkout@master
       - name: Install Rust
@@ -25,10 +54,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features "json tls ${{ matrix.feature }}"
-      - name: Docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          # Keep in sync with Cargo.toml's [package.metadata.docs.rs]
-          args: --no-default-features --no-deps --features "tls json charset cookies socks-proxy"
+          args: ${{ matrix.what }} --no-default-features --features "${{ matrix.tls }} ${{ matrix.feature }}"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -294,7 +294,6 @@ pub(crate) fn basic_auth(user: &str, pass: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Read;
     use std::thread;
 
     ///////////////////// AGENT TESTS //////////////////////////////
@@ -310,6 +309,8 @@ mod tests {
     #[test]
     #[cfg(any(feature = "tls", feature = "native-tls"))]
     fn agent_pool() {
+        use std::io::Read;
+
         let agent = crate::agent();
         let url = "https://ureq.s3.eu-central-1.amazonaws.com/sherlock.txt";
         // req 1

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::test;
 use crate::test::testserver::{read_headers, TestServer};
 use std::io::{self, Write};


### PR DESCRIPTION
By using `RUSTFLAGS="-D dead_code -D unused-variables -D unused"`, we tell
the compiler to upgrade warnings for unused code to errors. This combined
with a more elaborate test matrix means we can have the CI catch feature
flag combos that cause warnings.