### PR TITLE
Add test.sh.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,6 @@ jobs:
         what:
           - "--doc"
           - "--tests"
-        exclude:
-          - tls: ""
-            what: "--doc"
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"

--- a/src/response.rs
+++ b/src/response.rs
@@ -391,7 +391,7 @@ impl Response {
     ///
     /// ```
     /// let resp =
-    ///     ureq::get("https://ureq.s3.eu-central-1.amazonaws.com/hello_world.json")
+    ///     ureq::get("http://ureq.s3.eu-central-1.amazonaws.com/hello_world.json")
     ///         .call();
     ///
     /// let json = resp.into_json().unwrap();
@@ -436,7 +436,7 @@ impl Response {
     /// }
     ///
     /// let resp =
-    ///     ureq::get("https://ureq.s3.eu-central-1.amazonaws.com/hello_world.json")
+    ///     ureq::get("http://ureq.s3.eu-central-1.amazonaws.com/hello_world.json")
     ///         .call();
     ///
     /// let json = resp.into_json_deserialize::<Hello>().unwrap();

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu
+
+export RUST_BACKTRACE=1
+export RUSTFLAGS="-D dead_code -D unused-variables -D unused"
+
+for tls in "" tls native-tls ; do
+  for feature in "" json charset cookies socks-proxy ; do
+    for what in --doc --tests ; do
+      if ! cargo test "${what}" --no-default-features --features "${tls} ${feature}" ; then
+        echo Command failed: cargo test \"${what}\" --no-default-features --features \"${tls} ${feature}\"
+        exit 1
+      fi
+    done
+  done
+done


### PR DESCRIPTION
This emulates the test matrix that gets run in CI, making it easier to
find failures locally.

There was one conflict in the matrix: when JSON is enabled and TLS is
disabled, two of the doctests would fail. This was previous worked
around as an exclude in the github workflow. I changed the JSON doctest
to use HTTP instead.