### PR TITLE
Fix clippy warnings and run as lint in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run Rustfmt
       run: cargo fmt -- --check
-
+    - name: Run Clippy
+      run: RUSTFLAGS="-D warnings" cargo clippy      
   doc:
     name: Docs
     runs-on: ubuntu-latest

--- a/src/error.rs
+++ b/src/error.rs
@@ -288,6 +288,8 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
+    #[allow(clippy::wrong_self_convention)]
+    #[allow(clippy::new_ret_no_self)]
     pub(crate) fn new(self) -> Error {
         Error::new(self, None)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::all)]
+// new is just more readable than ..Default::default().
+#![allow(clippy::new_without_default)]
+// the matches! macro is obscure and not widely known.
+#![allow(clippy::match_like_matches_macro)]
+
 //! A simple, safe HTTP client.
 //!
 //! Ureq's first priority is being easy for you to use. It's great for
@@ -327,8 +332,7 @@ pub fn is_test(is: bool) -> bool {
     if is {
         IS_TEST.store(true, Ordering::SeqCst);
     }
-    let x = IS_TEST.load(Ordering::SeqCst);
-    x
+    IS_TEST.load(Ordering::SeqCst)
 }
 
 /// Agents are used to hold configuration and keep state between requests.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -46,7 +46,9 @@ impl Proxy {
         match host {
             Some(host) => {
                 let mut parts = host.as_ref().split(':').collect::<Vec<&str>>().into_iter();
-                let host = parts.next().ok_or(ErrorKind::InvalidProxyUrl.new())?;
+                let host = parts
+                    .next()
+                    .ok_or_else(|| ErrorKind::InvalidProxyUrl.new())?;
                 let port = parts.next();
                 Ok((
                     String::from(host),
@@ -155,11 +157,11 @@ Proxy-Connection: Keep-Alive\r\n\
         let top_line = response_string
             .lines()
             .next()
-            .ok_or(ErrorKind::ProxyConnect.new())?;
+            .ok_or_else(|| ErrorKind::ProxyConnect.new())?;
         let status_code = top_line
             .split_whitespace()
             .nth(1)
-            .ok_or(ErrorKind::ProxyConnect.new())?;
+            .ok_or_else(|| ErrorKind::ProxyConnect.new())?;
 
         match status_code {
             "200" => Ok(()),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -25,6 +25,7 @@ pub(crate) struct Stream {
     inner: BufReader<Inner>,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum Inner {
     Http(TcpStream),
     #[cfg(feature = "tls")]

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -36,7 +36,7 @@ impl Unit {
         agent: &Agent,
         method: &str,
         url: &Url,
-        headers: &Vec<Header>,
+        headers: &[Header],
         body: &SizedReader,
         deadline: Option<time::Instant>,
     ) -> Self {
@@ -229,7 +229,7 @@ fn connect_inner(
     let host = unit
         .url
         .host_str()
-        .ok_or(ErrorKind::InvalidUrl.msg("no host in URL"))?;
+        .ok_or_else(|| ErrorKind::InvalidUrl.msg("no host in URL"))?;
     let url = &unit.url;
     let method = &unit.method;
     // open socket


### PR DESCRIPTION
Fixes all clippy warnings by either addressing the problem or disabling the lint. 

Also start running clippy as part of CI build.