### PR TITLE
Remove "what" section of test matrix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,6 @@ jobs:
           - charset
           - cookies
           - socks-proxy
-        what:
-          - "--doc"
-          - "--tests"
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"
@@ -50,4 +47,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.what }} --no-default-features --features "${{ matrix.tls }} ${{ matrix.feature }}"
+          args: --no-default-features --features "${{ matrix.tls }} ${{ matrix.feature }}"

--- a/test.sh
+++ b/test.sh
@@ -6,11 +6,9 @@ export RUSTFLAGS="-D dead_code -D unused-variables -D unused"
 
 for tls in "" tls ; do
   for feature in "" json charset cookies socks-proxy ; do
-    for what in --doc --tests ; do
-      if ! cargo test "${what}" --no-default-features --features "${tls} ${feature}" ; then
-        echo Command failed: cargo test \"${what}\" --no-default-features --features \"${tls} ${feature}\"
-        exit 1
-      fi
-    done
+    if ! cargo test --no-default-features --features "${tls} ${feature}" ; then
+      echo Command failed: cargo test \"${what}\" --no-default-features --features \"${tls} ${feature}\"
+      exit 1
+    fi
   done
 done


### PR DESCRIPTION
We were generating two whole sets of jobs, for --tests and --docs
separately. But the default invocation of cargo runs both tests and
doctests. We can save some resources and speed up our test runs by
allowing cargo to do both in one invocation.