### PR TITLE
Stop percent encoding cookies and enforce RFC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ socks-proxy = ["socks"]
 [dependencies]
 base64 = "0.13"
 chunked_transfer = "1.2.0"
-cookie = { version = "0.15", features = ["percent-encode"], optional = true}
+cookie = { version = "0.15", deafult-features = false, optional = true}
 once_cell = "1"
 url = "2"
 socks = { version = "0.3.2", optional = true }

--- a/src/header.rs
+++ b/src/header.rs
@@ -190,7 +190,7 @@ fn valid_name(name: &[u8]) -> bool {
 }
 
 #[inline]
-fn is_tchar(b: &u8) -> bool {
+pub(crate) fn is_tchar(b: &u8) -> bool {
     match b {
         b'!' | b'#' | b'$' | b'%' | b'&' => true,
         b'\'' | b'*' | b'+' | b'-' | b'.' => true,

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -472,28 +472,7 @@ fn is_cookie_rfc_compliant(cookie: &Cookie) -> bool {
     //                       | "{" | "}" | SP | HT
 
     fn is_valid_name(b: &u8) -> bool {
-        b.is_ascii()
-            && !b.is_ascii_control()
-            && !b.is_ascii_whitespace()
-            && *b != b'('
-            && *b != b')'
-            && *b != b'<'
-            && *b != b'>'
-            && *b != b'@'
-            && *b != b','
-            && *b != b';'
-            && *b != b':'
-            && *b != b'\\'
-            && *b != b'\"'
-            && *b != b'/'
-            && *b != b'['
-            && *b != b']'
-            && *b != b'?'
-            && *b != b'='
-            && *b != b'{'
-            && *b != b'}'
-            && *b != b' '
-            && *b != b'\t'
+        header::is_tchar(b)
     }
 
     fn is_valid_value(b: &u8) -> bool {


### PR DESCRIPTION
Close #315
Superseds #338 

Stop ureq from percent-encoding cookie name/values.

Enforce RFC 6265 and 2616 for cookie name/values.