### PR TITLE
Add debug logs for stream pooling.

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -7,6 +7,7 @@ use crate::stream::Stream;
 use crate::unit::Unit;
 use crate::Proxy;
 
+use log::debug;
 use url::Url;
 
 /// Holder of recycled connections.
@@ -115,6 +116,7 @@ impl ConnectionPool {
                 remove_last_match(&mut inner.lru, &key)
                     .expect("invariant failed: key in recycle but not in lru");
 
+                debug!("pulling stream from pool: {:?} -> {:?}", key, stream);
                 Some(stream)
             }
             Entry::Vacant(_) => None,
@@ -125,6 +127,7 @@ impl ConnectionPool {
         if self.noop() {
             return;
         }
+        debug!("adding stream to pool: {:?} -> {:?}", key, stream);
 
         let mut inner = self.inner.lock().unwrap();
         match inner.recycle.entry(key.clone()) {
@@ -133,7 +136,13 @@ impl ConnectionPool {
                 streams.push_back(stream);
                 if streams.len() > self.max_idle_connections_per_host {
                     // Remove the oldest entry
-                    streams.pop_front();
+                    let stream = streams.pop_front().expect("empty streams list");
+                    debug!(
+                        "host {:?} has {} conns, dropping oldest: {:?}",
+                        key,
+                        streams.len(),
+                        stream
+                    );
                     remove_first_match(&mut inner.lru, &key)
                         .expect("invariant failed: key in recycle but not in lru");
                 }
@@ -159,9 +168,10 @@ impl ConnectionPool {
         match inner.recycle.entry(key) {
             Entry::Occupied(mut occupied_entry) => {
                 let streams = occupied_entry.get_mut();
-                streams
+                let stream = streams
                     .pop_front()
                     .expect("invariant failed: key existed in recycle but no streams available");
+                debug!("dropping oldest stream in pool: {:?}", stream);
                 if streams.len() == 0 {
                     occupied_entry.remove();
                 }


### PR DESCRIPTION
Now each phase in a stream's life cycle should be logged at debug: creation, adding to pool, removing from pool, and dropping.

This adds one .expect() for a condition that was checked on the line above (streams in pool > max_idle). It also tweaks the debug formatter for Stream so it prints the TcpStream directly. For now, since there's not much other data in the Stream, that's a nice succinct way to get at the useful information, like the source port and fd, and the remote IP address.

```
[2020-12-05T05:28:56Z DEBUG ureq::pool] adding stream to pool: https|www.example.com|443 -> TcpStream { addr: 10.255.129.68:50004, peer: 93.184.216.34:443, fd: 4 }
```