### PR TITLE
OrAnyStatus::or_any_status ergonomic helper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ mod testserver;
 
 pub use crate::agent::Agent;
 pub use crate::agent::AgentBuilder;
-pub use crate::error::{Error, ErrorKind, Transport};
+pub use crate::error::{Error, ErrorKind, OrAnyStatus, Transport};
 pub use crate::header::Header;
 pub use crate::proxy::Proxy;
 pub use crate::request::Request;


### PR DESCRIPTION
Some users might prefer to handle all HTTP responses as Response regardless of status code.

This helper might be controversial since it means we become a bit locked down to having two variants of the `Error` enum.