### PR TITLE
Ensure Error and Response implement Send+Sync

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -410,10 +410,8 @@ mod tests {
     }
 
     #[test]
-    fn error_is_send_and_sync() {
-        fn takes_send(_: impl Send) {}
-        fn takes_sync(_: impl Sync) {}
-        takes_send(crate::error::ErrorKind::InvalidUrl.new());
-        takes_sync(crate::error::ErrorKind::InvalidUrl.new());
+    fn error_implements_send_and_sync() {
+        let _error: Box<dyn Send> = Box::new(Error::new(ErrorKind::Io, None));
+        let _error: Box<dyn Sync> = Box::new(Error::new(ErrorKind::Io, None));
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -833,4 +833,10 @@ mod tests {
         let hist: Vec<&str> = response2.history.iter().map(|r| &**r).collect();
         assert_eq!(hist, ["http://1.example.com/", "http://2.example.com/"])
     }
+
+    #[test]
+    fn response_implements_send_and_sync() {
+        let _response: Box<dyn Send> = Box::new(Response::new(302, "Found", "").unwrap());
+        let _response: Box<dyn Sync> = Box::new(Response::new(302, "Found", "").unwrap());
+    }
 }


### PR DESCRIPTION
This is to ensure we don't accidentally introduce breaking changes
with respects to Send and Sync.