### PR TITLE
Additional Request functions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use url::Url;
+use url::{ParseError, Url};
 
 use std::error;
 use std::fmt::{self, Display};
@@ -312,6 +312,14 @@ impl From<io::Error> for Error {
 impl From<Transport> for Error {
     fn from(err: Transport) -> Error {
         Error::Transport(err)
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Self {
+        ErrorKind::InvalidUrl
+            .msg(&format!("failed to parse URL: {:?}", err))
+            .src(err)
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -111,19 +111,19 @@ impl Request {
         self.do_call(Payload::Empty)
     }
 
-    fn do_call(&self, payload: Payload) -> Result<Response> {
+    fn do_call(self, payload: Payload) -> Result<Response> {
         for h in &self.headers {
             h.validate()?;
         }
-        let mut url: Url = match self.url.clone() {
+        let mut url: Url = match self.url {
             Urlish::Url(u) => u,
-            Urlish::Str(s) => s.parse().map_err(|e: url::ParseError| {
+            Urlish::Str(s) => s.parse().map_err(|e| {
                 ErrorKind::InvalidUrl
-                    .msg(&format!("failed to parse URL '{}'", self.url))
+                    .msg(&format!("failed to parse URL: {:?}", e))
                     .src(e)
             })?,
         };
-        for (name, value) in self.query_params.clone() {
+        for (name, value) in self.query_params {
             url.query_pairs_mut().append_pair(&name, &value);
         }
         let deadline = match self.timeout.or(self.agent.config.timeout) {

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -136,7 +136,7 @@ fn request_debug() {
 
     assert_eq!(
         s,
-        "Request(GET http://localhost/my/page [], [Authorization: abcdef, \
+        "Request(GET http://localhost/my/page, [Authorization: abcdef, \
          Content-Length: 1234, Content-Type: application/json])"
     );
 
@@ -148,7 +148,7 @@ fn request_debug() {
 
     assert_eq!(
         s,
-        "Request(GET http://localhost/my/page?q=z [(\"foo\", \"bar baz\")], [Authorization: abcdef])"
+        "Request(GET http://localhost/my/page?q=z&foo=bar+baz, [Authorization: abcdef])"
     );
 }
 


### PR DESCRIPTION
Provide functions on `Request` to inspect the state. 

`.method()` returns GET, POST etc and `.url()` returns the url _as a &str;_, since this is our "native" url format.

Sadly there's an inconsistency carried over from old where `.set` sets a header, and `.query` sets a query parameter. To inspect headers, we have `.header()` and `.header_names()` (the consistent naming would have been `.header()` to set the header).

The new functions for query parameters are `.query_params()` to list all set query parameters, `.query_value()` to read the first value for a `param` and `.query_values()` to get all query values for a name.

The PR is big because there are two ways to set query parameters. These are equivalent:

1. `ureq::get("http://some/?my=param")`
2. `ureq::get("http://some/").query("my". "param")`

`.query_params()`, `.query_value()` etc should list all parameters, regardless of how they were set. We don't want to parse query multiple times, so the PR moves the parse of `url: &str` from being done last in the "build" methods `.do_call()` to be already at instantiation. An additional hurdle is that `Url` gives us the parsed parameters as `Cow<String>`, while we want the `ureq` API to operate on `&str`.



Close #297 

