### PR TITLE
bugfix: Don't re-pool streams on drop.

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -426,9 +426,3 @@ impl<R: Read + Sized + Into<Stream>> Read for PoolReturnRead<R> {
         Ok(amount)
     }
 }
-
-impl<R: Read + Sized + Into<Stream>> Drop for PoolReturnRead<R> {
-    fn drop(&mut self) {
-        self.return_connection();
-    }
-}

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -177,16 +177,17 @@ fn dirty_streams_not_returned() -> io::Result<()> {
     let url = format!("http://localhost:{}/", testserver.port);
     let agent = Agent::default().build();
     let resp = agent.get(&url).call();
-    assert!(resp.ok(), format!("error: {}", resp.status()));
+    if let Some(err) = resp.synthetic_error() {
+        panic!("resp failed: {:?}", err);
+    }
     let resp_str = resp.into_string()?;
     assert_eq!(resp_str, "corgidachsund");
 
     // Now fetch it again, but only read part of the body.
     let resp_to_be_dropped = agent.get(&url).call();
-    assert!(
-        resp_to_be_dropped.ok(),
-        format!("error: {}", resp_to_be_dropped.status())
-    );
+    if let Some(err) = resp_to_be_dropped.synthetic_error() {
+        panic!("resp_to_be_dropped failed: {:?}", err);
+    }
     let mut reader = resp_to_be_dropped.into_reader();
 
     // Read 9 bytes of the response and then drop the reader.
@@ -197,10 +198,9 @@ fn dirty_streams_not_returned() -> io::Result<()> {
     drop(reader);
 
     let resp_to_succeed = agent.get(&url).call();
-    assert!(
-        resp_to_succeed.ok(),
-        format!("error: {}", resp_to_succeed.status())
-    );
+    if let Some(err) = resp_to_succeed.synthetic_error() {
+        panic!("resp_to_succeed failed: {:?}", err);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
We only want streams in the pool that are ready for the next request,
and don't have any remaining bytes of the previous request. That's the
case when we return a stream due to EOF on the underlying `Read`.

However, there was also an `impl Drop` that returned the stream to the
pool on drop of a PoolReturnRead. That resulted in a bug: If a user
called `response.into_reader()`, but did not read the entire body,
a dirty stream would be returned to the pool. The next time a request
was made to the same host, that stream would be reused, and instead of
reading off "HTTP/1.1 200 OK", ureq would read a remnant of the previous
request, resulting in a BadStatus error.