### PR TITLE
Make Request::send more general.

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -17,11 +17,11 @@ use super::SerdeValue;
 /// *Internal API*
 pub(crate) enum Payload<'a> {
     Empty,
-    Text(String, String),
+    Text(&'a str, String),
     #[cfg(feature = "json")]
     JSON(SerdeValue),
     Reader(Box<dyn Read + 'a>),
-    Bytes(Vec<u8>),
+    Bytes(&'a [u8]),
 }
 
 impl fmt::Debug for Payload<'_> {
@@ -86,7 +86,7 @@ impl<'a> Payload<'a> {
                     encoding.encode(&text, EncoderTrap::Replace).unwrap()
                 };
                 #[cfg(not(feature = "charset"))]
-                let bytes = text.into_bytes();
+                let bytes = text.as_bytes();
                 let len = bytes.len();
                 let cursor = Cursor::new(bytes);
                 SizedReader::new(BodySize::Known(len as u64), Box::new(cursor))

--- a/src/body.rs
+++ b/src/body.rs
@@ -15,16 +15,16 @@ use super::SerdeValue;
 /// The different kinds of bodies to send.
 ///
 /// *Internal API*
-pub(crate) enum Payload {
+pub(crate) enum Payload<'a> {
     Empty,
     Text(String, String),
     #[cfg(feature = "json")]
     JSON(SerdeValue),
-    Reader(Box<dyn Read + 'static>),
+    Reader(Box<dyn Read + 'a>),
     Bytes(Vec<u8>),
 }
 
-impl fmt::Debug for Payload {
+impl fmt::Debug for Payload<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Payload::Empty => write!(f, "Empty"),
@@ -37,8 +37,8 @@ impl fmt::Debug for Payload {
     }
 }
 
-impl Default for Payload {
-    fn default() -> Payload {
+impl Default for Payload<'_> {
+    fn default() -> Self {
         Payload::Empty
     }
 }
@@ -56,25 +56,25 @@ pub(crate) enum BodySize {
 /// Payloads are turned into this type where we can hold both a size and the reader.
 ///
 /// *Internal API*
-pub(crate) struct SizedReader {
+pub(crate) struct SizedReader<'a> {
     pub size: BodySize,
-    pub reader: Box<dyn Read + 'static>,
+    pub reader: Box<dyn Read + 'a>,
 }
 
-impl fmt::Debug for SizedReader {
+impl fmt::Debug for SizedReader<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "SizedReader[size={:?},reader]", self.size)
     }
 }
 
-impl SizedReader {
-    fn new(size: BodySize, reader: Box<dyn Read + 'static>) -> Self {
+impl<'a> SizedReader<'a> {
+    fn new(size: BodySize, reader: Box<dyn Read + 'a>) -> Self {
         SizedReader { size, reader }
     }
 }
 
-impl Payload {
-    pub fn into_read(self) -> SizedReader {
+impl<'a> Payload<'a> {
+    pub fn into_read(self) -> SizedReader<'a> {
         match self {
             Payload::Empty => SizedReader::new(BodySize::Empty, Box::new(empty())),
             Payload::Text(text, _charset) => {

--- a/src/request.rs
+++ b/src/request.rs
@@ -227,7 +227,7 @@ impl Request {
     ///     .set("Content-Type", "text/plain")
     ///     .send(read);
     /// ```
-    pub fn send(&mut self, reader: impl Read + 'static) -> Response {
+    pub fn send(&mut self, reader: impl Read) -> Response {
         self.do_call(Payload::Reader(Box::new(reader)))
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -153,7 +153,7 @@ impl Request {
     /// println!("{:?}", r);
     /// ```
     pub fn send_bytes(&mut self, data: &[u8]) -> Response {
-        self.do_call(Payload::Bytes(data.to_owned()))
+        self.do_call(Payload::Bytes(data))
     }
 
     /// Send data as a string.
@@ -178,10 +178,9 @@ impl Request {
     /// println!("{:?}", r);
     /// ```
     pub fn send_string(&mut self, data: &str) -> Response {
-        let text = data.into();
         let charset =
             crate::response::charset_from_content_type(self.header("content-type")).to_string();
-        self.do_call(Payload::Text(text, charset))
+        self.do_call(Payload::Text(data, charset))
     }
 
     /// Send a sequence of (key, value) pairs as form-urlencoded data.
@@ -206,7 +205,7 @@ impl Request {
         let encoded = form_urlencoded::Serializer::new(String::new())
             .extend_pairs(data)
             .finish();
-        self.do_call(Payload::Bytes(encoded.into_bytes()))
+        self.do_call(Payload::Bytes(&encoded.into_bytes()))
     }
 
     /// Send data from a reader.
@@ -667,4 +666,10 @@ fn no_hostname() {
         "unix:/run/foo.socket".to_string(),
     );
     assert!(req.get_host().is_err());
+}
+
+#[test]
+fn send_byte_slice() {
+    let bytes = vec![1, 2, 3];
+    crate::agent().post("http://example.com").send(&bytes[1..2]);
 }


### PR DESCRIPTION
Removes `+ 'static` constraint from the `impl Read` parameter.
For this, lifetime parameters are added to `Payload` and `SizedReader`.