### PR TITLE
Fix main lib.rs and README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,12 @@ Version 2.0.0 was released recently and changed some APIs. See the [changelog] f
 In its simplest form, ureq looks like this:
 
 ```rust
-use ureq;
-
 fn main() -> Result<(), ureq::Error> {
-  let body: String = ureq::get("http://example.com")
-      .set("Example-Header", "header value")
-      .call()
-      .into_string()?;
-  println!("{:#?}",body);
-  Ok(())
+    let body: String = ureq::get("http://example.com")
+        .set("Example-Header", "header value")
+        .call()?
+        .into_string()?;
+    Ok(())
 }
 ```
 
@@ -79,7 +76,22 @@ Ureq supports sending and receiving json, if you enable the "json" feature:
 
 ureq returns errors via `Result<T, ureq::Error>`. That includes I/O errors,
 protocol errors, and status code errors (when the server responded 4xx or
-5xx). More details on the [Error] type.
+5xx)
+
+```rust
+use ureq::Error;
+
+match ureq::get("http://mypage.example.com/").call() {
+    Ok(response) => { /* it worked */},
+    Err(Error::Status(code, response)) => {
+        /* the server returned an unexpected status
+           code (such as 400, 500 etc) */
+    }
+    Err(_) => { /* some kind of io/transport error */ }
+}
+```
+
+More details on the [Error] type.
 
 ### Features
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,11 @@
 //! ```rust
 //! fn main() -> Result<(), ureq::Error> {
 //! # ureq::is_test(true);
-//!   let body: String = ureq::get("http://example.com")
-//!       .set("Example-Header", "header value")
-//!       .call()?
-//!       .into_string()?;
-//!   Ok(())
+//!     let body: String = ureq::get("http://example.com")
+//!         .set("Example-Header", "header value")
+//!         .call()?
+//!         .into_string()?;
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -86,7 +86,7 @@
 //!
 //! ureq returns errors via `Result<T, ureq::Error>`. That includes I/O errors,
 //! protocol errors, and status code errors (when the server responded 4xx or
-//! 5xx).
+//! 5xx)
 //!
 //! ```rust
 //! use ureq::Error;

--- a/src/response.rs
+++ b/src/response.rs
@@ -11,9 +11,9 @@ use url::Url;
 use crate::error::{Error, ErrorKind::BadStatus};
 use crate::header::Header;
 use crate::pool::PoolReturnRead;
+use crate::stream;
 use crate::stream::{DeadlineStream, Stream};
 use crate::unit::Unit;
-use crate::stream;
 
 #[cfg(feature = "json")]
 use serde::de::DeserializeOwned;


### PR DESCRIPTION
Small fixes to just ensure lib.rs and README.md are run via `cargo readme`.