### PR TITLE
Split out RequestBuilder from Request.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ base64 = "0.13"
 chunked_transfer = "1.2.0"
 cookie = { version = "0.14", features = ["percent-encode"], optional = true}
 once_cell = "1"
-qstring = "0.7"
 url = "2"
 socks = { version = "0.3.2", optional = true }
 rustls = { version = "0.18", optional = true, features = [] }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::pool::ConnectionPool;
 use crate::proxy::Proxy;
-use crate::request::Request;
+use crate::request::RequestBuilder;
 use crate::resolve::{ArcResolver, StdResolver};
 use std::time::Duration;
 
@@ -106,32 +106,35 @@ impl Agent {
     ///     .call();
     /// println!("{:?}", r);
     /// ```
-    pub fn request(&self, method: &str, path: &str) -> Request {
-        Request::new(self.clone(), method.into(), path.into())
+    pub fn request(&self, method: &str, url: &str) -> RequestBuilder {
+        RequestBuilder::new()
+            .agent(self.clone())
+            .method(method)
+            .url_str(url)
     }
 
     /// Make a GET request from this agent.
-    pub fn get(&self, path: &str) -> Request {
+    pub fn get(&self, path: &str) -> RequestBuilder {
         self.request("GET", path)
     }
 
     /// Make a HEAD request from this agent.
-    pub fn head(&self, path: &str) -> Request {
+    pub fn head(&self, path: &str) -> RequestBuilder {
         self.request("HEAD", path)
     }
 
     /// Make a POST request from this agent.
-    pub fn post(&self, path: &str) -> Request {
+    pub fn post(&self, path: &str) -> RequestBuilder {
         self.request("POST", path)
     }
 
     /// Make a PUT request from this agent.
-    pub fn put(&self, path: &str) -> Request {
+    pub fn put(&self, path: &str) -> RequestBuilder {
         self.request("PUT", path)
     }
 
     /// Make a DELETE request from this agent.
-    pub fn delete(&self, path: &str) -> Request {
+    pub fn delete(&self, path: &str) -> RequestBuilder {
         self.request("DELETE", path)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,7 @@ pub use crate::error::Error;
 pub use crate::header::Header;
 pub use crate::proxy::Proxy;
 pub use crate::request::Request;
+pub use crate::request::RequestBuilder;
 pub use crate::resolve::Resolver;
 pub use crate::response::Response;
 
@@ -155,32 +156,32 @@ pub fn agent() -> Agent {
 /// ```
 /// ureq::request("GET", "http://example.com").call().unwrap();
 /// ```
-pub fn request(method: &str, path: &str) -> Request {
+pub fn request(method: &str, path: &str) -> RequestBuilder {
     agent().request(method, path)
 }
 
 /// Make a GET request.
-pub fn get(path: &str) -> Request {
+pub fn get(path: &str) -> RequestBuilder {
     request("GET", path)
 }
 
 /// Make a HEAD request.
-pub fn head(path: &str) -> Request {
+pub fn head(path: &str) -> RequestBuilder {
     request("HEAD", path)
 }
 
 /// Make a POST request.
-pub fn post(path: &str) -> Request {
+pub fn post(path: &str) -> RequestBuilder {
     request("POST", path)
 }
 
 /// Make a PUT request.
-pub fn put(path: &str) -> Request {
+pub fn put(path: &str) -> RequestBuilder {
     request("PUT", path)
 }
 
 /// Make a DELETE request.
-pub fn delete(path: &str) -> Request {
+pub fn delete(path: &str) -> RequestBuilder {
     request("DELETE", path)
 }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -330,7 +330,7 @@ impl<R: Read + Sized + Into<Stream>> PoolReturnRead<R> {
             stream.reset()?;
 
             // insert back into pool
-            let key = PoolKey::new(&unit.url, unit.req.proxy());
+            let key = PoolKey::new(&unit.url, unit.req.agent.config.proxy.clone());
             unit.req.agent.state.pool.add(key, stream);
         }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -338,7 +338,7 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
         } else {
             unit.deadline
         };
-    let proxy: Option<Proxy> = unit.req.proxy();
+    let proxy: Option<Proxy> = unit.req.agent.config.proxy.clone();
     let netloc = match proxy {
         Some(ref proxy) => format!("{}:{}", proxy.server, proxy.port),
         None => format!("{}:{}", hostname, port),

--- a/src/test/query_string.rs
+++ b/src/test/query_string.rs
@@ -25,7 +25,11 @@ fn escaped_query_string() {
         .unwrap();
     let vec = resp.to_write_vec();
     let s = String::from_utf8_lossy(&vec);
-    assert!(s.contains("GET /escaped_query_string?foo=bar&baz=yo%20lo HTTP/1.1"))
+    assert!(
+        s.contains("GET /escaped_query_string?foo=bar&baz=yo+lo HTTP/1.1"),
+        "req: {}",
+        s
+    );
 }
 
 #[test]
@@ -50,5 +54,5 @@ fn query_in_path_and_req() {
         .unwrap();
     let vec = resp.to_write_vec();
     let s = String::from_utf8_lossy(&vec);
-    assert!(s.contains("GET /query_in_path_and_req?foo=bar&baz=1%202%203 HTTP/1.1"))
+    assert!(s.contains("GET /query_in_path_and_req?foo=bar&baz=1+2+3 HTTP/1.1"))
 }

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -130,25 +130,29 @@ fn request_debug() {
     let req = get("http://localhost/my/page")
         .set("Authorization", "abcdef")
         .set("Content-Length", "1234")
-        .set("Content-Type", "application/json");
+        .set("Content-Type", "application/json")
+        .build()
+        .unwrap();
 
     let s = format!("{:?}", req);
 
     assert_eq!(
         s,
-        "Request(GET /my/page, [Authorization: abcdef, \
+        "Request(GET http://localhost/my/page, [Authorization: abcdef, \
          Content-Length: 1234, Content-Type: application/json])"
     );
 
     let req = get("http://localhost/my/page?q=z")
         .query("foo", "bar baz")
-        .set("Authorization", "abcdef");
+        .set("Authorization", "abcdef")
+        .build()
+        .unwrap();
 
     let s = format!("{:?}", req);
 
     assert_eq!(
         s,
-        "Request(GET /my/page?q=z&foo=bar%20baz, [Authorization: abcdef])"
+        "Request(GET http://localhost/my/page?q=z&foo=bar+baz, [Authorization: abcdef])"
     );
 }
 


### PR DESCRIPTION
This formalizes the builder pattern with regards to a Request. All
methods like `ureq::get` that formerly returned a Request now return a
RequestBuilder, so you can add headers and params the same as before.
Also, RequestBuilder implements `call()` and `send*()` as shortcuts to
immediately build and send a Request, so call chains don't get longer.

Add the ability to set a URL on a request directly, in addition to the
ability to pass an unparsed `&str`. Remove some of the individual field
getters from Request, like get_method, get_url, get_scheme, and get_host.

Remove the `qstring` dependency. We can achieve the same thing
using Url's query_pairs_mut.

Delete the `.proxy()` convenience method on Request.