### PR TITLE
[1.x] Fix broken behavior for 308 redirects

### DIFF
--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -116,3 +116,17 @@ fn redirect_post() {
     assert!(resp.has("x-foo"));
     assert_eq!(resp.header("x-foo").unwrap(), "bar");
 }
+
+#[test]
+fn redirect_308() {
+    test::set_handler("/redirect_get3", |_| {
+        test::make_response(308, "Go here", vec!["Location: /valid_response"], vec![])
+    });
+    test::set_handler("/valid_response", |unit| {
+        assert_eq!(unit.req.method, "GET");
+        test::make_response(200, "OK", vec![], vec![])
+    });
+    let resp = get("test://host/redirect_get3").call();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.get_url(), "test://host/valid_response");
+}

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -240,8 +240,10 @@ pub(crate) fn connect(
                 // NOTE: DELETE is intentionally excluded: https://stackoverflow.com/questions/299628
                 307 | 308 if ["GET", "HEAD", "OPTIONS", "TRACE"].contains(&method.as_str()) => {
                     let empty = Payload::Empty.into_read();
+                    // recreate the unit to get a new hostname and cookies for the new host.
+                    let new_unit = Unit::new(req, &new_url, false, &empty);
                     debug!("redirect {} {} -> {}", resp.status(), url, new_url);
-                    return connect(req, unit, use_pooled, redirect_count - 1, empty, true);
+                    return connect(req, new_unit, use_pooled, redirect_count + 1, empty, true);
                 }
                 _ => (),
             };


### PR DESCRIPTION
Previously, this would unconditionally panic:

```
thread '<unnamed>' panicked at 'attempt to subtract with overflow', /home/joshua/src/rust/ureq/src/unit.rs:244:59
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Follow-up to #253. Sorry for not testing earlier!