### PR TITLE
Upgrade cookie to 0.15 and cookie_store to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ socks-proxy = ["socks"]
 [dependencies]
 base64 = "0.13"
 chunked_transfer = "1.2.0"
-cookie = { version = "0.14", features = ["percent-encode"], optional = true}
+cookie = { version = "0.15", features = ["percent-encode"], optional = true}
 once_cell = "1"
 url = "2"
 socks = { version = "0.3.2", optional = true }
@@ -37,7 +37,7 @@ rustls-native-certs = { version = "0.5", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
-cookie_store = { version = "0.12.0", optional = true }
+cookie_store = { version = "0.13.0", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4.11"
 
 [dev-dependencies]

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -43,6 +43,6 @@ impl CookieTin {
         I: Iterator<Item = cookie::Cookie<'static>>,
     {
         let mut store = self.inner.write().unwrap();
-        store.store_response_cookies(cookies, url)
+        store.store_response_cookies(cookies, url);
     }
 }


### PR DESCRIPTION
cookie_store default features pulls in reqwest, so we stop that
by specifying the exact features wanted.