### PR TITLE
Follow 307/308 redirects (1.x backport)

### DIFF
--- a/src/unit.rs
+++ b/src/unit.rs
@@ -235,9 +235,13 @@ pub(crate) fn connect(
                     debug!("redirect {} {} -> {}", resp.status(), url, new_url);
                     return connect(req, new_unit, use_pooled, redirect_count + 1, empty, true);
                 }
+                // never change the method for 307/308
+                307 | 308 => {
+                    let empty = Payload::Empty.into_read();
+                    debug!("redirect {} {} -> {}", resp.status(), url, new_url);
+                    return connect(req, unit, use_pooled, redirect_count - 1, empty, true);
+                }
                 _ => (),
-                // reinstate this with expect-100
-                // 307 | 308 | _ => connect(unit, method, use_pooled, redirects - 1, body),
             };
         }
     }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -236,7 +236,9 @@ pub(crate) fn connect(
                     return connect(req, new_unit, use_pooled, redirect_count + 1, empty, true);
                 }
                 // never change the method for 307/308
-                307 | 308 => {
+                // only resend the request if it cannot have a body
+                // NOTE: DELETE is intentionally excluded: https://stackoverflow.com/questions/299628
+                307 | 308 if ["GET", "HEAD", "OPTIONS", "TRACE"].contains(&method.as_str()) => {
                     let empty = Payload::Empty.into_read();
                     debug!("redirect {} {} -> {}", resp.status(), url, new_url);
                     return connect(req, unit, use_pooled, redirect_count - 1, empty, true);


### PR DESCRIPTION
This backports https://github.com/algesten/ureq/pull/252 to the 1.x branch. I confirmed locally that this fixes the deadlinks issue (https://github.com/deadlinks/cargo-deadlinks/issues/110).