### PR TITLE
Url access functions for Request (simpler)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ pub use crate::agent::AgentBuilder;
 pub use crate::error::{Error, ErrorKind, OrAnyStatus, Transport};
 pub use crate::header::Header;
 pub use crate::proxy::Proxy;
-pub use crate::request::Request;
+pub use crate::request::{Request, RequestUrl};
 pub use crate::resolve::Resolver;
 pub use crate::response::Response;
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -229,7 +229,8 @@ fn connect_inner(
     let host = unit
         .url
         .host_str()
-        .ok_or_else(|| ErrorKind::InvalidUrl.msg("no host in URL"))?;
+        // This unwrap is ok because Request::parse_url() ensure there is always a host present.
+        .unwrap();
     let url = &unit.url;
     let method = &unit.method;
     // open socket


### PR DESCRIPTION
@jsha Here's a take from scratch with keeping an internal `url: String` and no parsed state.

It keeps `query_pairs` in sync with `url`, and there is parsing on every `query()` call, but I actually quite like this one a lot because it's simple.