### PR TITLE
Update to webpki and webpki-roots 0.22.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ once_cell = "1"
 url = "2"
 socks = { version = "0.3.2", optional = true }
 rustls = { version = "0.19", optional = true }
-webpki = { version = "0.21", optional = true }
-webpki-roots = { version = "0.21", optional = true }
+webpki = { version = "0.22", optional = true }
+webpki-roots = { version = "0.22", optional = true }
 rustls-native-certs = { version = "0.5", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }

--- a/examples/cureq/main.rs
+++ b/examples/cureq/main.rs
@@ -9,7 +9,7 @@ use rustls::{
     Certificate, ClientConfig, RootCertStore, ServerCertVerified, ServerCertVerifier, TLSError,
 };
 use ureq;
-use webpki::DNSNameRef;
+use webpki::DnsNameRef;
 
 #[derive(Debug)]
 struct StringError(String);
@@ -102,7 +102,7 @@ impl ServerCertVerifier for AcceptAll {
         &self,
         _roots: &RootCertStore,
         _presented_certs: &[Certificate],
-        _dns_name: DNSNameRef<'_>,
+        _dns_name: DnsNameRef<'_>,
         _ocsp_response: &[u8],
     ) -> Result<ServerCertVerified, TLSError> {
         Ok(ServerCertVerified::assertion())

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -355,8 +355,8 @@ pub(crate) fn connect_https(unit: &Unit, hostname: &str) -> Result<Stream, Error
 
     let port = unit.url.port().unwrap_or(443);
 
-    let sni = webpki::DNSNameRef::try_from_ascii_str(hostname)
-        .map_err(|err| ErrorKind::Dns.new().src(err))?;
+    let sni = webpki::DnsNameRef::try_from_ascii_str(hostname)
+        .map_err(|err| ErrorKind::Dns.msg("invalid DNS name"))?;
     let tls_conf: &Arc<rustls::ClientConfig> = unit
         .agent
         .config


### PR DESCRIPTION
Can't be merged until rustls updates to these versions, because some of
the types that we have to send into rustls have been renamed.