### PR TITLE
Use BufRead in more places

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -229,7 +229,7 @@ fn pool_connections_limit() {
         proxy: None,
     });
     for key in poolkeys.clone() {
-        pool.add(key, Stream::Cursor(std::io::Cursor::new(vec![])));
+        pool.add(key, Stream::from_vec(vec![]))
     }
     assert_eq!(pool.len(), pool.max_idle_connections);
 
@@ -254,10 +254,7 @@ fn pool_per_host_connections_limit() {
     };
 
     for _ in 0..pool.max_idle_connections_per_host * 2 {
-        pool.add(
-            poolkey.clone(),
-            Stream::Cursor(std::io::Cursor::new(vec![])),
-        );
+        pool.add(poolkey.clone(), Stream::from_vec(vec![]))
     }
     assert_eq!(pool.len(), pool.max_idle_connections_per_host);
 
@@ -275,15 +272,12 @@ fn pool_checks_proxy() {
     let pool = ConnectionPool::new_with_limits(10, 1);
     let url = Url::parse("zzz:///example.com").unwrap();
 
-    pool.add(
-        PoolKey::new(&url, None),
-        Stream::Cursor(std::io::Cursor::new(vec![])),
-    );
+    pool.add(PoolKey::new(&url, None), Stream::from_vec(vec![]));
     assert_eq!(pool.len(), 1);
 
     pool.add(
         PoolKey::new(&url, Some(Proxy::new("localhost:9999").unwrap())),
-        Stream::Cursor(std::io::Cursor::new(vec![])),
+        Stream::from_vec(vec![]),
     );
     assert_eq!(pool.len(), 2);
 
@@ -292,7 +286,7 @@ fn pool_checks_proxy() {
             &url,
             Some(Proxy::new("user:password@localhost:9999").unwrap()),
         ),
-        Stream::Cursor(std::io::Cursor::new(vec![])),
+        Stream::from_vec(vec![]),
     );
     assert_eq!(pool.len(), 3);
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -526,18 +526,7 @@ pub(crate) fn set_stream(resp: &mut Response, url: String, unit: Option<Unit>, s
 
 fn read_next_line(reader: &mut impl BufRead) -> io::Result<String> {
     let mut s = String::new();
-    let result = reader.read_line(&mut s).map_err(|e| {
-        // On unix-y platforms set_read_timeout and set_write_timeout
-        // causes ErrorKind::WouldBlock instead of ErrorKind::TimedOut.
-        // Since the socket most definitely not set_nonblocking(true),
-        // we can safely normalize WouldBlock to TimedOut
-        if e.kind() == io::ErrorKind::WouldBlock {
-            io::Error::new(io::ErrorKind::TimedOut, "timed out reading headers")
-        } else {
-            e
-        }
-    });
-    if result? == 0 {
+    if reader.read_line(&mut s)? == 0 {
         return Err(io::Error::new(
             io::ErrorKind::ConnectionAborted,
             "Unexpected EOF",

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -138,13 +138,13 @@ impl Stream {
 
     fn from_tcp_stream(t: TcpStream) -> Stream {
         Stream {
-            inner: BufReader::with_capacity(1000, Inner::Http(t)),
+            inner: BufReader::new(Inner::Http(t)),
         }
     }
 
     fn from_tls_stream(t: StreamOwned<ClientSession, TcpStream>) -> Stream {
         Stream {
-            inner: BufReader::with_capacity(1000, Inner::Https(t)),
+            inner: BufReader::new(Inner::Https(t)),
         }
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -135,6 +135,7 @@ impl Stream {
         }
     }
 
+    #[cfg(tls)]
     fn from_tls_stream(t: StreamOwned<ClientSession, TcpStream>) -> Stream {
         Stream {
             inner: BufReader::new(Inner::Https(t)),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -135,7 +135,7 @@ impl Stream {
         }
     }
 
-    #[cfg(tls)]
+    #[cfg(feature = "tls")]
     fn from_tls_stream(t: StreamOwned<ClientSession, TcpStream>) -> Stream {
         Stream {
             inner: BufReader::new(Inner::Https(t)),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -3,7 +3,7 @@ use crate::stream::Stream;
 use crate::unit::Unit;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::io::{Cursor, Write};
+use std::io::Write;
 use std::sync::{Arc, Mutex};
 
 mod agent_test;
@@ -29,7 +29,7 @@ where
 }
 
 #[allow(clippy::write_with_newline)]
-pub fn make_response(
+pub(crate) fn make_response(
     status: u16,
     status_text: &str,
     headers: Vec<&str>,
@@ -42,9 +42,7 @@ pub fn make_response(
     }
     write!(&mut buf, "\r\n").ok();
     buf.append(&mut body);
-    let cursor = Cursor::new(buf);
-    let write: Vec<u8> = vec![];
-    Ok(Stream::Test(Box::new(cursor), write))
+    Ok(Stream::from_vec(buf))
 }
 
 pub(crate) fn resolve_handler(unit: &Unit) -> Result<Stream, Error> {


### PR DESCRIPTION
This moves Stream's enum into an `Inner` enum, and wraps a single BufReader around the whole thing. This makes it easier to consistently treat the contents of Stream as being wrapped in a BufReader.

Also, implement BufRead for DeadlineStream. This means when a timeout is set, we don't have to set that timeout on the socket with every small read, just when we fill up the buffer. This reduces the number of syscalls.

Remove the `Cursor` variant from Stream. It was strictly less powerful than that `Test` variant, so I've replaced the handful of Cursor uses with `Test`. Because some of those cases weren't test, I removed the `#[cfg(test)]` param on the `Test` variant.

Now that all inputs to `do_from_read` are `impl BufRead`, add that as a type constraint. Change `read_next_line` to take advantage of `BufRead::read_line`, which may be somewhat faster (though I haven't benchmarked).