### PR TITLE
Add `.http()` method to Error to extract HTTP-type errors

### DIFF
--- a/examples/smoke-test/main.rs
+++ b/examples/smoke-test/main.rs
@@ -1,11 +1,11 @@
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Read};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
-use std::{env, error, fmt, result, result::Result};
+use std::{env, error, fmt, result};
 
 use log::{error, info};
-use ureq::{self, Response};
+use ureq;
 
 #[derive(Debug)]
 struct Oops(String);
@@ -40,36 +40,12 @@ fn get(agent: &ureq::Agent, url: &str) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-fn get_and_write(agent: &ureq::Agent, url: &str) -> std::result::Result<(), Oops> {
-    let r = get_response(agent, url)?;
-    let mut reader = r.into_reader();
-    let mut bytes = vec![];
-    reader.read_to_end(&mut bytes)?;
-    std::io::stdout().write_all(&bytes)?;
-    Ok(())
-}
-
-fn get_response(agent: &ureq::Agent, url: &str) -> result::Result<Response, ureq::Error> {
-    let fetch = || agent.get(url).call();
-    let mut result = fetch();
-    for _ in 1..4 {
-        match result {
-            Err(ureq::Error {
-                response: Some(r), ..
-            }) if r.status() == 429 => {
-                let retry: u64 = r
-                    .header("retry-after")
-                    .and_then(|h| h.parse().ok())
-                    .unwrap_or(5);
-                eprintln!("403: {}", r.into_string()?);
-                thread::sleep(Duration::from_secs(retry));
-            }
-            r => return r,
-        }
-        result = fetch();
+fn get_and_write(agent: &ureq::Agent, url: &str) {
+    info!("🕷️ {}", url);
+    match get(agent, url) {
+        Ok(_) => info!("✔️ {}", url),
+        Err(e) => error!("⚠️ {} {}", url, e),
     }
-    println!("Failed after 5 tries: {:?}", &result);
-    result
 }
 
 fn get_many(urls: Vec<String>, simultaneous_fetches: usize) -> Result<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,14 +21,18 @@ use crate::Response;
 /// use ureq::{Response, Error};
 /// # fn main(){ ureq::is_test(true); get_response(); }
 ///
+/// // An example of a function that handles HTTP 500 errors differently
+/// // than other errors.
 /// fn get_response() -> Result<Response, Error> {
-///   let mut result = ureq::get("http://httpbin.org/status/500").call();
+///   let fetch = || ureq::get("http://httpbin.org/status/500").call();
+///   let mut result = fetch();
 ///   for _ in 1..4 {
 ///     match result {
+///       // Retry 500's after waiting for two seconds.
 ///       Err(e) if e.status() == 500 => thread::sleep(Duration::from_secs(2)),
 ///       r => return r,
 ///     }
-///     result = ureq::get("http://httpbin.org/status/500").call();
+///     result = fetch();
 ///   }
 ///   println!("Failed after 5 tries: {:?}", &result);
 ///   result

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,32 @@ use std::io::{self};
 use crate::Response;
 
 /// An error that may occur when processing a Request.
+///
+/// This can represent connection-level errors (e.g. connection refused),
+/// protocol-level errors (malformed response), or status code errors
+/// (e.g. 404 Not Found). For status code errors, kind() will be
+/// ErrorKind::HTTP, status() will return the status code, and into_response()
+/// will return the underlying Response. You can use that Response to, for
+/// instance, read the full body (which may contain a useful error message).
+///
+/// ```
+/// use std::{result::Result, time::Duration, thread};
+/// use ureq::{Response, Error};
+/// # fn main(){ ureq::is_test(true); get_response(); }
+///
+/// fn get_response() -> Result<Response, Error> {
+///   let mut result = ureq::get("http://httpbin.org/status/500").call();
+///   for _ in 1..4 {
+///     match result {
+///       Err(e) if e.status() == 500 => thread::sleep(Duration::from_secs(2)),
+///       r => return r,
+///     }
+///     result = ureq::get("http://httpbin.org/status/500").call();
+///   }
+///   println!("Failed after 5 tries: {:?}", &result);
+///   result
+/// }
+/// ```
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,7 @@ pub struct Error {
     message: Option<String>,
     url: Option<Url>,
     source: Option<Box<dyn error::Error + Send + Sync + 'static>>,
-    pub response: Option<Response>,
+    response: Option<Response>,
 }
 
 impl Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub struct Error {
     message: Option<String>,
     url: Option<Url>,
     source: Option<Box<dyn error::Error + Send + Sync + 'static>>,
-    response: Option<Response>,
+    pub response: Option<Response>,
 }
 
 impl Display for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,14 +6,15 @@ use std::io::{self};
 
 use crate::Response;
 
-/// An error that may occur when processing a Request.
+/// An error that may occur when processing a [Request](crate::Request).
 ///
 /// This can represent connection-level errors (e.g. connection refused),
 /// protocol-level errors (malformed response), or status code errors
-/// (e.g. 404 Not Found). For status code errors, kind() will be
-/// ErrorKind::HTTP, status() will return the status code, and into_response()
-/// will return the underlying Response. You can use that Response to, for
-/// instance, read the full body (which may contain a useful error message).
+/// (e.g. 404 Not Found). For status code errors, [kind()](Error::kind()) will be
+/// [ErrorKind::HTTP], [status()](Error::status()) will return the status
+/// code, and [into_response()](Error::into_response()) will return the underlying
+/// [Response](crate::Response). You can use that Response to, for instance, read
+/// the full body (which may contain a useful error message).
 ///
 /// ```
 /// use std::{result::Result, time::Duration, thread};
@@ -188,7 +189,7 @@ pub enum ErrorKind {
     ProxyConnect,
     /// Incorrect credentials for proxy
     InvalidProxyCreds,
-    /// HTTP status code indicating an error (e.g. 4xx, 5xx)
+    /// HTTP status code indicating an error (e.g. 4xx, 5xx).
     /// Read the inner response body for details and to return
     /// the connection to the pool.
     HTTP,

--- a/src/request.rs
+++ b/src/request.rs
@@ -121,7 +121,7 @@ impl Request {
         let response =
             unit::connect(unit, true, 0, reader, false).map_err(|e| e.url(url.clone()))?;
 
-        if response.error() && self.error_on_non_2xx {
+        if self.error_on_non_2xx && response.status() >= 400 {
             Err(ErrorKind::HTTP.new().url(url.clone()).response(response))
         } else {
             Ok(response)

--- a/src/response.rs
+++ b/src/response.rs
@@ -147,30 +147,6 @@ impl Response {
             .collect()
     }
 
-    /// Whether the response status is: 200 <= status <= 299
-    pub fn ok(&self) -> bool {
-        self.status >= 200 && self.status <= 299
-    }
-
-    pub fn redirect(&self) -> bool {
-        self.status >= 300 && self.status <= 399
-    }
-
-    /// Whether the response status is: 400 <= status <= 499
-    pub fn client_error(&self) -> bool {
-        self.status >= 400 && self.status <= 499
-    }
-
-    /// Whether the response status is: 500 <= status <= 599
-    pub fn server_error(&self) -> bool {
-        self.status >= 500 && self.status <= 599
-    }
-
-    /// Whether the response status is: 400 <= status <= 599
-    pub fn error(&self) -> bool {
-        self.client_error() || self.server_error()
-    }
-
     /// The content type part of the "Content-Type" header without
     /// the charset.
     ///

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -175,7 +175,6 @@ pub fn no_status_text() {
         test::make_response(200, "", vec![], vec![])
     });
     let resp = get("test://host/no_status_text").call().unwrap();
-    assert!(resp.ok());
     assert_eq!(resp.status(), 200);
 }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -231,7 +231,7 @@ pub(crate) fn connect(
     save_cookies(&unit, &resp);
 
     // handle redirects
-    if resp.redirect() && unit.agent.config.redirects > 0 {
+    if resp.status() >= 300 && resp.status() < 400 && unit.agent.config.redirects > 0 {
         if redirect_count == unit.agent.config.redirects {
             return Err(ErrorKind::TooManyRedirects.new());
         }


### PR DESCRIPTION
An alternate approach to #255, meant to reduce the need to call `.unwrap()`. This method returns a `Result<(u16, Response), Error>`.