### PR TITLE
Clarify example from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ Version 2.0.0 was released recently and changed some APIs. See the [changelog] f
 In its simplest form, ureq looks like this:
 
 ```rust
-let body: String = ureq::get("http://example.com")
-    .set("Accept", "text/html")
-    .call()?
-    .into_string()?;
+fn main() -> Result<(), ureq::Error> {
+  let body: String = ureq::get("http://example.com")
+      .set("Example-Header", "header value")
+      .call()?
+      .into_string()?;
+  Ok(())
+}
 ```
 
 For more involved tasks, you'll want to create an [Agent]. An Agent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,14 +23,14 @@
 //! In its simplest form, ureq looks like this:
 //!
 //! ```rust
-//! # fn main() -> Result<(), ureq::Error> {
+//! fn main() -> Result<(), ureq::Error> {
 //! # ureq::is_test(true);
-//! let body: String = ureq::get("http://example.com")
-//!     .set("Accept", "text/html")
-//!     .call()?
-//!     .into_string()?;
-//! # Ok(())
-//! # }
+//!   let body: String = ureq::get("http://example.com")
+//!       .set("Example-Header", "header value")
+//!       .call()?
+//!       .into_string()?;
+//!   Ok(())
+//! }
 //! ```
 //!
 //! For more involved tasks, you'll want to create an [Agent]. An Agent


### PR DESCRIPTION
We should include the `fn main() -> Result` part, because people may not
know they need the `-> Result` in order for `?` to work.

Also, I replaced `Accept: text/html` with `Example-Header: header
value`. My thinking is that if someone doesn't know they need to remove
that Accept for non-HTML URLs, they might get unexpected results.