### PR TITLE
Add Request::set_addresses to let app override host-resolution

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -44,6 +44,7 @@ pub struct Request {
     pub(crate) timeout: Option<time::Duration>,
     pub(crate) redirects: u32,
     pub(crate) proxy: Option<crate::proxy::Proxy>,
+    pub(crate) addresses: Vec<std::net::SocketAddr>,
     #[cfg(feature = "tls")]
     pub(crate) tls_config: Option<TLSClientConfig>,
     #[cfg(all(feature = "native-tls", not(feature = "tls")))]
@@ -555,6 +556,19 @@ impl Request {
     /// ```
     pub fn set_proxy(&mut self, proxy: crate::proxy::Proxy) -> &mut Request {
         self.proxy = Some(proxy);
+        self
+    }
+
+    /// Set the exact list of addresses that will be tried to connect to, in
+    /// order. Useful to override address-resolution, for testing or for
+    /// requirements of special application
+    /// ```
+    /// let req = ureq::get("https://cool.server/")
+    ///     .set_addresses(vec![(std::net::Ipv4Addr::LOCALHOST, 80).into()])
+    ///     .build();
+    /// ```
+    pub fn set_addresses(&mut self, addresses: Vec<std::net::SocketAddr>) -> &mut Request {
+        self.addresses = addresses;
         self
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,4 @@
-use std::fmt;
-use std::io::{
-    BufRead, BufReader, Cursor, Error as IoError, ErrorKind, Read, Result as IoResult, Write,
-};
+use std::io::{Cursor, Error as IoError, ErrorKind, Read, Result as IoResult, Write};
 use std::net::SocketAddr;
 use std::net::TcpStream;
 use std::net::ToSocketAddrs;
@@ -28,14 +25,14 @@ use crate::unit::Unit;
 
 #[allow(clippy::large_enum_variant)]
 pub enum Stream {
-    Http(BufReader<TcpStream>),
+    Http(TcpStream),
     #[cfg(all(feature = "tls", not(feature = "native-tls")))]
-    Https(BufReader<rustls::StreamOwned<rustls::ClientSession, TcpStream>>),
+    Https(rustls::StreamOwned<rustls::ClientSession, TcpStream>),
     #[cfg(all(feature = "native-tls", not(feature = "tls")))]
-    Https(BufReader<TlsStream<TcpStream>>),
+    Https(TlsStream<TcpStream>),
     Cursor(Cursor<Vec<u8>>),
     #[cfg(test)]
-    Test(Box<dyn BufRead + Send>, Vec<u8>),
+    Test(Box<dyn Read + Send>, Vec<u8>),
 }
 
 // DeadlineStream wraps a stream such that read() will return an error
@@ -103,8 +100,8 @@ pub(crate) fn io_err_timeout(error: String) -> IoError {
     IoError::new(ErrorKind::TimedOut, error)
 }
 
-impl fmt::Debug for Stream {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl ::std::fmt::Debug for Stream {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
         write!(
             f,
             "Stream[{}]",
@@ -164,9 +161,9 @@ impl Stream {
 
     pub(crate) fn socket(&self) -> Option<&TcpStream> {
         match self {
-            Stream::Http(b) => Some(b.get_ref()),
+            Stream::Http(tcpstream) => Some(tcpstream),
             #[cfg(feature = "tls")]
-            Stream::Https(b) => Some(&b.get_ref().sock),
+            Stream::Https(rustls_stream) => Some(&rustls_stream.sock),
             _ => None,
         }
     }
@@ -196,36 +193,6 @@ impl Read for Stream {
     }
 }
 
-impl BufRead for Stream {
-    fn fill_buf(&mut self) -> IoResult<&[u8]> {
-        match self {
-            Stream::Http(r) => r.fill_buf(),
-            #[cfg(any(
-                all(feature = "tls", not(feature = "native-tls")),
-                all(feature = "native-tls", not(feature = "tls")),
-            ))]
-            Stream::Https(r) => r.fill_buf(),
-            Stream::Cursor(r) => r.fill_buf(),
-            #[cfg(test)]
-            Stream::Test(r, _) => r.fill_buf(),
-        }
-    }
-
-    fn consume(&mut self, amt: usize) {
-        match self {
-            Stream::Http(r) => r.consume(amt),
-            #[cfg(any(
-                all(feature = "tls", not(feature = "native-tls")),
-                all(feature = "native-tls", not(feature = "tls")),
-            ))]
-            Stream::Https(r) => r.consume(amt),
-            Stream::Cursor(r) => r.consume(amt),
-            #[cfg(test)]
-            Stream::Test(r, _) => r.consume(amt),
-        }
-    }
-}
-
 impl<R: Read> From<ChunkDecoder<R>> for Stream
 where
     R: Read,
@@ -238,7 +205,7 @@ where
 
 #[cfg(all(feature = "tls", not(feature = "native-tls")))]
 fn read_https(
-    stream: &mut BufReader<StreamOwned<ClientSession, TcpStream>>,
+    stream: &mut StreamOwned<ClientSession, TcpStream>,
     buf: &mut [u8],
 ) -> IoResult<usize> {
     match stream.read(buf) {
@@ -249,7 +216,7 @@ fn read_https(
 }
 
 #[cfg(all(feature = "native-tls", not(feature = "tls")))]
-fn read_https(stream: &mut BufReader<TlsStream<TcpStream>>, buf: &mut [u8]) -> IoResult<usize> {
+fn read_https(stream: &mut TlsStream<TcpStream>, buf: &mut [u8]) -> IoResult<usize> {
     match stream.read(buf) {
         Ok(size) => Ok(size),
         Err(ref e) if is_close_notify(e) => Ok(0),
@@ -276,12 +243,12 @@ fn is_close_notify(e: &std::io::Error) -> bool {
 impl Write for Stream {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         match self {
-            Stream::Http(sock) => sock.get_mut().write(buf),
+            Stream::Http(sock) => sock.write(buf),
             #[cfg(any(
                 all(feature = "tls", not(feature = "native-tls")),
                 all(feature = "native-tls", not(feature = "tls")),
             ))]
-            Stream::Https(stream) => stream.get_mut().write(buf),
+            Stream::Https(stream) => stream.write(buf),
             Stream::Cursor(_) => panic!("Write to read only stream"),
             #[cfg(test)]
             Stream::Test(_, writer) => writer.write(buf),
@@ -289,12 +256,12 @@ impl Write for Stream {
     }
     fn flush(&mut self) -> IoResult<()> {
         match self {
-            Stream::Http(sock) => sock.get_mut().flush(),
+            Stream::Http(sock) => sock.flush(),
             #[cfg(any(
                 all(feature = "tls", not(feature = "native-tls")),
                 all(feature = "native-tls", not(feature = "tls")),
             ))]
-            Stream::Https(stream) => stream.get_mut().flush(),
+            Stream::Https(stream) => stream.flush(),
             Stream::Cursor(_) => panic!("Flush read only stream"),
             #[cfg(test)]
             Stream::Test(_, writer) => writer.flush(),
@@ -307,9 +274,7 @@ pub(crate) fn connect_http(unit: &Unit) -> Result<Stream, Error> {
     let hostname = unit.url.host_str().unwrap();
     let port = unit.url.port().unwrap_or(80);
 
-    connect_host(unit, hostname, port)
-        .map(BufReader::new)
-        .map(Stream::Http)
+    connect_host(unit, hostname, port).map(Stream::Http)
 }
 
 #[cfg(all(feature = "tls", feature = "native-certs"))]
@@ -351,7 +316,7 @@ pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
 
     let stream = rustls::StreamOwned::new(sess, sock);
 
-    Ok(Stream::Https(BufReader::new(stream)))
+    Ok(Stream::Https(stream))
 }
 
 #[cfg(all(feature = "native-tls", not(feature = "tls")))]
@@ -373,7 +338,25 @@ pub(crate) fn connect_https(unit: &Unit) -> Result<Stream, Error> {
             _ => Error::BadStatusRead,
         })?;
 
-    Ok(Stream::Https(BufReader::new(stream)))
+    Ok(Stream::Https(stream))
+}
+
+pub(crate) fn resolve_hosts<'iter>(
+    unit: &'iter Unit,
+    hostname: &str,
+    port: u16,
+) -> std::io::Result<Box<dyn Iterator<Item = SocketAddr> + 'iter>> {
+    if unit.addresses.is_empty() {
+        // TODO: Find a way to apply deadline to DNS lookup.
+        let iter = match unit.proxy {
+            Some(ref proxy) => format!("{}:{}", proxy.server, proxy.port),
+            None => format!("{}:{}", hostname, port),
+        }
+        .to_socket_addrs()?;
+        Ok(Box::new(iter))
+    } else {
+        Ok(Box::new(unit.addresses.iter().cloned()))
+    }
 }
 
 pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<TcpStream, Error> {
@@ -383,14 +366,9 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
         unit.deadline
     };
 
-    // TODO: Find a way to apply deadline to DNS lookup.
-    let sock_addrs: Vec<SocketAddr> = match unit.proxy {
-        Some(ref proxy) => format!("{}:{}", proxy.server, proxy.port),
-        None => format!("{}:{}", hostname, port),
-    }
-    .to_socket_addrs()
-    .map_err(|e| Error::DnsFailed(format!("{}", e)))?
-    .collect();
+    let sock_addrs = resolve_hosts(unit, hostname, port)
+        .map_err(|e| Error::DnsFailed(format!("{}", e)))?
+        .collect::<Vec<_>>();
 
     if sock_addrs.is_empty() {
         return Err(Error::DnsFailed(format!("No ip address for {}", hostname)));

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -40,6 +40,7 @@ pub(crate) struct Unit {
     pub deadline: Option<time::Instant>,
     pub method: String,
     pub proxy: Option<Proxy>,
+    pub addresses: Vec<std::net::SocketAddr>,
     #[cfg(feature = "tls")]
     pub tls_config: Option<TLSClientConfig>,
     #[cfg(all(feature = "native-tls", not(feature = "tls")))]
@@ -111,6 +112,7 @@ impl Unit {
             deadline,
             method: req.method.clone(),
             proxy: req.proxy.clone(),
+            addresses: req.addresses.clone(),
             #[cfg(feature = "tls")]
             tls_config: req.tls_config.clone(),
             #[cfg(all(feature = "native-tls", not(feature = "tls")))]

--- a/tests/override-addresses.rs
+++ b/tests/override-addresses.rs
@@ -1,0 +1,22 @@
+use std::io::Read;
+use std::net::TcpListener;
+
+#[test]
+fn adresses_overridden() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let listener_addr = listener.local_addr().unwrap();
+
+    let server = std::thread::spawn(move || {
+        let (mut client, _) = listener.accept().unwrap();
+        let mut buf = vec![0u8; 16];
+        let read = client.read(&mut buf).unwrap();
+        buf.truncate(read);
+        buf
+    });
+
+    ureq::get("http://cool.server/")
+        .set_addresses(vec![listener_addr])
+        .call();
+
+    assert_eq!(&server.join().unwrap(), b"GET / HTTP/1.1\r\n");
+}


### PR DESCRIPTION
This is one simple way to resolve https://github.com/algesten/ureq/issues/82. It has the drawback of not really handling redirection.

Another way to do it would be to implement a "trait Resolver" set in the Agent, and pre-populate it with a default std::net::ToSocketAddrs implementation. Not sure if that is motivated, though. (Not by my use-case)