### PR TITLE
 Clear Content-Length header from redirected requests

### DIFF
--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -157,7 +157,9 @@ fn redirect_post_with_data() {
         assert_eq!(unit.method, "GET");
         test::make_response(200, "OK", vec![], vec![])
     });
-    let resp = post("test://host/redirect_post1").send_string("data").unwrap();
+    let resp = post("test://host/redirect_post1")
+        .send_string("data")
+        .unwrap();
     assert_eq!(resp.status(), 200);
 }
 

--- a/src/test/redirect.rs
+++ b/src/test/redirect.rs
@@ -147,6 +147,21 @@ fn redirect_post() {
 }
 
 #[test]
+fn redirect_post_with_data() {
+    test::set_handler("/redirect_post1", |unit| {
+        assert_eq!(unit.header("Content-Length").unwrap(), "4");
+        test::make_response(302, "Go here", vec!["Location: /redirect_post2"], vec![])
+    });
+    test::set_handler("/redirect_post2", |unit| {
+        assert_eq!(unit.header("Content-Length"), None);
+        assert_eq!(unit.method, "GET");
+        test::make_response(200, "OK", vec![], vec![])
+    });
+    let resp = post("test://host/redirect_post1").send_string("data").unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[test]
 fn redirect_308() {
     test::set_handler("/redirect_get3", |_| {
         test::make_response(308, "Go here", vec!["Location: /valid_response"], vec![])

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -205,6 +205,8 @@ pub(crate) fn connect(
         debug!("redirect {} {} -> {}", resp.status(), url, new_url);
         history.push(unit.url.to_string());
         body = Payload::Empty.into_read();
+        &unit.headers.retain(|header| { header.name() != "Content-Length" });
+
         // recreate the unit to get a new hostname and cookies for the new host.
         unit = Unit::new(
             &unit.agent,

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -205,7 +205,7 @@ pub(crate) fn connect(
         debug!("redirect {} {} -> {}", resp.status(), url, new_url);
         history.push(unit.url.to_string());
         body = Payload::Empty.into_read();
-        &unit.headers.retain(|header| { header.name() != "Content-Length" });
+        unit.headers.retain(|h| h.name() != "Content-Length");
 
         // recreate the unit to get a new hostname and cookies for the new host.
         unit = Unit::new(


### PR DESCRIPTION
This PR removes the Content-Length header from subsequent redirect requests if set. A test verifies the new behaviour.

This is a copy of @guspower's #394, tweaked to pass our lint checks.