### PR TITLE
Do more validation on status line.

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -439,15 +439,14 @@ impl Response {
 fn parse_status_line(line: &str) -> Result<(ResponseStatusIndex, u16), Error> {
     //
 
-    let err = Err(BadStatus.new());
     if !line.is_ascii() {
-        return err;
+        return Err(BadStatus.msg("Status line not ASCII"));
     }
     // https://tools.ietf.org/html/rfc7230#section-3.1.2
     //      status-line = HTTP-version SP status-code SP reason-phrase CRLF
     let split: Vec<&str> = line.splitn(3, ' ').collect();
     if split.len() != 3 {
-        return err;
+        return Err(BadStatus.msg("Wrong number of tokens in status line"));
     }
 
     // https://tools.ietf.org/html/rfc7230#appendix-B
@@ -455,20 +454,20 @@ fn parse_status_line(line: &str) -> Result<(ResponseStatusIndex, u16), Error> {
     //    HTTP-version = HTTP-name "/" DIGIT "." DIGIT
     let http_version = split[0];
     if !http_version.starts_with("HTTP/") {
-        return err;
+        return Err(BadStatus.msg("HTTP version did not start with HTTP/"));
     }
     if http_version.len() != 8 {
-        return err;
+        return Err(BadStatus.msg("HTTP version was wrong length"));
     }
     if !http_version.as_bytes()[5].is_ascii_digit() || !http_version.as_bytes()[7].is_ascii_digit()
     {
-        return err;
+        return Err(BadStatus.msg("HTTP version did not match format"));
     }
 
     let status_str: &str = split[1];
     //      status-code    = 3DIGIT
     if status_str.len() != 3 {
-        return err;
+        return Err(BadStatus.msg("Status code was wrong length"));
     }
 
     let status: u16 = status_str.parse().map_err(|_| BadStatus.new())?;


### PR DESCRIPTION
Status code must be exactly three digits.
HTTP version must be "HTTP/", digit, dot, digit.

https://tools.ietf.org/html/rfc7230#section-3.1.2
     status-line = HTTP-version SP status-code SP reason-phrase CRLF