### PR TITLE
Move Agent construction to new AgentBuilder.

### DIFF
--- a/examples/smoke-test/main.rs
+++ b/examples/smoke-test/main.rs
@@ -61,7 +61,7 @@ fn get_and_write(agent: &ureq::Agent, url: &String) -> Result<()> {
 }
 
 fn get_many(urls: Vec<String>, simultaneous_fetches: usize) -> Result<()> {
-    let agent = ureq::Agent::default().build();
+    let agent = ureq::Agent::default();
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(simultaneous_fetches)
         .build()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ mod serde_macros;
 mod test;
 
 pub use crate::agent::Agent;
+pub use crate::agent::AgentBuilder;
 pub use crate::error::Error;
 pub use crate::header::Header;
 pub use crate::proxy::Proxy;
@@ -135,7 +136,7 @@ pub use serde_json::{to_value as serde_to_value, Map as SerdeMap, Value as Serde
 
 /// Agents are used to keep state between requests.
 pub fn agent() -> Agent {
-    Agent::new().build()
+    Agent::default()
 }
 
 /// Make a request setting the HTTP method via a string.
@@ -144,7 +145,7 @@ pub fn agent() -> Agent {
 /// ureq::request("GET", "http://example.com").call().unwrap();
 /// ```
 pub fn request(method: &str, path: &str) -> Request {
-    Agent::new().request(method, path)
+    agent().request(method, path)
 }
 
 /// Make a GET request.

--- a/src/request.rs
+++ b/src/request.rs
@@ -690,3 +690,17 @@ fn no_hostname() {
     );
     assert!(req.get_host().is_err());
 }
+
+#[test]
+fn request_implements_send_and_sync() {
+    let _request: Box<dyn Send> = Box::new(Request::new(
+        &Agent::default(),
+        "GET".to_string(),
+        "https://example.com/".to_string(),
+    ));
+    let _request: Box<dyn Sync> = Box::new(Request::new(
+        &Agent::default(),
+        "GET".to_string(),
+        "https://example.com/".to_string(),
+    ));
+}

--- a/src/test/auth.rs
+++ b/src/test/auth.rs
@@ -55,7 +55,7 @@ fn url_auth_overridden() {
         );
         test::make_response(200, "OK", vec![], vec![])
     });
-    let agent = agent().auth("martin", "rubbermashgum").build();
+    let agent = AgentBuilder::new().auth("martin", "rubbermashgum").build();
     let resp = agent
         .get("test://Aladdin:OpenSesame@host/url_auth_overridden")
         .call()

--- a/src/test/timeout.rs
+++ b/src/test/timeout.rs
@@ -25,7 +25,7 @@ fn dribble_body_respond(mut stream: TcpStream, contents: &[u8]) -> io::Result<()
 }
 
 fn get_and_expect_timeout(url: String) {
-    let agent = Agent::default().build();
+    let agent = Agent::default();
     let timeout = Duration::from_millis(500);
     let resp = agent.get(&url).timeout(timeout).call().unwrap();
 
@@ -86,7 +86,7 @@ fn overall_timeout_reading_json() {
     });
     let url = format!("http://localhost:{}/", server.port);
 
-    let agent = Agent::default().build();
+    let agent = Agent::default();
     let timeout = Duration::from_millis(500);
     let resp = agent.get(&url).timeout(timeout).call().unwrap();
 

--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -102,7 +102,7 @@ m0Wqhhi8/24Sy934t5Txgkfoltg8ahkx934WjP6WWRnSAu+cf+vW
 #[cfg(feature = "tls")]
 #[test]
 fn tls_client_certificate() {
-    let agent = ureq::Agent::default().build();
+    let agent = ureq::Agent::default();
 
     let mut tls_config = rustls::ClientConfig::new();
 


### PR DESCRIPTION
In the process, rename set_foo methods to just foo, since methods on the
builder will always be setters.

Adds a new() method on ConnectionPool so it can be constructed directly
with the desired limits. Removes the setter methods on ConnectionPool
for those limits. This means that connection limits can only be set when
an Agent is built.

There were two tests that verify Send and Sync implementations, one for
Agent and one for Request. This PR moves the Request test to request.rs,
and changes both tests to more directly verify the traits. There may be
another way to do this, I'm not sure.

Related to #184 