### PR TITLE
Add Send + Sync marker traits to into_reader.

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -288,7 +288,7 @@ impl Response {
     /// assert_eq!(bytes.len(), len);
     /// # }
     /// ```
-    pub fn into_reader(self) -> impl Read + Send + Sync {
+    pub fn into_reader(self) -> impl Read + Send {
         //
         let is_http10 = self.http_version().eq_ignore_ascii_case("HTTP/1.0");
         let is_close = self
@@ -327,7 +327,7 @@ impl Response {
 
         match (use_chunked, limit_bytes) {
             (true, _) => Box::new(PoolReturnRead::new(unit, ChunkDecoder::new(stream)))
-                as Box<dyn Read + Send + Sync>,
+                as Box<dyn Read + Send>,
             (false, Some(len)) => {
                 Box::new(PoolReturnRead::new(unit, LimitedRead::new(stream, len)))
             }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -35,7 +35,7 @@ pub enum Stream {
     Https(BufReader<TlsStream<TcpStream>>),
     Cursor(Cursor<Vec<u8>>),
     #[cfg(test)]
-    Test(Box<dyn BufRead + Send>, Vec<u8>),
+    Test(Box<dyn BufRead + Send + Sync>, Vec<u8>),
 }
 
 // DeadlineStream wraps a stream such that read() will return an error


### PR DESCRIPTION
This allows the resulting Read to be shared among threads.