### PR TITLE
Agent tweaks for 2.0

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -133,6 +133,11 @@ impl Agent {
         self.request("GET", path)
     }
 
+    /// Make a HEAD request from this agent.
+    pub fn head(&self, path: &str) -> Request {
+        self.request("HEAD", path)
+    }
+
     /// Make a POST request from this agent.
     pub fn post(&self, path: &str) -> Request {
         self.request("POST", path)
@@ -141,6 +146,11 @@ impl Agent {
     /// Make a PUT request from this agent.
     pub fn put(&self, path: &str) -> Request {
         self.request("PUT", path)
+    }
+
+    /// Make a DELETE request from this agent.
+    pub fn delete(&self, path: &str) -> Request {
+        self.request("DELETE", path)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,21 +182,6 @@ pub fn delete(path: &str) -> Request {
     request("DELETE", path)
 }
 
-/// Make a TRACE request.
-pub fn trace(path: &str) -> Request {
-    request("TRACE", path)
-}
-
-/// Make an OPTIONS request.
-pub fn options(path: &str) -> Request {
-    request("OPTIONS", path)
-}
-
-/// Make an PATCH request.
-pub fn patch(path: &str) -> Request {
-    request("PATCH", path)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/request.rs
+++ b/src/request.rs
@@ -118,12 +118,11 @@ impl Request {
     /// }
     /// ```
     #[cfg(feature = "json")]
-    pub fn send_json(self, data: SerdeValue) -> Result<Response> {
-        let mut this = self;
-        if this.header("Content-Type").is_none() {
-            this = this.set("Content-Type", "application/json");
+    pub fn send_json(mut self, data: SerdeValue) -> Result<Response> {
+        if self.header("Content-Type").is_none() {
+            self = self.set("Content-Type", "application/json");
         }
-        this.do_call(Payload::JSON(data))
+        self.do_call(Payload::JSON(data))
     }
 
     /// Send data as bytes.
@@ -182,15 +181,14 @@ impl Request {
     /// println!("{:?}", r);
     /// }
     /// ```
-    pub fn send_form(self, data: &[(&str, &str)]) -> Result<Response> {
-        let mut this = self;
-        if this.header("Content-Type").is_none() {
-            this = this.set("Content-Type", "application/x-www-form-urlencoded");
+    pub fn send_form(mut self, data: &[(&str, &str)]) -> Result<Response> {
+        if self.header("Content-Type").is_none() {
+            self = self.set("Content-Type", "application/x-www-form-urlencoded");
         }
         let encoded = form_urlencoded::Serializer::new(String::new())
             .extend_pairs(data)
             .finish();
-        this.do_call(Payload::Bytes(&encoded.into_bytes()))
+        self.do_call(Payload::Bytes(&encoded.into_bytes()))
     }
 
     /// Send data from a reader.
@@ -423,7 +421,7 @@ impl Request {
     }
 
     pub(crate) fn proxy(&self) -> Option<Proxy> {
-        if let Some(proxy) = &self.agent.state.proxy {
+        if let Some(proxy) = &self.agent.config.proxy {
             Some(proxy.clone())
         } else {
             None


### PR DESCRIPTION
Replace `this` idiom with `mut self`.

Move idle connections constants from pool.rs to agent.rs.

Remove Agent.set and some convenience request methods
(leaving get, post, and put).

Move max_idle_connections setting from AgentConfig to AgentBuilder
(since the builder passes these to ConnectionPool and the Agent
doesn't subsequently need them).

Eliminate duplicate copy of proxy in AgentState; use the one in
AgentConfig.