### PR TITLE
Implement Pluggable Name-resolution

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 use crate::header::{self, Header};
 use crate::pool::ConnectionPool;
 use crate::request::Request;
+use crate::resolve::ArcResolver;
 
 /// Agents keep state between requests.
 ///
@@ -53,6 +54,7 @@ pub(crate) struct AgentState {
     /// Cookies saved between requests.
     #[cfg(feature = "cookie")]
     pub(crate) jar: CookieJar,
+    pub(crate) resolver: ArcResolver,
 }
 
 impl AgentState {
@@ -188,6 +190,29 @@ impl Agent {
         state
             .pool
             .set_max_idle_connections_per_host(max_connections);
+    }
+
+    /// Configures a custom resolver to be used by this agent. By default,
+    /// address-resolution is done by std::net::ToSocketAddrs. This allows you
+    /// to override that resolution with your own alternative. Useful for
+    /// testing and special-cases like DNS-based load balancing.
+    ///
+    /// A `Fn(&str) -> io::Result<Vec<SocketAddr>>` is a valid resolver,
+    /// passing a closure is a simple way to override. Note that you might need
+    /// explicit type `&str` on the closure argument for type inference to
+    /// succeed.
+    /// ```
+    /// use std::net::ToSocketAddrs;
+    ///
+    /// let mut agent = ureq::agent();
+    /// agent.set_resolver(|addr: &str| match addr {
+    ///    "example.com" => Ok(vec![([127,0,0,1], 8096).into()]),
+    ///    addr => addr.to_socket_addrs().map(Iterator::collect),
+    /// });
+    /// ```
+    pub fn set_resolver(&mut self, resolver: impl crate::Resolver + 'static) -> &mut Self {
+        self.state.lock().unwrap().resolver = resolver.into();
+        self
     }
 
     /// Gets a cookie in this agent by name. Cookies are available

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -57,11 +57,7 @@ pub(crate) struct AgentState {
 
 impl AgentState {
     fn new() -> Self {
-        AgentState {
-            pool: ConnectionPool::new(),
-            #[cfg(feature = "cookie")]
-            jar: CookieJar::new(),
-        }
+        Self::default()
     }
     pub fn pool(&mut self) -> &mut ConnectionPool {
         &mut self.pool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ mod header;
 mod pool;
 mod proxy;
 mod request;
+mod resolve;
 mod response;
 mod stream;
 mod unit;
@@ -140,6 +141,7 @@ pub use crate::error::Error;
 pub use crate::header::Header;
 pub use crate::proxy::Proxy;
 pub use crate::request::Request;
+pub use crate::resolve::Resolver;
 pub use crate::response::Response;
 
 // re-export

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -74,10 +74,6 @@ impl Default for ConnectionPool {
 }
 
 impl ConnectionPool {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn set_max_idle_connections(&mut self, max_connections: usize) {
         if self.max_idle_connections == max_connections {
             return;
@@ -251,7 +247,7 @@ fn pool_connections_limit() {
     // Test inserting connections with different keys into the pool,
     // filling and draining it. The pool should evict earlier connections
     // when the connection limit is reached.
-    let mut pool = ConnectionPool::new();
+    let mut pool = ConnectionPool::default();
     let hostnames = (0..DEFAULT_MAX_IDLE_CONNECTIONS * 2).map(|i| format!("{}.example", i));
     let poolkeys = hostnames.map(|hostname| PoolKey {
         scheme: "https".to_string(),
@@ -276,7 +272,7 @@ fn pool_per_host_connections_limit() {
     // Test inserting connections with the same key into the pool,
     // filling and draining it. The pool should evict earlier connections
     // when the per-host connection limit is reached.
-    let mut pool = ConnectionPool::new();
+    let mut pool = ConnectionPool::default();
     let poolkey = PoolKey {
         scheme: "https".to_string(),
         hostname: "example.com".to_string(),
@@ -301,7 +297,7 @@ fn pool_per_host_connections_limit() {
 
 #[test]
 fn pool_update_connection_limit() {
-    let mut pool = ConnectionPool::new();
+    let mut pool = ConnectionPool::default();
     pool.set_max_idle_connections(50);
 
     let hostnames = (0..pool.max_idle_connections).map(|i| format!("{}.example", i));
@@ -321,7 +317,7 @@ fn pool_update_connection_limit() {
 
 #[test]
 fn pool_update_per_host_connection_limit() {
-    let mut pool = ConnectionPool::new();
+    let mut pool = ConnectionPool::default();
     pool.set_max_idle_connections(50);
     pool.set_max_idle_connections_per_host(50);
 
@@ -347,7 +343,7 @@ fn pool_update_per_host_connection_limit() {
 fn pool_checks_proxy() {
     // Test inserting different poolkeys with same address but different proxies.
     // Each insertion should result in an additional entry in the pool.
-    let mut pool = ConnectionPool::new();
+    let mut pool = ConnectionPool::default();
     let url = Url::parse("zzz:///example.com").unwrap();
 
     pool.add(

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,59 @@
+use std::fmt;
+use std::io::Result as IoResult;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+
+pub trait Resolver: Send + Sync {
+    fn resolve(&self, netloc: &str) -> IoResult<Vec<SocketAddr>>;
+}
+
+#[derive(Debug)]
+pub(crate) struct StdResolver;
+
+impl Resolver for StdResolver {
+    fn resolve(&self, netloc: &str) -> IoResult<Vec<SocketAddr>> {
+        ToSocketAddrs::to_socket_addrs(netloc).map(|iter| iter.collect())
+    }
+}
+
+impl<F> Resolver for F
+where
+    F: Fn(&str) -> IoResult<Vec<SocketAddr>>,
+    F: Send + Sync,
+{
+    fn resolve(&self, netloc: &str) -> IoResult<Vec<SocketAddr>> {
+        self(netloc)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ArcResolver(Arc<dyn Resolver>);
+
+impl<R> From<R> for ArcResolver
+where
+    R: Resolver + 'static,
+{
+    fn from(r: R) -> Self {
+        Self(Arc::new(r))
+    }
+}
+
+impl fmt::Debug for ArcResolver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ArcResolver(...)")
+    }
+}
+
+impl std::ops::Deref for ArcResolver {
+    type Target = dyn Resolver;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl Default for ArcResolver {
+    fn default() -> Self {
+        StdResolver.into()
+    }
+}

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -97,7 +97,7 @@ impl Unit {
     }
 
     pub fn resolver(&self) -> ArcResolver {
-        self.agent.lock().unwrap().resolver.clone()
+        self.req.agent.lock().unwrap().resolver.clone()
     }
 
     #[cfg(test)]

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -11,6 +11,7 @@ use cookie::{Cookie, CookieJar};
 use crate::agent::AgentState;
 use crate::body::{self, Payload, SizedReader};
 use crate::header;
+use crate::resolve::ArcResolver;
 use crate::stream::{self, connect_test, Stream};
 use crate::Proxy;
 use crate::{Error, Header, Request, Response};
@@ -119,6 +120,10 @@ impl Unit {
 
     pub fn is_head(&self) -> bool {
         self.method.eq_ignore_ascii_case("head")
+    }
+
+    pub fn resolver(&self) -> ArcResolver {
+        self.agent.lock().unwrap().resolver.clone()
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Alternative to PR#147.

Advantages;
 - API-change local to `Agent`, most users won't notice
 - Handles redirects
Drawbacks:
 - Small (probably neglible) overhead in extra `Mutex`-locking and `Arc`-cloning
 - Cannot do per-request overrides within the same `Agent`-session

Would also resolve #82 