### PR TITLE
Add history to response objects

### DIFF
--- a/examples/smoke-test/main.rs
+++ b/examples/smoke-test/main.rs
@@ -78,32 +78,9 @@ fn get_many(urls: Vec<String>, simultaneous_fetches: usize) -> Result<()> {
 
 fn main() -> Result<()> {
     let args = env::args();
-    if args.len() == 1 {
-        println!(
-            r##"Usage: {:#?} top-1m.csv
-        
-Where top-1m.csv is a simple, unquoted CSV containing two fields, a rank and
-a domain name. For instance you can get such a list from https://tranco-list.eu/.
-
-For each domain, this program will attempt to GET four URLs: The domain name
-name with HTTP and HTTPS, and with and without a www prefix. It will fetch
-using 50 threads concurrently.
-"##,
-            env::current_exe()?
-        );
-        return Ok(());
-    }
     env_logger::init();
-    let file = std::fs::File::open(args.skip(1).next().unwrap())?;
-    let bufreader = BufReader::new(file);
-    let mut urls = vec![];
-    for line in bufreader.lines() {
-        let domain = line?.rsplit(",").next().unwrap().to_string();
-        urls.push(format!("http://{}/", domain));
-        urls.push(format!("https://{}/", domain));
-        urls.push(format!("http://www.{}/", domain));
-        urls.push(format!("https://www.{}/", domain));
+    for a in args {
+        get_and_write(&ureq::agent(), &a);
     }
-    get_many(urls, 50)?;
     Ok(())
 }

--- a/examples/smoke-test/main.rs
+++ b/examples/smoke-test/main.rs
@@ -78,9 +78,32 @@ fn get_many(urls: Vec<String>, simultaneous_fetches: usize) -> Result<()> {
 
 fn main() -> Result<()> {
     let args = env::args();
-    env_logger::init();
-    for a in args {
-        get_and_write(&ureq::agent(), &a);
+    if args.len() == 1 {
+        println!(
+            r##"Usage: {:#?} top-1m.csv
+        
+Where top-1m.csv is a simple, unquoted CSV containing two fields, a rank and
+a domain name. For instance you can get such a list from https://tranco-list.eu/.
+
+For each domain, this program will attempt to GET four URLs: The domain name
+name with HTTP and HTTPS, and with and without a www prefix. It will fetch
+using 50 threads concurrently.
+"##,
+            env::current_exe()?
+        );
+        return Ok(());
     }
+    env_logger::init();
+    let file = std::fs::File::open(args.skip(1).next().unwrap())?;
+    let bufreader = BufReader::new(file);
+    let mut urls = vec![];
+    for line in bufreader.lines() {
+        let domain = line?.rsplit(",").next().unwrap().to_string();
+        urls.push(format!("http://{}/", domain));
+        urls.push(format!("https://{}/", domain));
+        urls.push(format!("http://www.{}/", domain));
+        urls.push(format!("https://www.{}/", domain));
+    }
+    get_many(urls, 50)?;
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,9 @@ impl Display for Error {
         match self {
             Error::Status(status, response) => {
                 write!(f, "{}: status code {}", response.get_url(), status)?;
+                if let Some(original) = response.history().last() {
+                    write!(f, " (redirected from {})", original.get_url())?;
+                }
             }
             Error::Transport(err) => {
                 write!(f, "{}", err)?;

--- a/src/request.rs
+++ b/src/request.rs
@@ -118,8 +118,7 @@ impl Request {
         }
         let reader = payload.into_read();
         let unit = Unit::new(&self.agent, &self.method, &url, &self.headers, &reader);
-        let response =
-            unit::connect(unit, true, 0, reader, false).map_err(|e| e.url(url.clone()))?;
+        let response = unit::connect(unit, true, reader, None).map_err(|e| e.url(url.clone()))?;
 
         if self.error_on_non_2xx && response.status() >= 400 {
             Err(Error::Status(response.status(), response))

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -206,7 +206,6 @@ pub(crate) fn connect(
     body::send_body(body, unit.is_chunked, &mut stream)?;
 
     // start reading the response to process cookies and redirects.
-    // let mut stream = stream::DeadlineStream::new(stream, unit.deadline);
     let result = Response::do_from_request(unit.clone(), stream, previous.clone());
 
     // https://tools.ietf.org/html/rfc7230#section-6.3.1

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,5 +1,8 @@
-use std::io::{self, Write};
 use std::time;
+use std::{
+    io::{self, Write},
+    sync::Arc,
+};
 
 use log::{debug, info};
 use url::Url;
@@ -19,6 +22,7 @@ use crate::Agent;
 /// A Unit is fully-built Request, ready to execute.
 ///
 /// *Internal API*
+#[derive(Clone)]
 pub(crate) struct Unit {
     pub agent: Agent,
     pub method: String,
@@ -163,9 +167,8 @@ impl Unit {
 pub(crate) fn connect(
     unit: Unit,
     use_pooled: bool,
-    redirect_count: u32,
     body: SizedReader,
-    redir: bool,
+    previous: Option<Arc<Response>>,
 ) -> Result<Response, Error> {
     //
 
@@ -184,14 +187,14 @@ pub(crate) fn connect(
         info!("sending request {} {}", method, url);
     }
 
-    let send_result = send_prelude(&unit, &mut stream, redir);
+    let send_result = send_prelude(&unit, &mut stream, previous.is_some());
 
     if let Err(err) = send_result {
         if is_recycled {
             debug!("retrying request early {} {}: {}", method, url, err);
             // we try open a new connection, this time there will be
             // no connection in the pool. don't use it.
-            return connect(unit, false, redirect_count, body, redir);
+            return connect(unit, false, body, previous);
         } else {
             // not a pooled connection, propagate the error.
             return Err(err.into());
@@ -203,8 +206,8 @@ pub(crate) fn connect(
     body::send_body(body, unit.is_chunked, &mut stream)?;
 
     // start reading the response to process cookies and redirects.
-    let mut stream = stream::DeadlineStream::new(stream, unit.deadline);
-    let result = Response::do_from_read(&mut stream);
+    // let mut stream = stream::DeadlineStream::new(stream, unit.deadline);
+    let result = Response::do_from_request(unit.clone(), stream, previous.clone());
 
     // https://tools.ietf.org/html/rfc7230#section-6.3.1
     // When an inbound connection is closed prematurely, a client MAY
@@ -216,11 +219,11 @@ pub(crate) fn connect(
     // from the ConnectionPool, since those are most likely to have
     // reached a server-side timeout. Note that this means we may do
     // up to N+1 total tries, where N is max_idle_connections_per_host.
-    let mut resp = match result {
+    let resp = match result {
         Err(err) if err.connection_closed() && retryable && is_recycled => {
             debug!("retrying request {} {}: {}", method, url, err);
             let empty = Payload::Empty.into_read();
-            return connect(unit, false, redirect_count, empty, redir);
+            return connect(unit, false, empty, previous);
         }
         Err(e) => return Err(e),
         Ok(resp) => resp,
@@ -232,8 +235,10 @@ pub(crate) fn connect(
 
     // handle redirects
     if (300..399).contains(&resp.status()) && unit.agent.config.redirects > 0 {
-        if redirect_count == unit.agent.config.redirects {
-            return Err(ErrorKind::TooManyRedirects.new());
+        if let Some(previous) = previous {
+            if previous.history().count() + 1 >= unit.agent.config.redirects as usize {
+                return Err(ErrorKind::TooManyRedirects.new());
+            }
         }
 
         // the location header
@@ -261,7 +266,7 @@ pub(crate) fn connect(
                         Unit::new(&unit.agent, &new_method, &new_url, &unit.headers, &empty);
 
                     debug!("redirect {} {} -> {}", resp.status(), url, new_url);
-                    return connect(new_unit, use_pooled, redirect_count + 1, empty, true);
+                    return connect(new_unit, use_pooled, empty, Some(Arc::new(resp)));
                 }
                 // never change the method for 307/308
                 // only resend the request if it cannot have a body
@@ -269,7 +274,7 @@ pub(crate) fn connect(
                 307 | 308 if ["GET", "HEAD", "OPTIONS", "TRACE"].contains(&method.as_str()) => {
                     let empty = Payload::Empty.into_read();
                     debug!("redirect {} {} -> {}", resp.status(), url, new_url);
-                    return connect(unit, use_pooled, redirect_count - 1, empty, true);
+                    return connect(unit, use_pooled, empty, Some(Arc::new(resp)));
                 }
                 _ => (),
             };
@@ -277,13 +282,6 @@ pub(crate) fn connect(
     }
 
     debug!("response {} to {} {}", resp.status(), method, url);
-
-    let mut stream: Stream = stream.into();
-    stream.reset()?;
-
-    // since it is not a redirect, or we're not following redirects,
-    // give away the incoming stream to the response object.
-    crate::response::set_stream(&mut resp, unit.url.to_string(), Some(unit), stream);
 
     // release the response
     Ok(resp)


### PR DESCRIPTION
This allows Error to report both the URL that caused an error, and the
original URL that was requested.

Change unit::connect to use the Response history for tracking number of
redirects, instead of passing the count as a separate parameter.

Incidentally, move handling of the `stream` fully inside `Response`.
Instead of `do_from_read` + `set_stream`, we now have `do_from_stream`,
which takes ownership of the stream and keeps it. We also have
`do_from_request`, which does all of `do_from_stream`, but also sets the
`previous` field.