### PR TITLE
Use correct host on redirect.

### DIFF
--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -1,3 +1,9 @@
+use std::{
+    io::{self, Write},
+    net::TcpStream,
+};
+use test::testserver::{self, TestServer};
+
 use crate::test;
 
 use super::super::*;
@@ -74,6 +80,25 @@ fn redirect_get() {
     assert_eq!(resp.get_url(), "test://host/redirect_get2");
     assert!(resp.has("x-foo"));
     assert_eq!(resp.header("x-foo").unwrap(), "bar");
+}
+
+#[test]
+fn redirect_host() {
+    // Set up a redirect to a host that doesn't exist; it should fail.
+    let srv = TestServer::new(|mut stream: TcpStream| -> io::Result<()> {
+        testserver::read_headers(&stream);
+        write!(stream, "HTTP/1.1 302 Found\r\n")?;
+        write!(stream, "Location: http://example.invalid/\r\n")?;
+        write!(stream, "\r\n")?;
+        Ok(())
+    });
+    let url = format!("http://localhost:{}/", srv.port);
+    let resp = crate::get(&url).call();
+    assert!(
+        matches!(resp.synthetic_error(), Some(Error::DnsFailed(_))),
+        "{:?}",
+        resp.synthetic_error()
+    );
 }
 
 #[test]

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -145,7 +145,10 @@ pub(crate) fn connect(
 ) -> Result<Response, Error> {
     //
 
-    let host = req.get_host()?;
+    let host = unit
+        .url
+        .host_str()
+        .ok_or(Error::BadUrl("no host".to_string()))?;
     let url = &unit.url;
     let method = &unit.req.method;
     // open socket
@@ -361,6 +364,7 @@ fn send_prelude(unit: &Unit, stream: &mut Stream, redir: bool) -> io::Result<()>
     // finish
     write!(prelude, "\r\n")?;
 
+    debug!("writing prelude: {}", String::from_utf8_lossy(&prelude));
     // write all to the wire
     stream.write_all(&prelude[..])?;
 


### PR DESCRIPTION
As of 1.5.0, redirects to a different host are broken. This broke as part of #153,
which set the hostname from `req` instead of from `unit.url`.

Fixes #179.