### PR TITLE
Rewrite the Error type.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,17 +1,103 @@
-use crate::response::Response;
-use std::fmt;
-use std::io::{self, ErrorKind};
+use url::Url;
+
+use std::error;
+use std::fmt::{self, Display};
+use std::io::{self};
+
+use crate::Response;
 
 #[derive(Debug)]
-pub enum Error {
+pub struct Error {
+    kind: ErrorKind,
+    message: String,
+    url: Option<Url>,
+    source: Option<Box<dyn error::Error>>,
+    response: Option<Box<Response>>,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(url) = &self.url {
+            write!(f, "{}: ", url)?;
+        }
+        if let Some(response) = &self.response {
+            write!(f, "status code {}", response.status())?;
+        } else {
+            write!(f, "{:?}: {}", self.kind, self.message)?;
+        }
+        if let Some(source) = &self.source {
+            write!(f, ": {}", source)?;
+        }
+        Ok(())
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        self.source.as_deref()
+    }
+}
+
+impl Error {
+    pub(crate) fn new(kind: ErrorKind, message: String) -> Self {
+        Error {
+            kind,
+            message,
+            url: None,
+            source: None,
+            response: None,
+        }
+    }
+
+    pub(crate) fn url(mut self, url: Url) -> Self {
+        self.url = Some(url);
+        self
+    }
+
+    pub(crate) fn src(mut self, e: impl error::Error + 'static) -> Self {
+        self.source = Some(Box::new(e));
+        self
+    }
+
+    pub(crate) fn response(mut self, response: Response) -> Self {
+        self.response = Some(Box::new(response));
+        self
+    }
+    pub(crate) fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Return true iff the error was due to a connection closing.
+    pub(crate) fn connection_closed(&self) -> bool {
+        if self.kind() != ErrorKind::Io {
+            return false;
+        }
+        let source = match self.source.as_ref() {
+            Some(e) => e,
+            None => return false,
+        };
+        let ioe: &Box<io::Error> = match source.downcast_ref() {
+            Some(e) => e,
+            None => return false,
+        };
+        match ioe.kind() {
+            io::ErrorKind::ConnectionAborted => true,
+            io::ErrorKind::ConnectionReset => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ErrorKind {
     /// The url could not be understood.
-    BadUrl(String),
+    BadUrl,
     /// The url scheme could not be understood.
-    UnknownScheme(String),
+    UnknownScheme,
     /// DNS lookup failed.
-    DnsFailed(String),
+    DnsFailed,
     /// Connection to server failed.
-    ConnectionFailed(String),
+    ConnectionFailed,
     /// Too many redirects.
     TooManyRedirects,
     /// A status line we don't understand `HTTP/1.1 200 OK`.
@@ -19,7 +105,7 @@ pub enum Error {
     /// A header line that couldn't be parsed.
     BadHeader,
     /// Some unspecified `std::io::Error`.
-    Io(io::Error),
+    Io,
     /// Proxy information was not properly formatted
     BadProxy,
     /// Proxy credentials were not properly formatted
@@ -31,44 +117,60 @@ pub enum Error {
     /// HTTP status code indicating an error (e.g. 4xx, 5xx)
     /// Read the inner response body for details and to return
     /// the connection to the pool.
-    HTTP(Box<Response>),
+    HTTP,
 }
 
-impl Error {
-    // Return true iff the error was due to a connection closing.
-    pub(crate) fn connection_closed(&self) -> bool {
-        match self {
-            Error::Io(e) if e.kind() == ErrorKind::ConnectionAborted => true,
-            Error::Io(e) if e.kind() == ErrorKind::ConnectionReset => true,
-            _ => false,
-        }
+impl ErrorKind {
+    pub(crate) fn new(self) -> Error {
+        Error::new(self, "".to_string())
+    }
+
+    pub(crate) fn msg(self, s: &str) -> Error {
+        Error::new(self, s.to_string())
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
-        Error::Io(err)
+        ErrorKind::Io.new().src(err)
     }
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::BadUrl(url) => write!(f, "Bad URL: {}", url),
-            Error::UnknownScheme(scheme) => write!(f, "Unknown Scheme: {}", scheme),
-            Error::DnsFailed(err) => write!(f, "Dns Failed: {}", err),
-            Error::ConnectionFailed(err) => write!(f, "Connection Failed: {}", err),
-            Error::TooManyRedirects => write!(f, "Too Many Redirects"),
-            Error::BadStatus => write!(f, "Bad Status"),
-            Error::BadHeader => write!(f, "Bad Header"),
-            Error::Io(ioe) => write!(f, "Network Error: {}", ioe),
-            Error::BadProxy => write!(f, "Malformed proxy"),
-            Error::BadProxyCreds => write!(f, "Failed to parse proxy credentials"),
-            Error::ProxyConnect => write!(f, "Proxy failed to connect"),
-            Error::InvalidProxyCreds => write!(f, "Provided proxy credentials are incorrect"),
-            Error::HTTP(response) => write!(f, "HTTP status {}", response.status()),
+            ErrorKind::BadUrl => write!(f, "Bad URL"),
+            ErrorKind::UnknownScheme => write!(f, "Unknown Scheme"),
+            ErrorKind::DnsFailed => write!(f, "Dns Failed"),
+            ErrorKind::ConnectionFailed => write!(f, "Connection Failed"),
+            ErrorKind::TooManyRedirects => write!(f, "Too Many Redirects"),
+            ErrorKind::BadStatus => write!(f, "Bad Status"),
+            ErrorKind::BadHeader => write!(f, "Bad Header"),
+            ErrorKind::Io => write!(f, "Network Error"),
+            ErrorKind::BadProxy => write!(f, "Malformed proxy"),
+            ErrorKind::BadProxyCreds => write!(f, "Failed to parse proxy credentials"),
+            ErrorKind::ProxyConnect => write!(f, "Proxy failed to connect"),
+            ErrorKind::InvalidProxyCreds => write!(f, "Provided proxy credentials are incorrect"),
+            ErrorKind::HTTP => write!(f, "HTTP status error"),
         }
     }
 }
 
-impl std::error::Error for Error {}
+#[test]
+fn status_code_error() {
+    let mut err = Error::new(ErrorKind::HTTP, "".to_string());
+    err = err.response(Response::new(500, "Internal Server Error", "too much going on").unwrap());
+    assert_eq!(err.to_string(), "status code 500");
+
+    err = err.url("http://example.com/".parse().unwrap());
+    assert_eq!(err.to_string(), "http://example.com/: status code 500");
+}
+
+#[test]
+fn io_error() {
+    let ioe = io::Error::new(io::ErrorKind::TimedOut, "too slow");
+    let mut err = Error::new(ErrorKind::Io, "oops".to_string()).src(ioe);
+
+    err = err.url("http://example.com/".parse().unwrap());
+    assert_eq!(err.to_string(), "http://example.com/: Io: oops: too slow");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ mod testserver;
 
 pub use crate::agent::Agent;
 pub use crate::agent::AgentBuilder;
-pub use crate::error::Error;
+pub use crate::error::{Error, ErrorKind};
 pub use crate::header::Header;
 pub use crate::proxy::Proxy;
 pub use crate::request::Request;
@@ -247,6 +247,7 @@ mod tests {
     #[cfg(feature = "tls")]
     fn connect_https_invalid_name() {
         let result = get("https://example.com{REQUEST_URI}/").call();
-        assert!(matches!(result.unwrap_err(), Error::DnsFailed(_)));
+        let e = ErrorKind::DnsFailed;
+        assert_eq!(result.unwrap_err().kind(), e);
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -3,12 +3,12 @@ use std::io::Read;
 
 use url::{form_urlencoded, Url};
 
-use crate::agent::Agent;
 use crate::body::Payload;
-use crate::error::Error;
+use crate::error::ErrorKind;
 use crate::header::{self, Header};
 use crate::unit::{self, Unit};
 use crate::Response;
+use crate::{agent::Agent, error::Error};
 
 #[cfg(feature = "json")]
 use super::SerdeValue;
@@ -76,19 +76,20 @@ impl Request {
         for h in &self.headers {
             h.validate()?;
         }
-        let mut url: Url = self
-            .url
-            .parse()
-            .map_err(|e: url::ParseError| Error::BadUrl(e.to_string()))?;
+        let mut url: Url = self.url.parse().map_err(|e: url::ParseError| {
+            ErrorKind::BadUrl
+                .msg(&format!("failed to parse URL '{}'", self.url))
+                .src(e)
+        })?;
         for (name, value) in self.query_params.clone() {
             url.query_pairs_mut().append_pair(&name, &value);
         }
         let reader = payload.into_read();
         let unit = Unit::new(&self.agent, &self.method, &url, &self.headers, &reader);
-        let response = unit::connect(unit, true, 0, reader, false)?;
+        let response = unit::connect(unit, true, 0, reader, false).map_err(|e| e.url(url))?;
 
         if response.error() && self.error_on_non_2xx {
-            Err(Error::HTTP(response.into()))
+            Err(ErrorKind::HTTP.new().response(response))
         } else {
             Ok(response)
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,10 +1,10 @@
 use std::fmt;
-use std::io::{self, Cursor, ErrorKind, Read};
+use std::io::{self, Cursor, Read};
 use std::str::FromStr;
 
 use chunked_transfer::Decoder as ChunkDecoder;
 
-use crate::error::Error;
+use crate::error::{Error, ErrorKind};
 use crate::header::Header;
 use crate::pool::PoolReturnRead;
 use crate::stream::{DeadlineStream, Stream};
@@ -371,13 +371,13 @@ impl Response {
             // We make a clone of the original error since serde_json::Error doesn't
             // let us get the wrapped error instance back.
             if let Some(ioe) = e.source().and_then(|s| s.downcast_ref::<io::Error>()) {
-                if ioe.kind() == ErrorKind::TimedOut {
+                if ioe.kind() == io::ErrorKind::TimedOut {
                     return io_err_timeout(ioe.to_string());
                 }
             }
 
             io::Error::new(
-                ErrorKind::InvalidData,
+                io::ErrorKind::InvalidData,
                 format!("Failed to read JSON: {}", e),
             )
         })
@@ -413,7 +413,7 @@ impl Response {
         let reader = self.into_reader();
         serde_json::from_reader(reader).map_err(|e| {
             io::Error::new(
-                ErrorKind::InvalidData,
+                io::ErrorKind::InvalidData,
                 format!("Failed to read JSON: {}", e),
             )
         })
@@ -473,19 +473,21 @@ fn parse_status_line(line: &str) -> Result<(ResponseStatusIndex, u16), Error> {
 
     let mut split = line.splitn(3, ' ');
 
-    let http_version = split.next().ok_or_else(|| Error::BadStatus)?;
+    let http_version = split.next().ok_or_else(|| ErrorKind::BadStatus.new())?;
     if http_version.len() < 5 {
-        return Err(Error::BadStatus);
+        return Err(ErrorKind::BadStatus.new());
     }
     let index1 = http_version.len();
 
-    let status = split.next().ok_or_else(|| Error::BadStatus)?;
+    let status = split.next().ok_or_else(|| ErrorKind::BadStatus.new())?;
     if status.len() < 2 {
-        return Err(Error::BadStatus);
+        return Err(ErrorKind::BadStatus.new());
     }
     let index2 = index1 + status.len();
 
-    let status = status.parse::<u16>().map_err(|_| Error::BadStatus)?;
+    let status = status
+        .parse::<u16>()
+        .map_err(|_| ErrorKind::BadStatus.new())?;
 
     Ok((
         ResponseStatusIndex {
@@ -540,7 +542,7 @@ fn read_next_line<R: Read>(reader: &mut R) -> io::Result<String> {
 
         if amt == 0 {
             return Err(io::Error::new(
-                ErrorKind::ConnectionAborted,
+                io::ErrorKind::ConnectionAborted,
                 "Unexpected EOF",
             ));
         }
@@ -549,8 +551,9 @@ fn read_next_line<R: Read>(reader: &mut R) -> io::Result<String> {
 
         if byte == b'\n' && prev_byte_was_cr {
             buf.pop(); // removing the '\r'
-            return String::from_utf8(buf)
-                .map_err(|_| io::Error::new(ErrorKind::InvalidInput, "Header is not in ASCII"));
+            return String::from_utf8(buf).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "Header is not in ASCII")
+            });
         }
 
         prev_byte_was_cr = byte == b'\r';
@@ -594,7 +597,7 @@ impl<R: Read> Read for LimitedRead<R> {
             // received, the recipient MUST consider the message to be
             // incomplete and close the connection.
             Ok(0) => Err(io::Error::new(
-                ErrorKind::InvalidData,
+                io::ErrorKind::InvalidData,
                 "response body closed before all bytes were read",
             )),
             Ok(amount) => {
@@ -743,7 +746,7 @@ mod tests {
     fn parse_borked_header() {
         let s = "HTTP/1.1 BORKED\r\n".to_string();
         let err = s.parse::<Response>().unwrap_err();
-        assert!(matches!(err, Error::BadStatus));
+        assert_eq!(err.kind(), ErrorKind::BadStatus);
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -446,11 +446,13 @@ fn socks5_local_nslookup(
     let addrs: Vec<SocketAddr> = unit
         .resolver()
         .resolve(&format!("{}:{}", hostname, port))
-        .map_err(|e| std::io::Error::new(ErrorKind::NotFound, format!("DNS failure: {}.", e)))?;
+        .map_err(|e| {
+            std::io::Error::new(io::ErrorKind::NotFound, format!("DNS failure: {}.", e))
+        })?;
 
     if addrs.is_empty() {
         return Err(std::io::Error::new(
-            ErrorKind::NotFound,
+            io::ErrorKind::NotFound,
             "DNS failure: no socket addrs found.",
         ));
     }
@@ -459,7 +461,7 @@ fn socks5_local_nslookup(
         Ok(addr) => Ok(addr),
         Err(err) => {
             return Err(std::io::Error::new(
-                ErrorKind::NotFound,
+                io::ErrorKind::NotFound,
                 format!("DNS failure: {}.", err),
             ))
         }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -600,5 +600,7 @@ pub(crate) fn connect_test(unit: &Unit) -> Result<Stream, Error> {
 
 #[cfg(not(feature = "tls"))]
 pub(crate) fn connect_https(unit: &Unit, _hostname: &str) -> Result<Stream, Error> {
-    Err(Error::UnknownScheme(unit.url.scheme().to_string()))
+    Err(ErrorKind::UnknownScheme
+        .msg("URL has 'https:' scheme but ureq was build without HTTP support")
+        .url(unit.url.clone()))
 }

--- a/src/test/agent_test.rs
+++ b/src/test/agent_test.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::error::Error;
 use crate::testserver::{read_request, TestServer};
 use std::io::{self, Read, Write};
 use std::net::TcpStream;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,10 +1,10 @@
+use crate::error::Error;
+use crate::stream::Stream;
 use crate::unit::Unit;
-use crate::{error::Error};
-use crate::{stream::Stream};
 use once_cell::sync::Lazy;
+use std::collections::HashMap;
 use std::io::{Cursor, Write};
 use std::sync::{Arc, Mutex};
-use std::{collections::HashMap};
 
 mod agent_test;
 mod body_read;

--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use testserver::{self, TestServer};
 
-use crate::test;
+use crate::{error::Error, test};
 
 use super::super::*;
 
@@ -34,7 +34,7 @@ fn redirect_many() {
         .build()
         .get("test://host/redirect_many1")
         .call();
-    assert!(matches!(result, Err(Error::TooManyRedirects)));
+    assert!(matches!(result, Err(e) if e.kind() == ErrorKind::TooManyRedirects));
 }
 
 #[test]
@@ -104,12 +104,11 @@ fn redirect_host() {
         Ok(())
     });
     let url = format!("http://localhost:{}/", srv.port);
-    let resp = crate::Agent::new().get(&url).call();
-    let err = resp.err();
+    let result = crate::Agent::new().get(&url).call();
     assert!(
-        matches!(err, Some(Error::DnsFailed(_))),
-        "expected DnsFailed, got: {:?}",
-        err
+        matches!(result, Err(ref e) if e.kind() == ErrorKind::DnsFailed),
+        "expected Err(DnsFailed), got: {:?}",
+        result
     );
 }
 

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -157,13 +157,13 @@ fn non_ascii_header() {
     test::set_handler("/non_ascii_header", |_unit| {
         test::make_response(200, "OK", vec!["Wörse: Hädör"], vec![])
     });
-    let resp = get("test://host/non_ascii_header")
+    let result = get("test://host/non_ascii_header")
         .set("Bäd", "Headör")
         .call();
     assert!(
-        matches!(resp, Err(Error::BadHeader)),
-        "expected Some(&BadHeader), got {:?}",
-        resp
+        matches!(result, Err(ref e) if e.kind() == ErrorKind::BadHeader),
+        "expected Err(BadHeader), got {:?}",
+        result
     );
 }
 

--- a/src/test/timeout.rs
+++ b/src/test/timeout.rs
@@ -1,8 +1,11 @@
 use crate::testserver::*;
-use std::io::{self, Write};
 use std::net::TcpStream;
 use std::thread;
 use std::time::Duration;
+use std::{
+    error::Error,
+    io::{self, Write},
+};
 
 use super::super::*;
 
@@ -96,10 +99,16 @@ fn read_timeout_during_headers() {
     let server = TestServer::new(dribble_headers_respond);
     let url = format!("http://localhost:{}/", server.port);
     let agent = builder().timeout_read(Duration::from_millis(10)).build();
-    let resp = agent.get(&url).call();
-    match resp {
+    let result = agent.get(&url).call();
+    match result {
         Ok(_) => Err("successful response".to_string()),
-        Err(Error::Io(e)) if e.kind() == io::ErrorKind::TimedOut => Ok(()),
+        Err(e) if e.kind() == ErrorKind::Io => {
+            let ioe: Option<&io::Error> = e.source().and_then(|s| s.downcast_ref());
+            match ioe {
+                Some(e) if e.kind() == io::ErrorKind::TimedOut => Ok(()),
+                _ => Err(format!("wrong error type {:?}", e)),
+            }
+        }
         Err(e) => Err(format!("Unexpected error type: {:?}", e)),
     }
     .expect("expected timeout but got something else");
@@ -111,10 +120,16 @@ fn overall_timeout_during_headers() {
     let server = TestServer::new(dribble_headers_respond);
     let url = format!("http://localhost:{}/", server.port);
     let agent = builder().timeout(Duration::from_millis(500)).build();
-    let resp = agent.get(&url).call();
-    match resp {
+    let result = agent.get(&url).call();
+    match result {
         Ok(_) => Err("successful response".to_string()),
-        Err(Error::Io(e)) if e.kind() == io::ErrorKind::TimedOut => Ok(()),
+        Err(e) if e.kind() == ErrorKind::Io => {
+            let ioe: Option<&io::Error> = e.source().and_then(|s| s.downcast_ref());
+            match ioe {
+                Some(e) if e.kind() == io::ErrorKind::TimedOut => Ok(()),
+                _ => Err(format!("wrong error type {:?}", e)),
+            }
+        }
         Err(e) => Err(format!("Unexpected error type: {:?}", e)),
     }
     .expect("expected timeout but got something else");


### PR DESCRIPTION
This adds a source field to keep track of upstream errors and allow
backtraces, plus a URL field to indicate what URL an error was
associated with.

The enum variants we used to use for Error are now part of a new
ErrorKind type. For convenience within ureq, ErrorKinds can be turned
into an Error with `.new()` or `.msg("some additional information")`.

Error acts as a builder, so additional information can be added after
initial construction. For instance, we return a DnsFailed error when
name resolution fails. When that error bubbles up to Request's
`do_call`, Request adds the URL.

Fixes #232.