### PR TITLE
Rename types to follow Rust conventions

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -38,7 +38,7 @@ pub(crate) struct AgentConfig {
     pub redirects: u32,
     pub user_agent: String,
     #[cfg(feature = "tls")]
-    pub tls_config: Option<TLSClientConfig>,
+    pub tls_config: Option<TlsClientConfig>,
 }
 
 /// Agents keep state between requests.
@@ -485,7 +485,7 @@ impl AgentBuilder {
     /// ```
     #[cfg(feature = "tls")]
     pub fn tls_config(mut self, tls_config: Arc<rustls::ClientConfig>) -> Self {
-        self.config.tls_config = Some(TLSClientConfig(tls_config));
+        self.config.tls_config = Some(TlsClientConfig(tls_config));
         self
     }
 
@@ -524,10 +524,10 @@ impl AgentBuilder {
 
 #[cfg(feature = "tls")]
 #[derive(Clone)]
-pub(crate) struct TLSClientConfig(pub(crate) Arc<rustls::ClientConfig>);
+pub(crate) struct TlsClientConfig(pub(crate) Arc<rustls::ClientConfig>);
 
 #[cfg(feature = "tls")]
-impl std::fmt::Debug for TLSClientConfig {
+impl std::fmt::Debug for TlsClientConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TLSClientConfig").finish()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -226,7 +226,7 @@ impl Error {
     /// ```
     pub fn kind(&self) -> ErrorKind {
         match self {
-            Error::Status(_, _) => ErrorKind::HTTP,
+            Error::Status(_, _) => ErrorKind::Http,
             Error::Transport(Transport { kind: k, .. }) => *k,
         }
     }
@@ -284,7 +284,7 @@ pub enum ErrorKind {
     /// HTTP status code indicating an error (e.g. 4xx, 5xx)
     /// Read the inner response body for details and to return
     /// the connection to the pool.
-    HTTP,
+    Http,
 }
 
 impl ErrorKind {
@@ -339,7 +339,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::InvalidProxyUrl => write!(f, "Malformed proxy"),
             ErrorKind::ProxyConnect => write!(f, "Proxy failed to connect"),
             ErrorKind::ProxyUnauthorized => write!(f, "Provided proxy credentials are incorrect"),
-            ErrorKind::HTTP => write!(f, "HTTP status error"),
+            ErrorKind::Http => write!(f, "HTTP status error"),
         }
     }
 }
@@ -381,7 +381,7 @@ mod tests {
         });
 
         let err = get("test://example.org/redirect_a").call().unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::HTTP, "{:?}", err);
+        assert_eq!(err.kind(), ErrorKind::Http, "{:?}", err);
         assert_eq!(
         err.to_string(),
         "http://example.com/status/500: status code 500 (redirected from test://example.org/redirect_a)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 #![allow(clippy::new_without_default)]
 // the matches! macro is obscure and not widely known.
 #![allow(clippy::match_like_matches_macro)]
-// we're not changing public api due to a lint.
-#![allow(clippy::upper_case_acronyms)]
 
 //! A simple, safe HTTP client.
 //!

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -3,8 +3,8 @@ use crate::error::{Error, ErrorKind};
 /// Proxy protocol
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Proto {
-    HTTPConnect,
-    SOCKS5,
+    HttpConnect,
+    Socks5,
 }
 
 /// Proxy server definition
@@ -83,13 +83,13 @@ impl Proxy {
 
         let proto = if proxy_parts.len() == 2 {
             match proxy_parts.next() {
-                Some("http") => Proto::HTTPConnect,
-                Some("socks") => Proto::SOCKS5,
-                Some("socks5") => Proto::SOCKS5,
+                Some("http") => Proto::HttpConnect,
+                Some("socks") => Proto::Socks5,
+                Some("socks5") => Proto::Socks5,
                 _ => return Err(ErrorKind::InvalidProxyUrl.new()),
             }
         } else {
-            Proto::HTTPConnect
+            Proto::HttpConnect
         };
 
         let remaining_parts = proxy_parts.next();
@@ -130,8 +130,8 @@ impl Proxy {
             ));
 
             match self.proto {
-                Proto::HTTPConnect => format!("Proxy-Authorization: basic {}\r\n", creds),
-                Proto::SOCKS5 => String::new(),
+                Proto::HttpConnect => format!("Proxy-Authorization: basic {}\r\n", creds),
+                Proto::Socks5 => String::new(),
             }
         } else {
             String::new()
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(proxy.password, Some(String::from("p@ssw0rd")));
         assert_eq!(proxy.server, String::from("localhost"));
         assert_eq!(proxy.port, 9999);
-        assert_eq!(proxy.proto, Proto::HTTPConnect);
+        assert_eq!(proxy.proto, Proto::HttpConnect);
     }
 
     #[cfg(feature = "socks-proxy")]
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(proxy.password, Some(String::from("p@ssw0rd")));
         assert_eq!(proxy.server, String::from("localhost"));
         assert_eq!(proxy.port, 9999);
-        assert_eq!(proxy.proto, Proto::SOCKS5);
+        assert_eq!(proxy.proto, Proto::Socks5);
     }
 
     #[cfg(feature = "socks-proxy")]
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(proxy.password, Some(String::from("p@ssw0rd")));
         assert_eq!(proxy.server, String::from("localhost"));
         assert_eq!(proxy.port, 9999);
-        assert_eq!(proxy.proto, Proto::SOCKS5);
+        assert_eq!(proxy.proto, Proto::Socks5);
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -2,7 +2,7 @@ use crate::error::{Error, ErrorKind};
 
 /// Proxy protocol
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum Proto {
+pub(crate) enum Proto {
     HttpConnect,
     Socks5,
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -402,7 +402,7 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
 
         debug!("connecting to {} at {}", netloc, &sock_addr);
         // connect with a configured timeout.
-        let stream = if Some(Proto::SOCKS5) == proto {
+        let stream = if Some(Proto::Socks5) == proto {
             connect_socks5(
                 &unit,
                 proxy.clone().unwrap(),
@@ -445,7 +445,7 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
         stream.set_write_timeout(unit.agent.config.timeout_write)?;
     }
 
-    if proto == Some(Proto::HTTPConnect) {
+    if proto == Some(Proto::HttpConnect) {
         if let Some(ref proxy) = proxy {
             write!(stream, "{}", proxy.connect(hostname, port)).unwrap();
             stream.flush()?;


### PR DESCRIPTION
This is a breaking API change.

Uncertain if we want to land it, but  wan to open for the discussion. I noticed the change in a crate we depend on, and was thinking maybe we should follow along? https://github.com/briansmith/webpki/commit/5b67fb92dacf216d11e26f99f4b972e24deabd4c

The breaking change is that `ErrorKind::HTTP` is now `ErrorKind::Http`
