### PR TITLE
Turn `Option<AgentState>` into `AgentState`

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -40,13 +40,13 @@ pub struct Agent {
     /// Copied into each request of this agent.
     pub(crate) headers: Vec<Header>,
     /// Reused agent state for repeated requests from this agent.
-    pub(crate) state: Arc<Mutex<Option<AgentState>>>,
+    pub(crate) state: Arc<Mutex<AgentState>>,
 }
 
 /// Container of the state
 ///
 /// *Internal API*.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct AgentState {
     /// Reused connections between requests.
     pub(crate) pool: ConnectionPool,
@@ -89,7 +89,7 @@ impl Agent {
     pub fn build(&self) -> Self {
         Agent {
             headers: self.headers.clone(),
-            state: Arc::new(Mutex::new(Some(AgentState::new()))),
+            state: Arc::new(Mutex::new(AgentState::new())),
         }
     }
 
@@ -175,10 +175,8 @@ impl Agent {
     /// agent.set_max_pool_connections(200);
     /// ```
     pub fn set_max_pool_connections(&self, max_connections: usize) {
-        let mut optional_state = self.state.lock().unwrap();
-        if let Some(state) = optional_state.as_mut() {
-            state.pool.set_max_idle_connections(max_connections);
-        }
+        let mut state = self.state.lock().unwrap();
+        state.pool.set_max_idle_connections(max_connections);
     }
 
     /// Sets the maximum number of connections per host to keep in the
@@ -190,12 +188,10 @@ impl Agent {
     /// agent.set_max_pool_connections_per_host(10);
     /// ```
     pub fn set_max_pool_connections_per_host(&self, max_connections: usize) {
-        let mut optional_state = self.state.lock().unwrap();
-        if let Some(state) = optional_state.as_mut() {
-            state
-                .pool
-                .set_max_idle_connections_per_host(max_connections);
-        }
+        let mut state = self.state.lock().unwrap();
+        state
+            .pool
+            .set_max_idle_connections_per_host(max_connections);
     }
 
     /// Gets a cookie in this agent by name. Cookies are available
@@ -212,10 +208,7 @@ impl Agent {
     #[cfg(feature = "cookie")]
     pub fn cookie(&self, name: &str) -> Option<Cookie<'static>> {
         let state = self.state.lock().unwrap();
-        state
-            .as_ref()
-            .and_then(|state| state.jar.get(name))
-            .cloned()
+        state.jar.get(name).cloned()
     }
 
     /// Set a cookie in this agent.
@@ -229,12 +222,7 @@ impl Agent {
     #[cfg(feature = "cookie")]
     pub fn set_cookie(&self, cookie: Cookie<'static>) {
         let mut state = self.state.lock().unwrap();
-        match state.as_mut() {
-            None => (),
-            Some(state) => {
-                state.jar.add_original(cookie);
-            }
-        }
+        state.jar.add_original(cookie);
     }
 
     /// Make a GET request from this agent.
@@ -321,8 +309,7 @@ mod tests {
         reader.read_to_end(&mut buf).unwrap();
 
         fn poolsize(agent: &Agent) -> usize {
-            let mut lock = agent.state.lock().unwrap();
-            let state = lock.as_mut().unwrap();
+            let mut state = agent.state.lock().unwrap();
             state.pool().len()
         }
         assert_eq!(poolsize(&agent), 1);

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -374,15 +374,13 @@ impl<R: Read + Sized + Into<Stream>> PoolReturnRead<R> {
             let state = &mut unit.agent.lock().unwrap();
             // bring back stream here to either go into pool or dealloc
             let stream = reader.into();
-            if let Some(agent) = state.as_mut() {
-                if !stream.is_poolable() {
-                    // just let it deallocate
-                    return;
-                }
-                // insert back into pool
-                let key = PoolKey::new(&unit.url, &unit.proxy);
-                agent.pool().add(key, stream);
+            if !stream.is_poolable() {
+                // just let it deallocate
+                return;
             }
+            // insert back into pool
+            let key = PoolKey::new(&unit.url, &unit.proxy);
+            state.pool().add(key, stream);
         }
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,7 +29,7 @@ use super::SerdeValue;
 /// ```
 #[derive(Clone, Default)]
 pub struct Request {
-    pub(crate) agent: Arc<Mutex<Option<AgentState>>>,
+    pub(crate) agent: Arc<Mutex<AgentState>>,
 
     // via agent
     pub(crate) method: String,

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -78,8 +78,7 @@ fn connection_reuse() {
     resp.into_string().unwrap();
 
     {
-        let mut guard_state = agent.state.lock().unwrap();
-        let mut state = guard_state.take().unwrap();
+        let mut state = agent.state.lock().unwrap();
         assert!(state.pool().len() > 0);
     }
 


### PR DESCRIPTION
`Some(AgentState)` seem to be assumed pretty much everywhere. I could not find any test or piece of code hinting at how `None` should be interpreted, or even see how a state of `None` could even be constructed.

If the `Option` don't serve a purpose (anymore), the code can be both simpler and most likely more performant without it.