### PR TITLE
Minor changes to simple example to get rid of warnings and error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ Version 2.0.0 was released recently and changed some APIs. See the [changelog] f
 In its simplest form, ureq looks like this:
 
 ```rust
+use ureq;
+
 fn main() -> Result<(), ureq::Error> {
   let body: String = ureq::get("http://example.com")
       .set("Example-Header", "header value")
-      .call()?
+      .call()
       .into_string()?;
+  println!("{:#?}",body);
   Ok(())
 }
 ```


### PR DESCRIPTION
Was running into error with the basic example given. I fixed the minor issue and included a println! to get rid of the unused body warning. 

```
error[E0277]: the `?` operator can only be applied to values that implement `Try`
 --> src\main.rs:4:24
  |
4 |       let body: String = ureq::get("http://example.com")
  |  ________________________^
5 | |         .set("Example-Header", "header value")
6 | |         .call()?
  | |________________^ the `?` operator cannot be applied to type `Response`
  |
  = help: the trait `Try` is not implemented for `Response`
  = note: required by `into_result`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
```