### PR TITLE
Fix 307/308 redirects (again, for 2.0)

### DIFF
--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -127,3 +127,17 @@ fn redirect_post() {
     assert!(resp.has("x-foo"));
     assert_eq!(resp.header("x-foo").unwrap(), "bar");
 }
+
+#[test]
+fn redirect_308() {
+    test::set_handler("/redirect_get3", |_| {
+        test::make_response(308, "Go here", vec!["Location: /valid_response"], vec![])
+    });
+    test::set_handler("/valid_response", |unit| {
+        assert_eq!(unit.method, "GET");
+        test::make_response(200, "OK", vec![], vec![])
+    });
+    let resp = get("test://host/redirect_get3").call().unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.get_url(), "test://host/valid_response");
+}

--- a/src/testserver.rs
+++ b/src/testserver.rs
@@ -13,6 +13,9 @@ use crate::{Agent, AgentBuilder};
 // An agent to be installed by default for tests and doctests, such
 // that all hostnames resolve to a TestServer on localhost.
 pub(crate) fn test_agent() -> Agent {
+    #[cfg(test)]
+    let _ = env_logger::try_init();
+
     let testserver = TestServer::new(|mut stream: TcpStream| -> io::Result<()> {
         let headers = read_request(&stream);
         if headers.0.is_empty() {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -271,7 +271,9 @@ pub(crate) fn connect(
                 307 | 308 if ["GET", "HEAD", "OPTIONS", "TRACE"].contains(&method.as_str()) => {
                     let empty = Payload::Empty.into_read();
                     debug!("redirect {} {} -> {}", resp.status(), url, new_url);
-                    return connect(unit, use_pooled, empty, Some(Arc::new(resp)));
+                    // recreate the unit to get a new hostname and cookies for the new host.
+                    let new_unit = Unit::new(&unit.agent, &unit.method, &new_url, &unit.headers, &empty);
+                    return connect(new_unit, use_pooled, empty, Some(Arc::new(resp)));
                 }
                 _ => (),
             };

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -170,8 +170,6 @@ pub(crate) fn connect(
     body: SizedReader,
     previous: Option<Arc<Response>>,
 ) -> Result<Response, Error> {
-    //
-
     let host = unit
         .url
         .host_str()


### PR DESCRIPTION
I guess the unit test got backported but never added to `main`.

Fixes the issue in https://github.com/deadlinks/cargo-deadlinks/pull/134.

Also add some improvements to registration of test handlers, and add env_logger support to tests.