### PR TITLE
Cleanups and coverage improvements.

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -366,7 +366,7 @@ impl AgentBuilder {
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
     /// let agent = ureq::builder()
-    ///     .timeout_read(Duration::from_secs(1))
+    ///     .timeout_write(Duration::from_secs(1))
     ///     .build();
     /// let result = agent.get("http://httpbin.org/delay/20").call();
     /// # Ok(())

--- a/src/body.rs
+++ b/src/body.rs
@@ -24,25 +24,6 @@ pub(crate) enum Payload<'a> {
     Bytes(&'a [u8]),
 }
 
-impl fmt::Debug for Payload<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Payload::Empty => write!(f, "Empty"),
-            Payload::Text(t, _) => write!(f, "{}", t),
-            #[cfg(feature = "json")]
-            Payload::JSON(_) => write!(f, "JSON"),
-            Payload::Reader(_) => write!(f, "Reader"),
-            Payload::Bytes(v) => write!(f, "{:?}", v),
-        }
-    }
-}
-
-impl Default for Payload<'_> {
-    fn default() -> Self {
-        Payload::Empty
-    }
-}
-
 /// The size of the body.
 ///
 /// *Internal API*


### PR DESCRIPTION
I looked at some grcov output locally, and found some code that was
unused: The BufRead impl on Stream, and the Debug and Default impls on
Payload. Deleted those.

Also, the timeout_write doctest on Agent was testing the wrong thing.
Fixed that.

Added some test cases to exercise Debug impls.

Used the Display formatter rather than the Debug formatter to write
ErrorKind in Error's Display impl.