### PR TITLE
Move unit tests inside conditionally compiled mod tests { } blocks

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -150,26 +150,6 @@ fn copy_chunked<R: Read, W: Write>(reader: &mut R, writer: &mut W) -> io::Result
     }
 }
 
-#[test]
-fn test_copy_chunked() {
-    let mut source = Vec::<u8>::new();
-    source.resize(CHUNK_MAX_PAYLOAD_SIZE, 33);
-    source.extend_from_slice(b"hello world");
-
-    let mut dest = Vec::<u8>::new();
-    copy_chunked(&mut &source[..], &mut dest).unwrap();
-
-    let mut dest_expected = Vec::<u8>::new();
-    dest_expected.extend_from_slice(format!("{:x}\r\n", CHUNK_MAX_PAYLOAD_SIZE).as_bytes());
-    dest_expected.resize(dest_expected.len() + CHUNK_MAX_PAYLOAD_SIZE, 33);
-    dest_expected.extend_from_slice(b"\r\n");
-
-    dest_expected.extend_from_slice(b"b\r\nhello world\r\n");
-    dest_expected.extend_from_slice(b"0\r\n\r\n");
-
-    assert_eq!(dest, dest_expected);
-}
-
 /// Helper to send a body, either as chunked or not.
 pub(crate) fn send_body(
     mut body: SizedReader,
@@ -183,4 +163,29 @@ pub(crate) fn send_body(
     };
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_copy_chunked() {
+        let mut source = Vec::<u8>::new();
+        source.resize(CHUNK_MAX_PAYLOAD_SIZE, 33);
+        source.extend_from_slice(b"hello world");
+
+        let mut dest = Vec::<u8>::new();
+        copy_chunked(&mut &source[..], &mut dest).unwrap();
+
+        let mut dest_expected = Vec::<u8>::new();
+        dest_expected.extend_from_slice(format!("{:x}\r\n", CHUNK_MAX_PAYLOAD_SIZE).as_bytes());
+        dest_expected.resize(dest_expected.len() + CHUNK_MAX_PAYLOAD_SIZE, 33);
+        dest_expected.extend_from_slice(b"\r\n");
+
+        dest_expected.extend_from_slice(b"b\r\nhello world\r\n");
+        dest_expected.extend_from_slice(b"0\r\n\r\n");
+
+        assert_eq!(dest, dest_expected);
+    }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -145,72 +145,77 @@ impl FromStr for Header {
     }
 }
 
-#[test]
-fn test_valid_name() {
-    assert!(valid_name("example"));
-    assert!(valid_name("Content-Type"));
-    assert!(valid_name("h-123456789"));
-    assert!(!valid_name("Content-Type:"));
-    assert!(!valid_name("Content-Type "));
-    assert!(!valid_name(" some-header"));
-    assert!(!valid_name("\"invalid\""));
-    assert!(!valid_name("Gödel"));
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_valid_value() {
-    assert!(valid_value("example"));
-    assert!(valid_value("foo bar"));
-    assert!(valid_value(" foobar "));
-    assert!(valid_value(" foo\tbar "));
-    assert!(valid_value(" foo~"));
-    assert!(valid_value(" !bar"));
-    assert!(valid_value(" "));
-    assert!(!valid_value(" \nfoo"));
-    assert!(!valid_value("foo\x7F"));
-}
-
-#[test]
-fn test_parse_invalid_name() {
-    let cases = vec![
-        "Content-Type  :",
-        " Content-Type: foo",
-        "Content-Type foo",
-        "\"some-header\": foo",
-        "Gödel: Escher, Bach",
-        "Foo: \n",
-        "Foo: \nbar",
-        "Foo: \x7F bar",
-    ];
-    for c in cases {
-        let result = c.parse::<Header>();
-        assert!(
-            matches!(result, Err(ref e) if e.kind() == ErrorKind::BadHeader),
-            "'{}'.parse(): expected BadHeader, got {:?}",
-            c,
-            result
-        );
+    #[test]
+    fn test_valid_name() {
+        assert!(valid_name("example"));
+        assert!(valid_name("Content-Type"));
+        assert!(valid_name("h-123456789"));
+        assert!(!valid_name("Content-Type:"));
+        assert!(!valid_name("Content-Type "));
+        assert!(!valid_name(" some-header"));
+        assert!(!valid_name("\"invalid\""));
+        assert!(!valid_name("Gödel"));
     }
-}
 
-#[test]
-fn empty_value() {
-    let h = "foo:".parse::<Header>().unwrap();
-    assert_eq!(h.value(), "");
-}
+    #[test]
+    fn test_valid_value() {
+        assert!(valid_value("example"));
+        assert!(valid_value("foo bar"));
+        assert!(valid_value(" foobar "));
+        assert!(valid_value(" foo\tbar "));
+        assert!(valid_value(" foo~"));
+        assert!(valid_value(" !bar"));
+        assert!(valid_value(" "));
+        assert!(!valid_value(" \nfoo"));
+        assert!(!valid_value("foo\x7F"));
+    }
 
-#[test]
-fn value_with_whitespace() {
-    let h = "foo:      bar    ".parse::<Header>().unwrap();
-    assert_eq!(h.value(), "bar");
-}
+    #[test]
+    fn test_parse_invalid_name() {
+        let cases = vec![
+            "Content-Type  :",
+            " Content-Type: foo",
+            "Content-Type foo",
+            "\"some-header\": foo",
+            "Gödel: Escher, Bach",
+            "Foo: \n",
+            "Foo: \nbar",
+            "Foo: \x7F bar",
+        ];
+        for c in cases {
+            let result = c.parse::<Header>();
+            assert!(
+                matches!(result, Err(ref e) if e.kind() == ErrorKind::BadHeader),
+                "'{}'.parse(): expected BadHeader, got {:?}",
+                c,
+                result
+            );
+        }
+    }
 
-#[test]
-fn name_and_value() {
-    let header: Header = "X-Forwarded-For: 127.0.0.1".parse().unwrap();
-    assert_eq!("X-Forwarded-For", header.name());
-    assert_eq!("127.0.0.1", header.value());
-    assert!(header.is_name("X-Forwarded-For"));
-    assert!(header.is_name("x-forwarded-for"));
-    assert!(header.is_name("X-FORWARDED-FOR"));
+    #[test]
+    fn empty_value() {
+        let h = "foo:".parse::<Header>().unwrap();
+        assert_eq!(h.value(), "");
+    }
+
+    #[test]
+    fn value_with_whitespace() {
+        let h = "foo:      bar    ".parse::<Header>().unwrap();
+        assert_eq!(h.value(), "bar");
+    }
+
+    #[test]
+    fn name_and_value() {
+        let header: Header = "X-Forwarded-For: 127.0.0.1".parse().unwrap();
+        assert_eq!("X-Forwarded-For", header.name());
+        assert_eq!("127.0.0.1", header.value());
+        assert!(header.is_name("X-Forwarded-For"));
+        assert!(header.is_name("x-forwarded-for"));
+        assert!(header.is_name("X-FORWARDED-FOR"));
+    }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -219,88 +219,6 @@ impl PoolKey {
     }
 }
 
-#[test]
-fn poolkey_new() {
-    // Test that PoolKey::new() does not panic on unrecognized schemes.
-    PoolKey::new(&Url::parse("zzz:///example.com").unwrap(), None);
-}
-
-#[test]
-fn pool_connections_limit() {
-    // Test inserting connections with different keys into the pool,
-    // filling and draining it. The pool should evict earlier connections
-    // when the connection limit is reached.
-    let pool = ConnectionPool::new_with_limits(10, 1);
-    let hostnames = (0..pool.max_idle_connections * 2).map(|i| format!("{}.example", i));
-    let poolkeys = hostnames.map(|hostname| PoolKey {
-        scheme: "https".to_string(),
-        hostname,
-        port: Some(999),
-        proxy: None,
-    });
-    for key in poolkeys.clone() {
-        pool.add(key, Stream::from_vec(vec![]))
-    }
-    assert_eq!(pool.len(), pool.max_idle_connections);
-
-    for key in poolkeys.skip(pool.max_idle_connections) {
-        let result = pool.remove(&key);
-        assert!(result.is_some(), "expected key was not in pool");
-    }
-    assert_eq!(pool.len(), 0)
-}
-
-#[test]
-fn pool_per_host_connections_limit() {
-    // Test inserting connections with the same key into the pool,
-    // filling and draining it. The pool should evict earlier connections
-    // when the per-host connection limit is reached.
-    let pool = ConnectionPool::new_with_limits(10, 2);
-    let poolkey = PoolKey {
-        scheme: "https".to_string(),
-        hostname: "example.com".to_string(),
-        port: Some(999),
-        proxy: None,
-    };
-
-    for _ in 0..pool.max_idle_connections_per_host * 2 {
-        pool.add(poolkey.clone(), Stream::from_vec(vec![]))
-    }
-    assert_eq!(pool.len(), pool.max_idle_connections_per_host);
-
-    for _ in 0..pool.max_idle_connections_per_host {
-        let result = pool.remove(&poolkey);
-        assert!(result.is_some(), "expected key was not in pool");
-    }
-    assert_eq!(pool.len(), 0);
-}
-
-#[test]
-fn pool_checks_proxy() {
-    // Test inserting different poolkeys with same address but different proxies.
-    // Each insertion should result in an additional entry in the pool.
-    let pool = ConnectionPool::new_with_limits(10, 1);
-    let url = Url::parse("zzz:///example.com").unwrap();
-
-    pool.add(PoolKey::new(&url, None), Stream::from_vec(vec![]));
-    assert_eq!(pool.len(), 1);
-
-    pool.add(
-        PoolKey::new(&url, Some(Proxy::new("localhost:9999").unwrap())),
-        Stream::from_vec(vec![]),
-    );
-    assert_eq!(pool.len(), 2);
-
-    pool.add(
-        PoolKey::new(
-            &url,
-            Some(Proxy::new("user:password@localhost:9999").unwrap()),
-        ),
-        Stream::from_vec(vec![]),
-    );
-    assert_eq!(pool.len(), 3);
-}
-
 /// Read wrapper that returns the stream to the pool once the
 /// read is exhausted (reached a 0).
 ///
@@ -358,5 +276,92 @@ impl<R: Read + Sized + Into<Stream>> Read for PoolReturnRead<R> {
             self.return_connection()?;
         }
         Ok(amount)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poolkey_new() {
+        // Test that PoolKey::new() does not panic on unrecognized schemes.
+        PoolKey::new(&Url::parse("zzz:///example.com").unwrap(), None);
+    }
+
+    #[test]
+    fn pool_connections_limit() {
+        // Test inserting connections with different keys into the pool,
+        // filling and draining it. The pool should evict earlier connections
+        // when the connection limit is reached.
+        let pool = ConnectionPool::new_with_limits(10, 1);
+        let hostnames = (0..pool.max_idle_connections * 2).map(|i| format!("{}.example", i));
+        let poolkeys = hostnames.map(|hostname| PoolKey {
+            scheme: "https".to_string(),
+            hostname,
+            port: Some(999),
+            proxy: None,
+        });
+        for key in poolkeys.clone() {
+            pool.add(key, Stream::from_vec(vec![]))
+        }
+        assert_eq!(pool.len(), pool.max_idle_connections);
+
+        for key in poolkeys.skip(pool.max_idle_connections) {
+            let result = pool.remove(&key);
+            assert!(result.is_some(), "expected key was not in pool");
+        }
+        assert_eq!(pool.len(), 0)
+    }
+
+    #[test]
+    fn pool_per_host_connections_limit() {
+        // Test inserting connections with the same key into the pool,
+        // filling and draining it. The pool should evict earlier connections
+        // when the per-host connection limit is reached.
+        let pool = ConnectionPool::new_with_limits(10, 2);
+        let poolkey = PoolKey {
+            scheme: "https".to_string(),
+            hostname: "example.com".to_string(),
+            port: Some(999),
+            proxy: None,
+        };
+
+        for _ in 0..pool.max_idle_connections_per_host * 2 {
+            pool.add(poolkey.clone(), Stream::from_vec(vec![]))
+        }
+        assert_eq!(pool.len(), pool.max_idle_connections_per_host);
+
+        for _ in 0..pool.max_idle_connections_per_host {
+            let result = pool.remove(&poolkey);
+            assert!(result.is_some(), "expected key was not in pool");
+        }
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn pool_checks_proxy() {
+        // Test inserting different poolkeys with same address but different proxies.
+        // Each insertion should result in an additional entry in the pool.
+        let pool = ConnectionPool::new_with_limits(10, 1);
+        let url = Url::parse("zzz:///example.com").unwrap();
+
+        pool.add(PoolKey::new(&url, None), Stream::from_vec(vec![]));
+        assert_eq!(pool.len(), 1);
+
+        pool.add(
+            PoolKey::new(&url, Some(Proxy::new("localhost:9999").unwrap())),
+            Stream::from_vec(vec![]),
+        );
+        assert_eq!(pool.len(), 2);
+
+        pool.add(
+            PoolKey::new(
+                &url,
+                Some(Proxy::new("user:password@localhost:9999").unwrap()),
+            ),
+            Stream::from_vec(vec![]),
+        );
+        assert_eq!(pool.len(), 3);
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -171,8 +171,7 @@ Proxy-Connection: Keep-Alive\r\n\
 
 #[cfg(test)]
 mod tests {
-    use super::Proto;
-    use super::Proxy;
+    use super::*;
 
     #[test]
     fn parse_proxy_fakeproto() {

--- a/src/request.rs
+++ b/src/request.rs
@@ -397,25 +397,30 @@ impl Request {
     }
 }
 
-#[test]
-fn request_implements_send_and_sync() {
-    let _request: Box<dyn Send> = Box::new(Request::new(
-        Agent::new(),
-        "GET".to_string(),
-        "https://example.com/".to_string(),
-    ));
-    let _request: Box<dyn Sync> = Box::new(Request::new(
-        Agent::new(),
-        "GET".to_string(),
-        "https://example.com/".to_string(),
-    ));
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn send_byte_slice() {
-    let bytes = vec![1, 2, 3];
-    crate::agent()
-        .post("http://example.com")
-        .send(&bytes[1..2])
-        .ok();
+    #[test]
+    fn request_implements_send_and_sync() {
+        let _request: Box<dyn Send> = Box::new(Request::new(
+            Agent::new(),
+            "GET".to_string(),
+            "https://example.com/".to_string(),
+        ));
+        let _request: Box<dyn Sync> = Box::new(Request::new(
+            Agent::new(),
+            "GET".to_string(),
+            "https://example.com/".to_string(),
+        ));
+    }
+
+    #[test]
+    fn send_byte_slice() {
+        let bytes = vec![1, 2, 3];
+        crate::agent()
+            .post("http://example.com")
+            .send(&bytes[1..2])
+            .ok();
+    }
 }


### PR DESCRIPTION
Idiomatic rust organizes unit tests into `mod tests { }` blocks
using conditional compilation `[cfg(test)]` to decide whether to
compile the code in that block.

This commit moves "bare" test functions into such blocks, and puts
the block at the bottom of respective file.