### PR TITLE
Remove specialized error message for complete_io.

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -353,10 +353,8 @@ pub(crate) fn connect_https(unit: &Unit, hostname: &str) -> Result<Stream, Error
     let mut sock = connect_host(unit, hostname, port)?;
     let mut sess = rustls::ClientSession::new(&tls_conf, sni);
 
-    sess.complete_io(&mut sock).map_err(|err| {
-        ErrorKind::ConnectionFailed.new()
-            .src(err)
-    })?;
+    sess.complete_io(&mut sock)
+        .map_err(|err| ErrorKind::ConnectionFailed.new().src(err))?;
     let stream = rustls::StreamOwned::new(sess, sock);
 
     Ok(Stream::from_tls_stream(stream))

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -354,8 +354,7 @@ pub(crate) fn connect_https(unit: &Unit, hostname: &str) -> Result<Stream, Error
     let mut sess = rustls::ClientSession::new(&tls_conf, sni);
 
     sess.complete_io(&mut sock).map_err(|err| {
-        ErrorKind::ConnectionFailed
-            .msg("error during TLS handshake. Sometimes this means the host doesn't support any of the same ciphersuites as rustls, or doesn't support TLS 1.2 and above")
+        ErrorKind::ConnectionFailed.new()
             .src(err)
     })?;
     let stream = rustls::StreamOwned::new(sess, sock);


### PR DESCRIPTION
This was triggering for errors like InvalidCertificate and giving the
message "Sometimes this means the host doesn't support any of the same
ciphersuites as rustls, or doesn't support TLS 1.2 and above," which is
confusing in that situation.

For now, offer no specialized error. I'd like to come back when I find
more time and restore this, but only for the error cases where it's
useful.