### PR TITLE
Fix typo in doc of `into_json`

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -321,7 +321,7 @@ impl Response {
     }
 
     /// Read the body of this response into a serde_json::Value, or any other type that
-    // implements the [serde::Deserialize] trait.
+    /// implements the [serde::Deserialize] trait.
     ///
     /// You must use either a type annotation as shown below (`message: Message`), or the
     /// [turbofish operator] (`::<Type>`) so Rust knows what type you are trying to read.


### PR DESCRIPTION
Hi, this fixes a typo which causes part of the documentation of `into_json` to be missing:
![image](https://user-images.githubusercontent.com/15840814/104843164-76d0d380-58c9-11eb-95f3-0e9f4cbabab5.png)
