### PR TITLE
Turn Unit into a built Request

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -330,8 +330,8 @@ impl<R: Read + Sized + Into<Stream>> PoolReturnRead<R> {
             stream.reset()?;
 
             // insert back into pool
-            let key = PoolKey::new(&unit.url, unit.req.agent.config.proxy.clone());
-            unit.req.agent.state.pool.add(key, stream);
+            let key = PoolKey::new(&unit.url, unit.agent.config.proxy.clone());
+            unit.agent.state.pool.add(key, stream);
         }
 
         Ok(())

--- a/src/response.rs
+++ b/src/response.rs
@@ -266,7 +266,7 @@ impl Response {
         let stream = self.stream.expect("No reader in response?!");
         let unit = self.unit;
         if let Some(unit) = &unit {
-            let result = stream.set_read_timeout(unit.req.agent.config.timeout_read);
+            let result = stream.set_read_timeout(unit.agent.config.timeout_read);
             if let Err(e) = result {
                 return Box::new(ErrorReader(e)) as Box<dyn Read + Send>;
             }

--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -59,7 +59,7 @@ fn redirect_head() {
         test::make_response(302, "Go here", vec!["Location: /redirect_head2"], vec![])
     });
     test::set_handler("/redirect_head2", |unit| {
-        assert_eq!(unit.req.method, "HEAD");
+        assert_eq!(unit.method, "HEAD");
         test::make_response(200, "OK", vec!["x-foo: bar"], vec![])
     });
     let resp = head("test://host/redirect_head1").call().unwrap();
@@ -75,7 +75,7 @@ fn redirect_get() {
         test::make_response(302, "Go here", vec!["Location: /redirect_get2"], vec![])
     });
     test::set_handler("/redirect_get2", |unit| {
-        assert_eq!(unit.req.method, "GET");
+        assert_eq!(unit.method, "GET");
         assert!(unit.has("Range"));
         assert_eq!(unit.header("Range").unwrap(), "bytes=10-50");
         test::make_response(200, "OK", vec!["x-foo: bar"], vec![])
@@ -119,7 +119,7 @@ fn redirect_post() {
         test::make_response(302, "Go here", vec!["Location: /redirect_post2"], vec![])
     });
     test::set_handler("/redirect_post2", |unit| {
-        assert_eq!(unit.req.method, "GET");
+        assert_eq!(unit.method, "GET");
         test::make_response(200, "OK", vec!["x-foo: bar"], vec![])
     });
     let resp = post("test://host/redirect_post1").call().unwrap();

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -412,8 +412,7 @@ fn save_cookies(unit: &Unit, resp: &Response) {
             Ok(c) => Some(c),
         }
     });
-    unit.req
-        .agent
+    unit.agent
         .state
         .cookie_tin
         .store_response_cookies(cookies, &unit.url.clone());


### PR DESCRIPTION
This involved removing the Request reference from Unit, and adding an
Agent, a method, and headers.

Also, move is_retryable to Unit.