### PR TITLE
Remove percent-encoding of cookies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ socks-proxy = ["socks"]
 [dependencies]
 base64 = "0.13"
 chunked_transfer = "1.2.0"
-cookie = { version = "0.14", features = ["percent-encode"], optional = true}
+cookie = { version = "0.14", optional = true}
 once_cell = "1"
 url = "2"
 socks = { version = "0.3.2", optional = true }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -301,7 +301,7 @@ fn extract_cookies(agent: &Agent, url: &Url) -> Option<Header> {
         .cookie_tin
         .get_request_cookies(url)
         .iter()
-        .map(|c| c.encoded().to_string())
+        .map(|c| c.to_string())
         .collect::<Vec<_>>()
         .join(";");
     match header_value.as_str() {


### PR DESCRIPTION
Fixes #315 

NOTE: This might be breaking for some people that might have relied on additional client-side percent-encoding, but I'd classify this as a bug-fix