### PR TITLE
Update some more doctests.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,11 @@ pub fn agent() -> Agent {
 /// Make a request setting the HTTP method via a string.
 ///
 /// ```
-/// ureq::request("GET", "http://example.com").call().unwrap();
+/// # fn main() -> Result<(), ureq::Error> {
+/// # ureq::is_test(true);
+/// ureq::request("GET", "http://example.com").call()?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn request(method: &str, path: &str) -> Request {
     agent().request(method, path)

--- a/src/request.rs
+++ b/src/request.rs
@@ -60,16 +60,10 @@ impl Request {
 
     /// Executes the request and blocks the caller until done.
     ///
-    /// Use `.timeout_connect()` and `.timeout_read()` to avoid blocking forever.
-    ///
     /// ```
-    /// use std::time::Duration;
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
-    /// let resp = ureq::builder()
-    ///     .timeout_connect(Duration::from_secs(10))
-    ///     .build()
-    ///     .get("http://example.com/")
+    /// let resp = ureq::get("http://example.com/")
     ///     .call()?;
     /// # Ok(())
     /// # }

--- a/src/response.rs
+++ b/src/response.rs
@@ -318,10 +318,10 @@ impl Response {
     ///
     /// ## Charset support
     ///
-    /// Requires feature `ureq = { version = "*", features = ["charset"] }`
-    ///
-    /// Attempts to respect the character encoding of the `Content-Type` header and
-    /// falls back to `utf-8`.
+    /// If you enable feature `ureq = { version = "*", features = ["charset"] }`, into_string()
+    /// attempts to respect the character encoding of the `Content-Type` header. If there is no
+    /// Content-Type header, or the Content-Type header does not specify a charset, into_string()
+    /// uses `utf-8`.
     ///
     /// I.e. `Content-Length: text/plain; charset=iso-8859-1` would be decoded in latin-1.
     ///
@@ -350,13 +350,15 @@ impl Response {
     /// Example:
     ///
     /// ```
-    /// let resp =
-    ///     ureq::get("http://ureq.s3.eu-central-1.amazonaws.com/hello_world.json")
-    ///         .call().unwrap();
-    ///
-    /// let json = resp.into_json().unwrap();
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # ureq::is_test(true);
+    /// let json: serde_json::Value = ureq::get("http://example.com/hello_world.json")
+    ///     .call()?
+    ///     .into_json()?;
     ///
     /// assert_eq!(json["hello"], "world");
+    /// # Ok(())
+    /// # }
     /// ```
     #[cfg(feature = "json")]
     pub fn into_json(self) -> io::Result<serde_json::Value> {
@@ -381,27 +383,30 @@ impl Response {
         })
     }
 
-    /// Turn the body of this response into a type implementing the (serde) Deserialize trait.
+    /// Turn the body of this response into a type that implements the [serde::Deserialize] trait.
     ///
     /// Requires feature `ureq = { version = "*", features = ["json"] }`
     ///
     /// Example:
     ///
     /// ```
-    /// use serde::Deserialize;
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # ureq::is_test(true);
+    /// use serde::{Deserialize, de::DeserializeOwned};
     ///
     /// #[derive(Deserialize)]
-    /// struct Hello {
+    /// struct Message {
     ///     hello: String,
     /// }
     ///
-    /// let resp =
-    ///     ureq::get("http://ureq.s3.eu-central-1.amazonaws.com/hello_world.json")
-    ///         .call().unwrap();
+    /// let message: Message =
+    ///     ureq::get("http://example.com/hello_world.json")
+    ///         .call()?
+    ///         .into_json_deserialize()?;
     ///
-    /// let json = resp.into_json_deserialize::<Hello>().unwrap();
-    ///
-    /// assert_eq!(json.hello, "world");
+    /// assert_eq!(message.hello, "world");
+    /// # Ok(())
+    /// # }
     /// ```
     #[cfg(feature = "json")]
     pub fn into_json_deserialize<T: DeserializeOwned>(self) -> io::Result<T> {

--- a/src/testserver.rs
+++ b/src/testserver.rs
@@ -22,6 +22,10 @@ pub(crate) fn test_agent() -> Agent {
             stream.write_all(b"Content-Length: 100\r\n")?;
             stream.write_all(b"\r\n")?;
             stream.write_all(&[0; 100])?;
+        } else if headers.path() == "/hello_world.json" {
+            stream.write_all(b"HTTP/1.1 200 OK\r\n")?;
+            stream.write_all(b"\r\n")?;
+            stream.write_all(br#"{"hello": "world"}"#)?;
         } else if headers.path() == "/redirect/3" {
             stream.write_all(b"HTTP/1.1 302 Found\r\n")?;
             stream.write_all(b"Location: /redirect/3\r\n")?;


### PR DESCRIPTION
I missed these in my previous doctest PR.

The doctests all now run without accessing the network. Tested by
turning off networking and running them.

Request.call's doctest wouldn't run because it relied on making a custom
AgentBuilder and building it, which bypasses the test_agent. I concluded
that this doctest was mostly illustrating behavior of AgentBuilder, not
call(), and simplified it to be more like the other calling methods on
request.