### PR TITLE
add documentation link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Simple, safe HTTP client"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/algesten/ureq"
 readme = "README.md"
+documentation = "https://docs.rs/ureq/"
 keywords = ["web", "request", "https", "http", "client"]
 categories = ["web-programming::http-client"]
 edition = "2018"


### PR DESCRIPTION
Hey, thank you for the excellent library, it's a pleasure to use.
This change allows the documentation link to show up on crates.io.
Thanks!