### PR TITLE
Fix is_connection_closed.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -179,3 +179,14 @@ fn io_error() {
     err = err.url("http://example.com/".parse().unwrap());
     assert_eq!(err.to_string(), "http://example.com/: Io: oops: too slow");
 }
+
+#[test]
+fn connection_closed() {
+    let ioe = io::Error::new(io::ErrorKind::ConnectionReset, "connection reset");
+    let err = ErrorKind::Io.new().src(ioe);
+    assert!(err.connection_closed());
+
+    let ioe = io::Error::new(io::ErrorKind::ConnectionAborted, "connection aborted");
+    let err = ErrorKind::Io.new().src(ioe);
+    assert!(err.connection_closed());
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,7 @@ impl Error {
             Some(e) => e,
             None => return false,
         };
-        let ioe: &Box<io::Error> = match source.downcast_ref() {
+        let ioe: &io::Error = match source.downcast_ref() {
             Some(e) => e,
             None => return false,
         };


### PR DESCRIPTION
Fixes #237. 

I'm working on writing a matching unittest, but I'm having trouble writing a test that can reliably produce a ConnectionAborted or ConnectionReset under semi-realistic conditions. I can just instantiate an Error that contains an io::Error with one of those types, but that feels a bit too much like just matching the test to the code.