### PR TITLE
Add RequestUrl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,7 @@ pub use crate::error::{Error, ErrorKind, OrAnyStatus, Transport};
 pub use crate::header::Header;
 pub use crate::proxy::Proxy;
 pub use crate::request::Request;
+pub use crate::request::RequestUrl;
 pub use crate::resolve::Resolver;
 pub use crate::response::Response;
 


### PR DESCRIPTION
This provides a way to access the URL that will be used for a
currently-being-built Request. This is particularly useful for building
Requests that need signing, since you can access the parsed values of
query parameters.

@algesten this is my proposed alternative to #340. My reasoning is
that a user who wants access to the query pairs is likely to also want
the scheme, host, path, etc. By putting them on one object we can keep
the cognitive burden of Request small, while still making accessors that
return the types we want (&str).