### PR TITLE
Replace lazy_static! with once_cell Lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ socks-proxy = ["socks"]
 base64 = "0.13"
 chunked_transfer = "1.2.0"
 cookie = { version = "0.14", features = ["percent-encode"], optional = true}
-lazy_static = "1"
+once_cell = "1"
 qstring = "0.7"
 url = "2"
 socks = { version = "0.3.2", optional = true }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -327,16 +327,14 @@ fn configure_certs(config: &mut rustls::ClientConfig) {
 
 #[cfg(all(feature = "tls", not(feature = "native-tls")))]
 pub(crate) fn connect_https(unit: &Unit, hostname: &str) -> Result<Stream, Error> {
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use std::sync::Arc;
 
-    lazy_static! {
-        static ref TLS_CONF: Arc<rustls::ClientConfig> = {
-            let mut config = rustls::ClientConfig::new();
-            configure_certs(&mut config);
-            Arc::new(config)
-        };
-    }
+    static TLS_CONF: Lazy<Arc<rustls::ClientConfig>> = Lazy::new(|| {
+        let mut config = rustls::ClientConfig::new();
+        configure_certs(&mut config);
+        Arc::new(config)
+    });
 
     let port = unit.url.port().unwrap_or(443);
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::stream::Stream;
 use crate::unit::Unit;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::io::{Cursor, Write};
 use std::sync::{Arc, Mutex};
@@ -19,10 +19,8 @@ mod timeout;
 
 type RequestHandler = dyn Fn(&Unit) -> Result<Stream, Error> + Send + 'static;
 
-lazy_static! {
-    pub(crate) static ref TEST_HANDLERS: Arc<Mutex<HashMap<String, Box<RequestHandler>>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-}
+pub(crate) static TEST_HANDLERS: Lazy<Arc<Mutex<HashMap<String, Box<RequestHandler>>>>> =
+    Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
 
 pub(crate) fn set_handler<H>(path: &str, handler: H)
 where


### PR DESCRIPTION
Modern rust code bases prefer once_cell::sync::Lazy over the older
macro based lazy_static.

Notice we still have `lazy_static` in the tree, but only for tests. If we run `cargo tree` without test deps, we are now lazy_static free:

```bash
cargo tree -e normal,build
```
