### PR TITLE
Remove convenience methods for CONNECT verb.

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -281,11 +281,6 @@ impl Agent {
         self.request("OPTIONS", path)
     }
 
-    /// Make a CONNECT request from this agent.
-    pub fn connect(&self, path: &str) -> Request {
-        self.request("CONNECT", path)
-    }
-
     /// Make a PATCH request from this agent.
     pub fn patch(&self, path: &str) -> Request {
         self.request("PATCH", path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,11 +199,6 @@ pub fn options(path: &str) -> Request {
     request("OPTIONS", path)
 }
 
-/// Make an CONNECT request.
-pub fn connect(path: &str) -> Request {
-    request("CONNECT", path)
-}
-
 /// Make an PATCH request.
 pub fn patch(path: &str) -> Request {
     request("PATCH", path)


### PR DESCRIPTION
CONNECT, specified at https://tools.ietf.org/html/rfc7231#section-4.3.6,
says:

> if successful, thereafter restrict its behavior to blind forwarding
> of packets, in both directions, until the tunnel is closed.

ureq doesn't actually support the semantics of CONNECT, since it doesn't
offer a bidirectional channel on a Response. So I'm fairly confident no
one is using these methods.