### PR TITLE
Add log dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,12 +39,14 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding = { version = "0.2", optional = true }
 native-tls = { version = "0.2", optional = true }
+log = "0.4.11"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 rayon = "1.3.0"
 rayon-core = "1.7.0"
 chrono = "0.4.11"
+env_logger = "0.7.1"
 
 [[example]]
 name = "smoke-test"

--- a/examples/smoke-test/main.rs
+++ b/examples/smoke-test/main.rs
@@ -1,6 +1,5 @@
 use chrono::Local;
 use rayon::prelude::*;
-use rayon_core;
 
 use std::io::{self, BufRead, BufReader, Read};
 use std::iter::Iterator;
@@ -92,6 +91,7 @@ using 50 threads concurrently.
         );
         return Ok(());
     }
+    env_logger::init();
     let file = std::fs::File::open(args.skip(1).next().unwrap())?;
     let bufreader = BufReader::new(file);
     let mut urls = vec![];


### PR DESCRIPTION
Also add log statements to unit. Each request gets one info line;
retries, redirects, and responses get logged at debug level.

Fixes #163 