### PR TITLE
Use native-tls on platforms that need it, and remove "tls" feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    env: 
+    env:
       RUSTFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
         with:
           command: doc
           # Keep in sync with Cargo.toml's [package.metadata.docs.rs]
-          args: --no-default-features --no-deps --features "tls json charset cookies socks-proxy"
+          args: --no-default-features --no-deps --features "tls native-tls json charset cookies socks-proxy"
   build_and_test:
     name: Test
     runs-on: ubuntu-latest
@@ -47,13 +47,15 @@ jobs:
       matrix:
         tls:
           - ""
-          - tls
+          - "tls"
+          - "native-tls"
         feature:
           - ""
           - json
           - charset
           - cookies
           - socks-proxy
+          - native-tls-adapter
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"
@@ -68,4 +70,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features "${{ matrix.tls }} ${{ matrix.feature }}"
+          args: --no-default-features --features "${{ matrix.tls }}" "${{ matrix.feature }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,6 @@ jobs:
           - charset
           - cookies
           - socks-proxy
-          - native-tls-adapter
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.3.0
+ * Upgarde to rustls 0.20 (#427).
+ * Make test mocks of Response more accurate by removing newline (#423).
+ * Redact sensitive headers when logging prelude (#414).
+
 # 2.2.0
  * Update to latest dependencies
  * Add SOCKS4 support (#410).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 # Keep in sync with .github/workflows/test.yml
-features = [ "tls", "json", "charset", "cookies", "socks-proxy" ]
+features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy"]
 
 [features]
 default = ["tls"]
+tls = ["webpki", "webpki-roots", "rustls"]
+native-certs = ["rustls-native-certs"]
 json = ["serde", "serde_json"]
 charset = ["encoding_rs"]
-tls = ["rustls", "webpki", "webpki-roots"]
-native-certs = ["rustls-native-certs"]
 cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
 
@@ -30,15 +30,21 @@ cookie = { version = "0.15", default-features = false, optional = true}
 once_cell = "1"
 url = "2"
 socks = { version = "0.3", optional = true }
-rustls = { version = "0.20", optional = true }
-webpki = { version = "0.22", optional = true }
-webpki-roots = { version = "0.22", optional = true }
-rustls-native-certs = { version = "0.5", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 cookie_store = { version = "0.15", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4"
+webpki = { version = "0.21", optional = true }
+webpki-roots = { version = "0.21", optional = true }
+rustls = { version = "0.20", optional = true }
+rustls-native-certs = { version = "0.5", optional = true }
+native-tls = { version = "0.2", optional = true }
+
+# rustls is only supported on x86, x86-64, armv7, and aarch64
+# https://github.com/rustls/rustls#platform-support
+[target.'cfg(not(any(target_arch="x86", target_arch="x86_64", target_arch="armv7", target_arch="aarch64")))'.dependencies]
+native-tls = { version = "0.2" }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -51,4 +57,4 @@ name = "smoke-test"
 
 [[example]]
 name = "cureq"
-required-features = ["charset", "cookies", "socks-proxy"]
+required-features = ["charset", "cookies", "socks-proxy", "native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 cookie_store = { version = "0.15", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4"
-webpki = { version = "0.21", optional = true }
-webpki-roots = { version = "0.21", optional = true }
+webpki = { version = "0.22", optional = true }
+webpki-roots = { version = "0.22", optional = true }
 rustls = { version = "0.20", optional = true }
 rustls-native-certs = { version = "0.5", optional = true }
 native-tls = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ureq"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Martin Algesten <martin@algesten.se>", "Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>"]
 description = "Simple, safe HTTP client"
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can control them when including ureq as a dependency.
 * `native-tls` enables an adapter so you can pass a `native_tls::TlsConnector` instance
   to `AgentBuilder::tls_connector`. Due to the risk of diamond dependencies accidentally switching on an unwanted
   TLS implementation, `native-tls` is never picked up as a default or used by the crate level
-  convencience calls (`ureq::get` etc) – it must be configured.
+  convenience calls (`ureq::get` etc) – it must be configured.
 
 ## Plain requests
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HTTPS, and charset decoding.
 Ureq is in pure Rust for safety and ease of understanding. It avoids using
 `unsafe` directly. It [uses blocking I/O][blocking] instead of async I/O, because that keeps
 the API simple and and keeps dependencies to a minimum. For TLS, ureq uses
-[rustls].
+[rustls or native-tls](#tls).
 
 Version 2.0.0 was released recently and changed some APIs. See the [changelog] for details.
 
@@ -100,13 +100,16 @@ You can control them when including ureq as a dependency.
 
 `ureq = { version = "*", features = ["json", "charset"] }`
 
-* `tls` enables https. This is enabled by default.
 * `cookies` enables cookies.
 * `json` enables [Response::into_json()] and [Request::send_json()] via serde_json.
 * `charset` enables interpreting the charset part of the Content-Type header
    (e.g.  `Content-Type: text/plain; charset=iso-8859-1`). Without this, the
    library defaults to Rust's built in `utf-8`.
 * `socks-proxy` enables proxy config using the `socks4://`, `socks4a://`, `socks5://` and `socks://` (equal to `socks5://`) prefix.
+* `native-tls` enables an adapter so you can pass a `native_tls::TlsConnector` instance
+  to `AgentBuilder::tls_connector`. Due to the risk of diamond dependencies accidentally switching on an unwanted
+  TLS implementation, `native-tls` is never picked up as a default or used by the crate level
+  convencience calls (`ureq::get` etc) – it must be configured.
 
 ## Plain requests
 
@@ -210,6 +213,39 @@ fn proxy_example_2() -> std::result::Result<(), ureq::Error> {
     Ok(())
 }
 ```
+
+## HTTPS / TLS / SSL
+
+On platforms that support rustls, ureq uses rustls. On other platforms, native-tls can
+be manually configured using [`AgentBuilder::tls_connector`].
+
+You might want to use native-tls if you need to interoperate with servers that
+only support less-secure TLS configurations (rustls doesn't support TLS 1.0 and 1.1, for
+instance). You might also want to use it if you need to validate certificates for IP addresses,
+which are not currently supported in rustls.
+
+Here's an example of constructing an Agent that uses native-tls. It requires the
+"native-tls" feature to be enabled.
+
+```rust
+  use std::sync::Arc;
+  use ureq::Agent;
+
+  let agent = ureq::AgentBuilder::new()
+      .tls_connector(Arc::new(native_tls::TlsConnector::new().unwrap()))
+      .build();
+```
+
+### Trusted Roots
+
+When you use rustls, ureq defaults to trusting [webpki-roots](https://docs.rs/webpki-roots/), a
+copy of the Mozilla Root program that is bundled into your program (and so won't update if your
+program isn't updated). You can alternately configure
+[rustls-native-certs](https://docs.rs/rustls-native-certs/) which extracts the roots from your
+OS' trust store. That means it will update when your OS is updated, and also that it will
+include locally installed roots.
+
+When you use native-tls, ureq will use your OS' certificate verifier and root store.
 
 ## Blocking I/O for simplicity
 

--- a/examples/cureq/main.rs
+++ b/examples/cureq/main.rs
@@ -3,13 +3,14 @@ use std::fmt;
 use std::io;
 use std::thread;
 use std::time::Duration;
+use std::time::SystemTime;
 use std::{env, sync::Arc};
 
-use rustls::{
-    Certificate, ClientConfig, RootCertStore, ServerCertVerified, ServerCertVerifier, TLSError,
-};
+use rustls::client::ServerCertVerified;
+use rustls::client::ServerCertVerifier;
+use rustls::ServerName;
+use rustls::{Certificate, ClientConfig};
 use ureq;
-use webpki::DNSNameRef;
 
 #[derive(Debug)]
 struct StringError(String);
@@ -100,11 +101,13 @@ struct AcceptAll {}
 impl ServerCertVerifier for AcceptAll {
     fn verify_server_cert(
         &self,
-        _roots: &RootCertStore,
-        _presented_certs: &[Certificate],
-        _dns_name: DNSNameRef<'_>,
+        _end_entity: &Certificate,
+        _intermediates: &[Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
         _ocsp_response: &[u8],
-    ) -> Result<ServerCertVerified, TLSError> {
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
         Ok(ServerCertVerified::assertion())
     }
 }
@@ -132,6 +135,7 @@ fn main2() -> Result<(), Error> {
 -k            Ignore certificate errors
 -m <time>     Max time for the entire request
 -ct <time>    Connection timeout
+--native-tls  Use native-tls
 
 Fetch url and copy it to stdout.
 "##,
@@ -160,11 +164,14 @@ Fetch url and copy it to stdout.
                 wait = Duration::from_secs(wait_seconds);
             }
             "-k" => {
-                let mut client_config = ClientConfig::new();
-                client_config
-                    .dangerous()
-                    .set_certificate_verifier(Arc::new(AcceptAll {}));
+                let client_config = ClientConfig::builder()
+                    .with_safe_defaults()
+                    .with_custom_certificate_verifier(Arc::new(AcceptAll {}))
+                    .with_no_client_auth();
                 builder = builder.tls_config(Arc::new(client_config));
+            }
+            "--native-tls" => {
+                builder = builder.tls_connector(Arc::new(native_tls::TlsConnector::new().unwrap()));
             }
             "-m" => {
                 let t: f32 = args

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::Arc;
 
 use url::Url;
@@ -6,6 +7,7 @@ use crate::pool::ConnectionPool;
 use crate::proxy::Proxy;
 use crate::request::Request;
 use crate::resolve::{ArcResolver, StdResolver};
+use crate::stream::TlsConnector;
 use std::time::Duration;
 
 #[cfg(feature = "cookies")]
@@ -28,7 +30,7 @@ pub struct AgentBuilder {
 }
 
 /// Config as built by AgentBuilder and then static for the lifetime of the Agent.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct AgentConfig {
     pub proxy: Option<Proxy>,
     pub timeout_connect: Option<Duration>,
@@ -37,8 +39,13 @@ pub(crate) struct AgentConfig {
     pub timeout: Option<Duration>,
     pub redirects: u32,
     pub user_agent: String,
-    #[cfg(feature = "tls")]
-    pub tls_config: Option<TLSClientConfig>,
+    pub tls_config: Arc<dyn TlsConnector>,
+}
+
+impl fmt::Debug for AgentConfig {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
 }
 
 /// Agents keep state between requests.
@@ -210,8 +217,7 @@ impl AgentBuilder {
                 timeout: None,
                 redirects: 5,
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
-                #[cfg(feature = "tls")]
-                tls_config: None,
+                tls_config: crate::default_tls_config(),
             },
             max_idle_connections: DEFAULT_MAX_IDLE_CONNECTIONS,
             max_idle_connections_per_host: DEFAULT_MAX_IDLE_CONNECTIONS_PER_HOST,
@@ -467,9 +473,10 @@ impl AgentBuilder {
         self
     }
 
-    /// Set the TLS client config to use for the connection. See [`ClientConfig`](https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html).
+    /// Configure TLS options for rustls to use when making HTTPS connections from this Agent.
     ///
-    /// Example:
+    /// This overrides any previous call to tls_config or tls_connector.
+    ///
     /// ```
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
@@ -492,10 +499,34 @@ impl AgentBuilder {
     ///     .build();
     /// # Ok(())
     /// # }
-    /// ```
     #[cfg(feature = "tls")]
     pub fn tls_config(mut self, tls_config: Arc<rustls::ClientConfig>) -> Self {
-        self.config.tls_config = Some(TLSClientConfig(tls_config));
+        self.config.tls_config = Arc::new(tls_config);
+        self
+    }
+
+    /// Configure TLS options for a backend other than rustls. The parameter can be a
+    /// any type which implements the [HttpsConnector] trait. If you enable the native-tls
+    /// feature, we provide `impl HttpsConnector for native_tls::TlsConnector` so you can pass
+    /// [`Arc<native_tls::TlsConnector>`](https://docs.rs/native-tls/0.2.7/native_tls/struct.TlsConnector.html).
+    ///
+    /// This overrides any previous call to tls_config or tls_connector.
+    ///
+    /// ```
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # ureq::is_test(true);
+    /// use std::sync::Arc;
+    /// # #[cfg(feature = "native-tls")]
+    /// let tls_connector = Arc::new(native_tls::TlsConnector::new().unwrap());
+    /// # #[cfg(feature = "native-tls")]
+    /// let agent = ureq::builder()
+    ///     .tls_connector(tls_connector.clone())
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tls_connector<T: TlsConnector + 'static>(mut self, tls_config: Arc<T>) -> Self {
+        self.config.tls_config = tls_config;
         self
     }
 
@@ -529,17 +560,6 @@ impl AgentBuilder {
     pub fn cookie_store(mut self, cookie_store: CookieStore) -> Self {
         self.cookie_store = Some(cookie_store);
         self
-    }
-}
-
-#[cfg(feature = "tls")]
-#[derive(Clone)]
-pub(crate) struct TLSClientConfig(pub(crate) Arc<rustls::ClientConfig>);
-
-#[cfg(feature = "tls")]
-impl std::fmt::Debug for TLSClientConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TLSClientConfig").finish()
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -64,7 +64,7 @@ impl fmt::Display for HeaderLine {
 
 #[derive(Clone, PartialEq)]
 /// Wrapper type for a header field.
-/// https://tools.ietf.org/html/rfc7230#section-3.2
+/// <https://tools.ietf.org/html/rfc7230#section-3.2>
 pub struct Header {
     // Line contains the unmodified bytes of single header field.
     // It does not contain the final CRLF.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@
 //! * `native-tls` enables an adapter so you can pass a `native_tls::TlsConnector` instance
 //!   to `AgentBuilder::tls_connector`. Due to the risk of diamond dependencies accidentally switching on an unwanted
 //!   TLS implementation, `native-tls` is never picked up as a default or used by the crate level
-//!   convencience calls (`ureq::get` etc) – it must be configured.
+//!   convenience calls (`ureq::get` etc) – it must be configured.
 //!
 //! # Plain requests
 //!
@@ -361,7 +361,8 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
             _dns_name: &str,
             _tcp_stream: TcpStream,
         ) -> Result<Box<dyn HttpsStream>, crate::error::Error> {
-            panic!("No TLS backend. Use feature 'tls' or AgentBuilder::tls_connector (native-tls is never configured as a default)");
+            Err(ErrorKind::UnknownScheme
+                .msg("cannot make HTTPS request because no TLS backend is configured"))
         }
     }
 

--- a/src/ntls.rs
+++ b/src/ntls.rs
@@ -1,0 +1,30 @@
+use crate::error::Error;
+use crate::error::ErrorKind;
+use crate::stream::{HttpsStream, TlsConnector};
+
+use std::net::TcpStream;
+use std::sync::Arc;
+
+#[allow(dead_code)]
+pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
+    Arc::new(native_tls::TlsConnector::new().unwrap())
+}
+
+impl TlsConnector for native_tls::TlsConnector {
+    fn connect(
+        &self,
+        dns_name: &str,
+        tcp_stream: TcpStream,
+    ) -> Result<Box<dyn HttpsStream>, Error> {
+        let stream = native_tls::TlsConnector::connect(self, dns_name, tcp_stream)
+            .map_err(|e| ErrorKind::Dns.new().src(e))?;
+        Ok(Box::new(stream))
+    }
+}
+
+#[cfg(feature = "native-tls")]
+impl HttpsStream for native_tls::TlsStream<TcpStream> {
+    fn socket(&self) -> Option<&TcpStream> {
+        Some(self.get_ref())
+    }
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -491,8 +491,8 @@ impl Response {
     }
 
     #[cfg(test)]
-    pub fn to_write_vec(self) -> Vec<u8> {
-        self.stream.to_write_vec()
+    pub fn as_write_vec(&self) -> &[u8] {
+        self.stream.as_write_vec()
     }
 
     #[cfg(test)]

--- a/src/rtls.rs
+++ b/src/rtls.rs
@@ -3,6 +3,8 @@ use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
 
+use once_cell::sync::Lazy;
+
 use crate::ErrorKind;
 use crate::{
     stream::{HttpsStream, TlsConnector},
@@ -63,7 +65,7 @@ fn root_certs() -> rustls::RootCertStore {
 }
 
 #[cfg(not(feature = "native-certs"))]
-fn root_certs(config: &mut rustls::ClientConfig) {
+fn root_certs() -> rustls::RootCertStore {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
         rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
@@ -97,7 +99,6 @@ impl TlsConnector for Arc<rustls::ClientConfig> {
 }
 
 pub fn default_tls_config() -> Arc<dyn TlsConnector> {
-    use once_cell::sync::Lazy;
     static TLS_CONF: Lazy<Arc<dyn TlsConnector>> = Lazy::new(|| {
         let config = rustls::ClientConfig::builder()
             .with_safe_defaults()

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -8,10 +8,6 @@ use std::{fmt, io::Cursor};
 
 use chunked_transfer::Decoder as ChunkDecoder;
 
-#[cfg(feature = "tls")]
-use rustls::ClientConnection;
-#[cfg(feature = "tls")]
-use rustls::StreamOwned;
 #[cfg(feature = "socks-proxy")]
 use socks::{TargetAddr, ToTargetAddr};
 
@@ -21,16 +17,83 @@ use crate::{error::Error, proxy::Proto};
 use crate::error::ErrorKind;
 use crate::unit::Unit;
 
-pub(crate) struct Stream {
-    inner: BufReader<Inner>,
+pub trait HttpsStream: Read + Write + Send + Sync + 'static {
+    fn socket(&self) -> Option<&TcpStream>;
 }
 
-#[allow(clippy::large_enum_variant)]
-enum Inner {
-    Http(TcpStream),
-    #[cfg(feature = "tls")]
-    Https(rustls::StreamOwned<rustls::ClientConnection, TcpStream>),
-    Test(Box<dyn Read + Send + Sync>, Vec<u8>),
+pub trait TlsConnector: Send + Sync {
+    fn connect(
+        &self,
+        dns_name: &str,
+        tcp_stream: TcpStream,
+    ) -> Result<Box<dyn HttpsStream>, crate::error::Error>;
+}
+
+pub(crate) struct Stream {
+    inner: BufReader<Box<dyn Inner + Send + Sync + 'static>>,
+}
+
+trait Inner: Read + Write {
+    fn is_poolable(&self) -> bool;
+    fn socket(&self) -> Option<&TcpStream>;
+    fn as_write_vec(&self) -> &[u8] {
+        panic!("as_write_vec on non Test stream");
+    }
+}
+
+impl<T: HttpsStream + ?Sized> HttpsStream for Box<T> {
+    fn socket(&self) -> Option<&TcpStream> {
+        HttpsStream::socket(self.as_ref())
+    }
+}
+
+impl<T: HttpsStream> Inner for T {
+    fn is_poolable(&self) -> bool {
+        true
+    }
+
+    fn socket(&self) -> Option<&TcpStream> {
+        HttpsStream::socket(self)
+    }
+}
+
+impl Inner for TcpStream {
+    fn is_poolable(&self) -> bool {
+        true
+    }
+    fn socket(&self) -> Option<&TcpStream> {
+        Some(self)
+    }
+}
+
+struct TestStream(Box<dyn Read + Send + Sync>, Vec<u8>);
+
+impl Inner for TestStream {
+    fn is_poolable(&self) -> bool {
+        false
+    }
+    fn socket(&self) -> Option<&TcpStream> {
+        None
+    }
+    fn as_write_vec(&self) -> &[u8] {
+        &self.1
+    }
+}
+
+impl Read for TestStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl Write for TestStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.1.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 // DeadlineStream wraps a stream such that read() will return an error
@@ -112,16 +175,20 @@ pub(crate) fn io_err_timeout(error: String) -> io::Error {
 
 impl fmt::Debug for Stream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.inner.get_ref() {
-            Inner::Http(tcpstream) => write!(f, "{:?}", tcpstream),
-            #[cfg(feature = "tls")]
-            Inner::Https(tlsstream) => write!(f, "{:?}", tlsstream.get_ref()),
-            Inner::Test(_, _) => write!(f, "Stream(Test)"),
+        match self.inner.get_ref().socket() {
+            Some(s) => write!(f, "{:?}", s),
+            None => write!(f, "Stream(Test)"),
         }
     }
 }
 
 impl Stream {
+    fn new(t: impl Inner + Send + Sync + 'static) -> Stream {
+        Stream::logged_create(Stream {
+            inner: BufReader::new(Box::new(t)),
+        })
+    }
+
     fn logged_create(stream: Stream) -> Stream {
         debug!("created stream: {:?}", stream);
         stream
@@ -129,20 +196,13 @@ impl Stream {
 
     pub(crate) fn from_vec(v: Vec<u8>) -> Stream {
         Stream::logged_create(Stream {
-            inner: BufReader::new(Inner::Test(Box::new(Cursor::new(v)), vec![])),
+            inner: BufReader::new(Box::new(TestStream(Box::new(Cursor::new(v)), vec![]))),
         })
     }
 
     fn from_tcp_stream(t: TcpStream) -> Stream {
         Stream::logged_create(Stream {
-            inner: BufReader::new(Inner::Http(t)),
-        })
-    }
-
-    #[cfg(feature = "tls")]
-    fn from_tls_stream(t: StreamOwned<ClientConnection, TcpStream>) -> Stream {
-        Stream::logged_create(Stream {
-            inner: BufReader::new(Inner::Https(t)),
+            inner: BufReader::new(Box::new(t)),
         })
     }
 
@@ -186,12 +246,7 @@ impl Stream {
         }
     }
     pub fn is_poolable(&self) -> bool {
-        match self.inner.get_ref() {
-            Inner::Http(_) => true,
-            #[cfg(feature = "tls")]
-            Inner::Https(_) => true,
-            _ => false,
-        }
+        self.inner.get_ref().is_poolable()
     }
 
     pub(crate) fn reset(&mut self) -> io::Result<()> {
@@ -206,12 +261,7 @@ impl Stream {
     }
 
     pub(crate) fn socket(&self) -> Option<&TcpStream> {
-        match self.inner.get_ref() {
-            Inner::Http(b) => Some(b),
-            #[cfg(feature = "tls")]
-            Inner::Https(b) => Some(b.get_ref()),
-            _ => None,
-        }
+        self.inner.get_ref().socket()
     }
 
     pub(crate) fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
@@ -223,28 +273,14 @@ impl Stream {
     }
 
     #[cfg(test)]
-    pub fn to_write_vec(&self) -> Vec<u8> {
-        match self.inner.get_ref() {
-            Inner::Test(_, writer) => writer.clone(),
-            _ => panic!("to_write_vec on non Test stream"),
-        }
+    pub fn as_write_vec(&self) -> &[u8] {
+        self.inner.get_ref().as_write_vec()
     }
 }
 
 impl Read for Stream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
-    }
-}
-
-impl Read for Inner {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match self {
-            Inner::Http(sock) => sock.read(buf),
-            #[cfg(feature = "tls")]
-            Inner::Https(stream) => read_https(stream, buf),
-            Inner::Test(reader, _) => reader.read(buf),
-        }
     }
 }
 
@@ -268,50 +304,12 @@ where
     }
 }
 
-#[cfg(feature = "tls")]
-fn read_https(
-    stream: &mut StreamOwned<ClientConnection, TcpStream>,
-    buf: &mut [u8],
-) -> io::Result<usize> {
-    match stream.read(buf) {
-        Ok(size) => Ok(size),
-        Err(ref e) if is_close_notify(e) => Ok(0),
-        Err(e) => Err(e),
-    }
-}
-
-#[allow(deprecated)]
-#[cfg(feature = "tls")]
-fn is_close_notify(e: &std::io::Error) -> bool {
-    if e.kind() != io::ErrorKind::ConnectionAborted {
-        return false;
-    }
-
-    if let Some(msg) = e.get_ref() {
-        // :(
-
-        return msg.description().contains("CloseNotify");
-    }
-
-    false
-}
-
 impl Write for Stream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match self.inner.get_mut() {
-            Inner::Http(sock) => sock.write(buf),
-            #[cfg(feature = "tls")]
-            Inner::Https(stream) => stream.write(buf),
-            Inner::Test(_, writer) => writer.write(buf),
-        }
+        self.inner.get_mut().write(buf)
     }
     fn flush(&mut self) -> io::Result<()> {
-        match self.inner.get_mut() {
-            Inner::Http(sock) => sock.flush(),
-            #[cfg(feature = "tls")]
-            Inner::Https(stream) => stream.flush(),
-            Inner::Test(_, writer) => writer.flush(),
-        }
+        self.inner.get_mut().flush()
     }
 }
 
@@ -328,54 +326,14 @@ pub(crate) fn connect_http(unit: &Unit, hostname: &str) -> Result<Stream, Error>
     connect_host(unit, hostname, port).map(Stream::from_tcp_stream)
 }
 
-#[cfg(feature = "tls")]
 pub(crate) fn connect_https(unit: &Unit, hostname: &str) -> Result<Stream, Error> {
-    use once_cell::sync::Lazy;
-    use std::{convert::TryFrom, sync::Arc};
-
-    static TLS_CONF: Lazy<Arc<rustls::ClientConfig>> = Lazy::new(|| {
-        let mut root_store = rustls::RootCertStore::empty();
-        #[cfg(not(feature = "native-tls"))]
-        root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
-            rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
-        #[cfg(feature = "native-tls")]
-        root_store.add_server_trust_anchors(
-            rustls_native_certs::load_native_certs().expect("Could not load platform certs"),
-        );
-
-        let config = rustls::ClientConfig::builder()
-            .with_safe_defaults()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        Arc::new(config)
-    });
-
     let port = unit.url.port().unwrap_or(443);
 
-    let tls_conf: Arc<rustls::ClientConfig> = unit
-        .agent
-        .config
-        .tls_config
-        .as_ref()
-        .map(|c| c.0.clone())
-        .unwrap_or_else(|| TLS_CONF.clone());
-    let mut sock = connect_host(unit, hostname, port)?;
-    let mut sess = rustls::ClientConnection::new(
-        tls_conf,
-        rustls::ServerName::try_from(hostname).expect("invalid DNS name"),
-    )
-    .map_err(|e| ErrorKind::Io.new().src(e))?;
+    let sock = connect_host(unit, hostname, port)?;
 
-    sess.complete_io(&mut sock)
-        .map_err(|err| ErrorKind::ConnectionFailed.new().src(err))?;
-    let stream = rustls::StreamOwned::new(sess, sock);
-
-    Ok(Stream::from_tls_stream(stream))
+    let tls_conf = &unit.agent.config.tls_config;
+    let https_stream = tls_conf.connect(hostname, sock)?;
+    Ok(Stream::new(https_stream))
 }
 
 pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<TcpStream, Error> {
@@ -664,11 +622,4 @@ pub(crate) fn connect_test(unit: &Unit) -> Result<Stream, Error> {
 #[cfg(not(test))]
 pub(crate) fn connect_test(unit: &Unit) -> Result<Stream, Error> {
     Err(ErrorKind::UnknownScheme.msg(&format!("unknown scheme '{}'", unit.url.scheme())))
-}
-
-#[cfg(not(feature = "tls"))]
-pub(crate) fn connect_https(unit: &Unit, _hostname: &str) -> Result<Stream, Error> {
-    Err(ErrorKind::UnknownScheme
-        .msg("URL has 'https:' scheme but ureq was build without HTTP support")
-        .url(unit.url.clone()))
 }

--- a/src/test/body_send.rs
+++ b/src/test/body_send.rs
@@ -10,7 +10,7 @@ fn content_length_on_str() {
     let resp = post("test://host/content_length_on_str")
         .send_string("Hello World!!!")
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nContent-Length: 14\r\n"));
 }
@@ -24,7 +24,7 @@ fn user_set_content_length_on_str() {
         .set("Content-Length", "12345")
         .send_string("Hello World!!!")
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nContent-Length: 12345\r\n"));
 }
@@ -43,7 +43,7 @@ fn content_length_on_json() {
     let resp = post("test://host/content_length_on_json")
         .send_json(SerdeValue::Object(json))
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nContent-Length: 20\r\n"));
 }
@@ -57,7 +57,7 @@ fn content_length_and_chunked() {
         .set("Transfer-Encoding", "chunked")
         .send_string("Hello World!!!")
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("Transfer-Encoding: chunked\r\n"));
     assert!(!s.contains("\r\nContent-Length:\r\n"));
@@ -73,7 +73,7 @@ fn str_with_encoding() {
         .set("Content-Type", "text/plain; charset=iso-8859-1")
         .send_string("Hällo Wörld!!!")
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     assert_eq!(
         &vec[vec.len() - 14..],
         //H  ä    l    l    o    _   W   ö    r    l    d    !   !   !
@@ -95,7 +95,7 @@ fn content_type_on_json() {
     let resp = post("test://host/content_type_on_json")
         .send_json(SerdeValue::Object(json))
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nContent-Type: application/json\r\n"));
 }
@@ -115,7 +115,7 @@ fn content_type_not_overriden_on_json() {
         .set("content-type", "text/plain")
         .send_json(SerdeValue::Object(json))
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\ncontent-type: text/plain\r\n"));
 }

--- a/src/test/query_string.rs
+++ b/src/test/query_string.rs
@@ -8,7 +8,7 @@ fn no_query_string() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://host/no_query_string").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("GET /no_query_string HTTP/1.1"))
 }
@@ -23,7 +23,7 @@ fn escaped_query_string() {
         .query("baz", "yo lo")
         .call()
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(
         s.contains("GET /escaped_query_string?foo=bar&baz=yo+lo HTTP/1.1"),
@@ -38,7 +38,7 @@ fn query_in_path() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://host/query_in_path?foo=bar").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("GET /query_in_path?foo=bar HTTP/1.1"))
 }
@@ -52,7 +52,7 @@ fn query_in_path_and_req() {
         .query("baz", "1 2 3")
         .call()
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("GET /query_in_path_and_req?foo=bar&baz=1+2+3 HTTP/1.1"))
 }

--- a/src/test/range.rs
+++ b/src/test/range.rs
@@ -1,13 +1,39 @@
-#[cfg(feature = "tls")]
-use std::io::Read;
-
-#[cfg(feature = "tls")]
-use super::super::*;
-
 #[test]
 #[cfg(feature = "tls")]
-fn read_range() {
+fn read_range_rustls() {
+    use std::io::Read;
+
+    use super::super::*;
+
+    // rustls is used via crate level convenience calls
     let resp = get("https://ureq.s3.eu-central-1.amazonaws.com/sherlock.txt")
+        .set("Range", "bytes=1000-1999")
+        .call()
+        .unwrap();
+    assert_eq!(resp.status(), 206);
+    let mut reader = resp.into_reader();
+    let mut buf = vec![];
+    let len = reader.read_to_end(&mut buf).unwrap();
+    assert_eq!(len, 1000);
+    assert_eq!(
+        &buf[0..20],
+        [83, 99, 111, 116, 116, 34, 10, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32]
+    )
+}
+
+#[test]
+#[cfg(feature = "native-tls")]
+fn read_range_native_tls() {
+    use std::io::Read;
+    use std::sync::Arc;
+
+    use super::super::*;
+
+    let tls_config = native_tls::TlsConnector::new().unwrap();
+    let agent = builder().tls_connector(Arc::new(tls_config)).build();
+
+    let resp = agent
+        .get("https://ureq.s3.eu-central-1.amazonaws.com/sherlock.txt")
         .set("Range", "bytes=1000-1999")
         .call()
         .unwrap();

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -120,7 +120,7 @@ fn escape_path() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://host/escape_path here").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("GET /escape_path%20here HTTP/1.1"))
 }
@@ -198,7 +198,7 @@ pub fn host_no_port() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://myhost/host_no_port").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nHost: myhost\r\n"));
 }
@@ -209,7 +209,7 @@ pub fn host_with_port() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://myhost:234/host_with_port").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nHost: myhost:234\r\n"));
 }

--- a/test.sh
+++ b/test.sh
@@ -4,11 +4,9 @@ set -eu
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D dead_code -D unused-variables -D unused"
 
-for tls in "" tls ; do
-  for feature in "" json charset cookies socks-proxy ; do
-    if ! cargo test --no-default-features --features "${tls} ${feature}" ; then
-      echo Command failed: cargo test \"${what}\" --no-default-features --features \"${tls} ${feature}\"
-      exit 1
-    fi
-  done
+for feature in "" tls json charset cookies socks-proxy native-tls ; do
+  if ! cargo test --no-default-features --features "${feature}" ; then
+    echo Command failed: cargo test --no-default-features --features \"${tls} ${feature}\"
+    exit 1
+  fi
 done

--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -1,5 +1,4 @@
-#[cfg(feature = "tls")]
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "tls", feature = "tls-native")))]
 #[test]
 fn agent_set_header() {
     use serde::Deserialize;
@@ -23,8 +22,10 @@ fn agent_set_header() {
     assert_eq!("value", json.headers.get("Header").unwrap());
 }
 
-#[cfg(feature = "tls")]
-const BADSSL_CLIENT_CERT_PEM: &str = r#"Bag Attributes
+#[test]
+#[cfg(any(feature = "tls", feature = "tls-native"))]
+fn tls_client_certificate() {
+    const BADSSL_CLIENT_CERT_PEM: &str = r#"Bag Attributes
     localKeyID: 41 C3 6C 33 C7 E3 36 DD EA 4A 1F C0 B7 23 B8 E6 9C DC D8 0F
 subject=C = US, ST = California, L = San Francisco, O = BadSSL, CN = BadSSL Client Certificate
 
@@ -89,9 +90,6 @@ m0Wqhhi8/24Sy934t5Txgkfoltg8ahkx934WjP6WWRnSAu+cf+vW
 -----END RSA PRIVATE KEY-----
 "#;
 
-#[cfg(feature = "tls")]
-#[test]
-fn tls_client_certificate() {
     let certs = rustls_pemfile::certs(&mut BADSSL_CLIENT_CERT_PEM.as_bytes())
         .unwrap()
         .into_iter()


### PR DESCRIPTION
Per #319, we want to add back native-tls support. However, as discussed in https://github.com/algesten/ureq/issues/319#issuecomment-930795723, using Cargo features to select a TLS backend (as we did in 1.x) is a bad fit, due to diamond dependencies.

Instead, ureq takes an opinionated stance and allows runtime configuration to change it. On all platforms that support rustls, we use rustls. On other platforms, we use native-tls. In either case, you can override the default: supply your own TLS implementation by calling `AgentBuilder::tls_connector`. Since this is configured per-Agent, there's no risk that crate A can accidentally change the backend used by crate B.

We now have a couple of new traits, `TlsConnector` and `HttpsStream`, that abstract over TLS configuration and encrypted streams. There are impls of `TlsConnector` for both `rustls::ClientConfig` and `native_tls::TlsConnector`. To enable the native_tls impl on platforms that default to rustls, build with the native-tls-adapter feature (and call `AgentBuilder::tls_connector`).

To mange the complexity introduced by having platform-based configs, this removes the "tls" feature. TLS is now always enabled, on all platforms. For applications that want to omit TLS support for binary-size reasons, we may in the future offer a linker-friendly AgentBuilder method that disables TLS. That should allow the linker to remove the unused TLS-related symbols and build time.