### PR TITLE
Apply deadline across redirects.

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, time};
 use std::io::Read;
 
 use url::{form_urlencoded, Url};
@@ -116,8 +116,16 @@ impl Request {
         for (name, value) in self.query_params.clone() {
             url.query_pairs_mut().append_pair(&name, &value);
         }
+        let deadline = match self.agent.config.timeout {
+            None => None,
+            Some(timeout) => {
+                let now = time::Instant::now();
+                Some(now.checked_add(timeout).unwrap())
+            }
+        };
+
         let reader = payload.into_read();
-        let unit = Unit::new(&self.agent, &self.method, &url, &self.headers, &reader);
+        let unit = Unit::new(&self.agent, &self.method, &url, &self.headers, &reader, deadline);
         let response = unit::connect(unit, true, reader).map_err(|e| e.url(url.clone()))?;
 
         if response.status() >= 400 {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,5 @@
-use std::{fmt, time};
 use std::io::Read;
+use std::{fmt, time};
 
 use url::{form_urlencoded, Url};
 
@@ -125,7 +125,14 @@ impl Request {
         };
 
         let reader = payload.into_read();
-        let unit = Unit::new(&self.agent, &self.method, &url, &self.headers, &reader, deadline);
+        let unit = Unit::new(
+            &self.agent,
+            &self.method,
+            &url,
+            &self.headers,
+            &reader,
+            deadline,
+        );
         let response = unit::connect(unit, true, reader).map_err(|e| e.url(url.clone()))?;
 
         if response.status() >= 400 {

--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -1,4 +1,9 @@
-use std::{io::{self, Write}, net::TcpStream, thread, time::Duration};
+use std::{
+    io::{self, Write},
+    net::TcpStream,
+    thread,
+    time::Duration,
+};
 use testserver::{self, TestServer};
 
 use crate::{error::Error, test};
@@ -173,8 +178,11 @@ fn redirects_hit_timeout() {
     });
     let req = crate::builder().timeout(Duration::from_millis(100)).build();
     let result = req.get("test://host/redirect_sleep1").call();
-    assert!(matches!(result, Err(Error::Transport(_))),
-        "expected Transport error, got {:?}", result);
+    assert!(
+        matches!(result, Err(Error::Transport(_))),
+        "expected Transport error, got {:?}",
+        result
+    );
 }
 
 #[test]

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -38,7 +38,7 @@ impl Unit {
         url: &Url,
         headers: &Vec<Header>,
         body: &SizedReader,
-        deadline: Option<time::Instant>
+        deadline: Option<time::Instant>,
     ) -> Self {
         //
 
@@ -206,7 +206,14 @@ pub(crate) fn connect(
         history.push(unit.url.to_string());
         body = Payload::Empty.into_read();
         // recreate the unit to get a new hostname and cookies for the new host.
-        unit = Unit::new(&unit.agent, &new_method, &new_url, &unit.headers, &body, unit.deadline);
+        unit = Unit::new(
+            &unit.agent,
+            &new_method,
+            &new_url,
+            &unit.headers,
+            &body,
+            unit.deadline,
+        );
     };
     resp.history = history;
     Ok(resp)

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -38,6 +38,7 @@ impl Unit {
         url: &Url,
         headers: &Vec<Header>,
         body: &SizedReader,
+        deadline: Option<time::Instant>
     ) -> Self {
         //
 
@@ -98,14 +99,6 @@ impl Unit {
             .chain(extra_headers.iter())
             .cloned()
             .collect();
-
-        let deadline = match agent.config.timeout {
-            None => None,
-            Some(timeout) => {
-                let now = time::Instant::now();
-                Some(now.checked_add(timeout).unwrap())
-            }
-        };
 
         Unit {
             agent: agent.clone(),
@@ -213,7 +206,7 @@ pub(crate) fn connect(
         history.push(unit.url.to_string());
         body = Payload::Empty.into_read();
         // recreate the unit to get a new hostname and cookies for the new host.
-        unit = Unit::new(&unit.agent, &new_method, &new_url, &unit.headers, &body);
+        unit = Unit::new(&unit.agent, &new_method, &new_url, &unit.headers, &body, unit.deadline);
     };
     resp.history = history;
     Ok(resp)


### PR DESCRIPTION
Previously, each redirect could take `timeout` time, so a series of slow
redirects could run for longer than expected, or indefinitely.

Related #312 /cc @Shnatsel