### PR TITLE
Response: Use ErrorKind::UnexpectedEof for "premature close"

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -618,7 +618,7 @@ impl<R: Read> Read for LimitedRead<R> {
             // received, the recipient MUST consider the message to be
             // incomplete and close the connection.
             Ok(0) => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
+                io::ErrorKind::UnexpectedEof,
                 "response body closed before all bytes were read",
             )),
             Ok(amount) => {
@@ -636,7 +636,7 @@ fn short_read() {
     let mut lr = LimitedRead::new(Cursor::new(vec![b'a'; 3]), 10);
     let mut buf = vec![0; 1000];
     let result = lr.read_to_end(&mut buf);
-    assert!(result.is_err());
+    assert!(result.err().unwrap().kind() == io::ErrorKind::UnexpectedEof);
 }
 
 impl<R: Read> From<LimitedRead<R>> for Stream


### PR DESCRIPTION
In a client application, we're explicitly trying to differentiate "invalid data" scenarios from "broken transfer". `ureq` calling a broken transfer "invalid data" becomes a bit confusing. We can of course solve it locally for us, but I'd at least want to bring it up for discussion first. 