### PR TITLE
Add -k option to cureq example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cookie = { version = "0.14", features = ["percent-encode"], optional = true}
 once_cell = "1"
 url = "2"
 socks = { version = "0.3.2", optional = true }
-rustls = { version = "0.19", optional = true, features = [] }
+rustls = { version = "0.19", optional = true, features = ["dangerous_configuration"] }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.21", optional = true }
 rustls-native-certs = { version = "0.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cookie = { version = "0.14", features = ["percent-encode"], optional = true}
 once_cell = "1"
 url = "2"
 socks = { version = "0.3.2", optional = true }
-rustls = { version = "0.19", optional = true, features = ["dangerous_configuration"] }
+rustls = { version = "0.19", optional = true }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.21", optional = true }
 rustls-native-certs = { version = "0.5", optional = true }
@@ -43,6 +43,7 @@ log = "0.4.11"
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 env_logger = "0.8.1"
+rustls = { version = "0.19", features = ["dangerous_configuration"] }
 
 [[example]]
 name = "smoke-test"


### PR DESCRIPTION
By analogy with curl, this turns off certificate verification. Requires
enabling the "dangerous_configuration" feature in the rustls dependency.