### PR TITLE
Provide url in Response Debug impl

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -74,10 +74,14 @@ impl fmt::Debug for Response {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Response[status: {}, status_text: {}]",
+            "Response[status: {}, status_text: {}",
             self.status(),
-            self.status_text()
-        )
+            self.status_text(),
+        )?;
+        if let Some(url) = &self.url {
+            write!(f, ", url: {}", url)?;
+        }
+        write!(f, "]")
     }
 }
 


### PR DESCRIPTION
Close #232 

Probably ok without the request method. This solves #232 by virtue of `Response` being part of `Error`. Example:

```rust
pub fn main() {
    let x = ureq::get("https://httpbin.org/status/404").call();
    println!("{:?}", x);
}
```

`Err(Status(404, Response[status: 404, status_text: NOT FOUND, url: https://httpbin.org/status/404]))`