### PR TITLE
Check error immediately after Response::from_read

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -221,6 +221,11 @@ impl Response {
         &self.error
     }
 
+    // Internal-only API, to allow unit::connect to return early on errors.
+    pub(crate) fn into_error(self) -> Option<Error> {
+        self.error
+    }
+
     /// The content type part of the "Content-Type" header without
     /// the charset.
     ///

--- a/src/test/timeout.rs
+++ b/src/test/timeout.rs
@@ -28,15 +28,15 @@ fn get_and_expect_timeout(url: String) {
     let agent = Agent::default().build();
     let timeout = Duration::from_millis(500);
     let resp = agent.get(&url).timeout(timeout).call();
-
-    match resp.into_string() {
-        Err(io_error) => match io_error.kind() {
-            io::ErrorKind::TimedOut => Ok(()),
-            _ => Err(format!("{:?}", io_error)),
-        },
-        Ok(_) => Err("successful response".to_string()),
-    }
-    .expect("expected timeout but got something else");
+    assert!(
+        matches!(resp.synthetic_error(), Some(Error::Io(_))),
+        "expected timeout error, got {:?}",
+        resp.synthetic_error()
+    );
+    assert_eq!(
+        resp.synthetic_error().as_ref().unwrap().body_text(),
+        "Network Error: timed out reading response"
+    );
 }
 
 #[test]

--- a/src/test/timeout.rs
+++ b/src/test/timeout.rs
@@ -60,6 +60,18 @@ fn dribble_headers_respond(mut stream: TcpStream) -> io::Result<()> {
 }
 
 #[test]
+fn read_timeout_during_headers() {
+    let server = TestServer::new(dribble_headers_respond);
+    let url = format!("http://localhost:{}/", server.port);
+    let resp = crate::get(&url).timeout_read(10).call();
+    assert!(!resp.ok());
+    assert_eq!(
+        resp.into_string().unwrap(),
+        "Network Error: timed out reading response\n"
+    );
+}
+
+#[test]
 fn overall_timeout_during_headers() {
     // Start a test server on an available port, that dribbles out a response at 1 write per 10ms.
     let server = TestServer::new(dribble_headers_respond);

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -181,9 +181,6 @@ pub(crate) fn connect(
     // start reading the response to process cookies and redirects.
     let mut stream = stream::DeadlineStream::new(stream, unit.deadline);
     let mut resp = Response::from_read(&mut stream);
-    if resp.synthetic_error().is_some() {
-        return Err(resp.into_error().unwrap());
-    }
 
     // https://tools.ietf.org/html/rfc7230#section-6.3.1
     // When an inbound connection is closed prematurely, a client MAY
@@ -201,6 +198,8 @@ pub(crate) fn connect(
             let empty = Payload::Empty.into_read();
             return connect(req, unit, false, redirect_count, empty, redir);
         }
+        // Non-retryable errors return early.
+        return Err(resp.into_error().unwrap());
     }
 
     // squirrel away cookies

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -181,6 +181,9 @@ pub(crate) fn connect(
     // start reading the response to process cookies and redirects.
     let mut stream = stream::DeadlineStream::new(stream, unit.deadline);
     let mut resp = Response::from_read(&mut stream);
+    if resp.synthetic_error().is_some() {
+        return Err(resp.into_error().unwrap());
+    }
 
     // https://tools.ietf.org/html/rfc7230#section-6.3.1
     // When an inbound connection is closed prematurely, a client MAY


### PR DESCRIPTION
This is a fix for the issue reported in the second comment at https://github.com/algesten/ureq/issues/196#issuecomment-712863514. Note that it's a draft because this breaks at least one existing test: `overall_timeout_during_headers`. That's because previously, the overall timeout was getting preserved on the stream, and `into_string()` was returning an I/O error. With this fix, the stream is not getting assigned to the Response at all, and so `into_string()` is successfully reading the synthetic error body.