### PR TITLE
Add support for using testserver in doctests.

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -107,14 +107,12 @@ impl Request {
     /// The `Content-Length` header is implicitly set to the length of the serialized value.
     ///
     /// ```
-    /// #[macro_use]
-    /// extern crate ureq;
-    ///
-    /// fn main() {
-    /// let r = ureq::post("/my_page")
-    ///     .send_json(json!({ "name": "martin", "rust": true }));
-    /// println!("{:?}", r);
-    /// }
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # ureq::is_test(true);
+    /// let r = ureq::post("http://example.com/form")
+    ///     .send_json(ureq::json!({ "name": "martin", "rust": true }))?;
+    /// # Ok(())
+    /// # }
     /// ```
     #[cfg(feature = "json")]
     pub fn send_json(mut self, data: SerdeValue) -> Result<Response> {

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::test::testserver::{read_headers, TestServer};
+use crate::testserver::{read_headers, TestServer};
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::time::Duration;

--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -2,7 +2,7 @@ use std::{
     io::{self, Write},
     net::TcpStream,
 };
-use test::testserver::{self, TestServer};
+use testserver::{self, TestServer};
 
 use crate::test;
 

--- a/src/test/timeout.rs
+++ b/src/test/timeout.rs
@@ -1,4 +1,4 @@
-use crate::test::testserver::*;
+use crate::testserver::*;
 use std::io::{self, Write};
 use std::net::TcpStream;
 use std::thread;

--- a/src/testserver.rs
+++ b/src/testserver.rs
@@ -87,7 +87,7 @@ pub fn read_headers(stream: &TcpStream) -> TestHeaders {
 
 impl TestServer {
     pub fn new(handler: fn(TcpStream) -> io::Result<()>) -> Self {
-        let listener = TcpListener::bind("localhost:0").unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let done = Arc::new(AtomicBool::new(false));
         let done_clone = done.clone();
@@ -106,7 +106,7 @@ impl TestServer {
         });
         // before returning from new(), ensure the server is ready to accept connections
         loop {
-            if let Err(e) = TcpStream::connect(format!("localhost:{}", port)) {
+            if let Err(e) = TcpStream::connect(format!("127.0.0.1:{}", port)) {
                 match e.kind() {
                     io::ErrorKind::ConnectionRefused => {
                         std::thread::sleep(Duration::from_millis(100));

--- a/src/testserver.rs
+++ b/src/testserver.rs
@@ -1,8 +1,46 @@
-use std::io::{self, BufRead, BufReader};
-use std::net::{TcpListener, TcpStream};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
+use std::{
+    io::{self, BufRead, BufReader, Write},
+    net::ToSocketAddrs,
+};
+
+use crate::{Agent, AgentBuilder};
+
+// An agent to be installed by default for tests and doctests, such
+// that all hostnames resolve to a TestServer on localhost.
+pub(crate) fn test_agent() -> Agent {
+    let testserver = TestServer::new(|mut stream: TcpStream| -> io::Result<()> {
+        read_headers(&stream);
+        stream.write_all(b"HTTP/1.1 200 OK\r\n")?;
+        stream.write_all(b"Transfer-Encoding: chunked\r\n")?;
+        stream.write_all(b"Content-Type: text/html; charset=ISO-8859-1\r\n")?;
+        stream.write_all(b"\r\n")?;
+        stream.write_all(b"7\r\n")?;
+        stream.write_all(b"success\r\n")?;
+        stream.write_all(b"0\r\n")?;
+        stream.write_all(b"\r\n")?;
+        Ok(())
+    });
+    // Slightly tricky thing here: we want to make sure the TestServer lives
+    // as long as the agent. This is accomplished by `move`ing it into the
+    // closure, which becomes owned by the agent.
+    AgentBuilder::new()
+        .resolver(move |h: &str| -> io::Result<Vec<SocketAddr>> {
+            // Don't override resolution for HTTPS requests yet, since we
+            // don't have a setup for an HTTPS testserver. Also, skip localhost
+            // resolutions since those may come from a unittest that set up
+            // its own, specific testserver.
+            if h.ends_with(":443") || h.starts_with("localhost:") {
+                return Ok(h.to_socket_addrs()?.collect::<Vec<_>>());
+            }
+            let addr: SocketAddr = format!("127.0.0.1:{}", testserver.port).parse().unwrap();
+            Ok(vec![addr])
+        })
+        .build()
+}
 
 pub struct TestServer {
     pub port: u16,
@@ -11,6 +49,7 @@ pub struct TestServer {
 
 pub struct TestHeaders(Vec<String>);
 
+#[allow(dead_code)]
 impl TestHeaders {
     // Return the path for a request, e.g. /foo from "GET /foo HTTP/1.1"
     #[cfg(feature = "cookies")]


### PR DESCRIPTION
Doctests run against a normally-built copy of the crate, i.e. one
without #[cfg(test)] set, so we can't use the conditional compilation
feature.

Instead, define a static var that indicates whether the library is
running in test mode or not. For each doctest, insert a hidden call that
sets this var to true. Then, when ureq::agent() is called, it returns a
test_agent instead.

This required moving testserver out of the test mod and into src/, so
that it can be included unconditionally (i.e. when cfg(test) is false).

This PR converts one doctest as an example. If we land this PR, I'll
send a followup to convert the rest.