### PR TITLE
Pass through io::Errors when reading headers.

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -478,14 +478,14 @@ impl Response {
         // HTTP/1.1 200 OK\r\n
         let status_line = read_next_line(&mut reader).map_err(|e| match e.kind() {
             ErrorKind::ConnectionAborted => Error::BadStatusRead,
-            _ => Error::BadStatus,
+            _ => Error::Io(e),
         })?;
 
         let (index, status) = parse_status_line(status_line.as_str())?;
 
         let mut headers: Vec<Header> = Vec::new();
         loop {
-            let line = read_next_line(&mut reader).map_err(|_| Error::BadHeader)?;
+            let line = read_next_line(&mut reader)?;
             if line.is_empty() {
                 break;
             }


### PR DESCRIPTION
Previously any io::Error on reading a status line or response headers
would be unconditionally mapping into BadStatus or BadHeader. I think
it's better to pass through the actual io:Error.

BadStatusRead is still kept, since it has special status when dealing
with timed out connections, and BadStatus is still used when the status
line is malformed.