### PR TITLE
Handle ConnectionReset+ConnectionAbort at any time

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -476,10 +476,7 @@ impl Response {
     fn do_from_read(mut reader: impl Read) -> Result<Response, Error> {
         //
         // HTTP/1.1 200 OK\r\n
-        let status_line = read_next_line(&mut reader).map_err(|e| match e.kind() {
-            ErrorKind::ConnectionAborted => Error::BadStatusRead,
-            _ => Error::Io(e),
-        })?;
+        let status_line = read_next_line(&mut reader)?;
 
         let (index, status) = parse_status_line(status_line.as_str())?;
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -179,12 +179,8 @@ pub(crate) fn connect(
     // from the ConnectionPool, since those are most likely to have
     // reached a server-side timeout. Note that this means we may do
     // up to N+1 total tries, where N is max_idle_connections_per_host.
-    //
-    // TODO: is_bad_status_read is too narrow since it covers only the
-    // first line. It's also allowable to retry requests that hit a
-    // closed connection during the sending or receiving of headers.
     if let Some(err) = resp.synthetic_error() {
-        if err.is_bad_status_read() && retryable && is_recycled {
+        if err.connection_closed() && retryable && is_recycled {
             let empty = Payload::Empty.into_read();
             return connect(req, unit, false, redirect_count, empty, redir);
         }


### PR DESCRIPTION
Previously we had a special case for BadStatusRead that would happen
only when we got a ConnectionAborted error reading the status line.
However, sometimes we get ConnectionReset instead. Also the HTTP
spec says that idempotent requests may be retried anytime a connection
is closed prematurely.

The change treats as retryable any ConnectionAborted OR ConnectionReset
error while reading the status line and headers. It removes the special
case BadStatusRead error.

Fixes #165 (I think).