### PR TITLE
Use cookie_store crate instead of cookie::CookieJar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ json = ["serde", "serde_json"]
 charset = ["encoding"]
 tls = ["rustls", "webpki", "webpki-roots"]
 native-certs = ["rustls-native-certs"]
-cookies = ["cookie"]
+cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
 
 [dependencies]
@@ -39,7 +39,7 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding = { version = "0.2", optional = true }
 native-tls = { version = "0.2", optional = true }
-cookie_store = "0.12.0"
+cookie_store = { version = "0.12.0", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding = { version = "0.2", optional = true }
 native-tls = { version = "0.2", optional = true }
+cookie_store = "0.12.0"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -31,34 +31,6 @@ fn agent_reuse_headers() {
     assert_eq!(resp.header("X-Call").unwrap(), "2");
 }
 
-#[cfg(feature = "cookie")]
-#[test]
-fn agent_cookies() {
-    let agent = agent();
-
-    test::set_handler("/agent_cookies", |_unit| {
-        test::make_response(
-            200,
-            "OK",
-            vec!["Set-Cookie: foo=bar%20baz; Path=/; HttpOnly"],
-            vec![],
-        )
-    });
-
-    agent.get("test://host/agent_cookies").call();
-
-    assert!(agent.cookie("foo").is_some());
-    assert_eq!(agent.cookie("foo").unwrap().value(), "bar baz");
-
-    test::set_handler("/agent_cookies", |unit| {
-        assert!(unit.has("cookie"));
-        assert_eq!(unit.header("cookie").unwrap(), "foo=bar%20baz");
-        test::make_response(200, "OK", vec![], vec![])
-    });
-
-    agent.get("test://host/agent_cookies").call();
-}
-
 // Handler that answers with a simple HTTP response, and times
 // out idle connections after 2 seconds.
 fn idle_timeout_handler(mut stream: TcpStream) -> io::Result<()> {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -8,6 +8,7 @@ use url::Url;
 #[cfg(feature = "cookie")]
 use cookie::Cookie;
 
+#[cfg(feature = "cookie")]
 use crate::agent::AgentState;
 use crate::body::{self, BodySize, Payload, SizedReader};
 use crate::header;


### PR DESCRIPTION
CookieJar doesn't support the path-match and domain-match algorithms from [RFC 6265](https://tools.ietf.org/html/rfc6265#section-5.1.3), while cookie_store does.

This fixes some issues with the cookie matching algorithm currently in ureq. For instance,
the domain-match uses substring matching rather than the RFC 6265 algorithm.

This deletes two tests:

match_cookies_returns_nothing_when_no_cookies didn't test much
agent_cookies was failing because cookie_store rejects cookies on the `test:` scheme. The way around this is to set up a testserver - but it turns out cookies_on_redirect already does that, and covers the same cases and more.