### PR TITLE
Add request Display impl `$method $url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+ * Add `Display` impl for `Request` of form _`"$method $url"`_.
+
 # 2.0.1
  * Fix handling of 308 redirects (port from 1.5.4 branch).
  * Return UnexpectedEof instead of InvalidData on short responses. (#293)

--- a/src/request.rs
+++ b/src/request.rs
@@ -21,6 +21,15 @@ enum Urlish {
     Str(String),
 }
 
+impl fmt::Display for Urlish {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Urlish::Url(u) => write!(f, "{}", u),
+            Urlish::Str(s) => write!(f, "{}", s),
+        }
+    }
+}
+
 /// Request instances are builders that creates a request.
 ///
 /// ```
@@ -42,12 +51,16 @@ pub struct Request {
     query_params: Vec<(String, String)>,
 }
 
-impl fmt::Display for Urlish {
+/// Format: `$method $url`.
+/// ```
+/// let request = ureq::get("http://example.com/form")
+///     .query("foo", "bar baz");  // not included in Display
+///
+/// assert_eq!(format!("{}", request), "GET http://example.com/form");
+/// ```
+impl fmt::Display for Request {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Urlish::Url(u) => write!(f, "{}", u),
-            Urlish::Str(s) => write!(f, "{}", s),
-        }
+        write!(f, "{} {}", self.method, self.url)
     }
 }
 


### PR DESCRIPTION
Add `impl Display for Request` so that `ureq::get("https://example.com")` -> `GET https://example.com`. Ignores all other request properties. Terse + easy to read.

Resolves #297

If this wasn't how you guys wanted to go about it, feel free to close.