### PR TITLE
Add support for gzip and brotli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ tls = ["rustls", "webpki", "webpki-roots"]
 native-certs = ["rustls-native-certs"]
 cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
+gzip = ["flate2"]
+brotli = ["brotli-decompressor"]
 
 [dependencies]
 base64 = "0.13"
@@ -39,6 +41,8 @@ serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 cookie_store = { version = "0.15", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4"
+flate2 = { version = "1.0.22", optional = true }
+brotli-decompressor = { version = "2.3.2", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ You can control them when including ureq as a dependency.
    (e.g.  `Content-Type: text/plain; charset=iso-8859-1`). Without this, the
    library defaults to Rust's built in `utf-8`.
 * `socks-proxy` enables proxy config using the `socks4://`, `socks4a://`, `socks5://` and `socks://` (equal to `socks5://`) prefix.
+* `gzip` enables automatically requesting gzip-compressed responses and decompressing them.
+* `brotli` enables automatically requesting Brotli-compressed responses and decompressing them.
 
 ## Plain requests
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,8 @@
 //!    (e.g.  `Content-Type: text/plain; charset=iso-8859-1`). Without this, the
 //!    library defaults to Rust's built in `utf-8`.
 //! * `socks-proxy` enables proxy config using the `socks4://`, `socks4a://`, `socks5://` and `socks://` (equal to `socks5://`) prefix.
+//! * `gzip` enables automatically requesting gzip-compressed responses and decompressing them.
+//! * `brotli` enables automatically requesting Brotli-compressed responses and decompressing them.
 //!
 //! # Plain requests
 //!

--- a/src/request.rs
+++ b/src/request.rs
@@ -92,11 +92,35 @@ impl Request {
         )?)
     }
 
-    fn do_call(self, payload: Payload) -> Result<Response> {
+    /// Add Accept-Encoding header with supported values, unless user has
+    /// already set this header or is requesting a specific byte-range.
+    #[cfg(any(feature = "gzip", feature = "brotli"))]
+    fn add_accept_encoding(&mut self) {
+        let should_add = !self.headers.iter().map(|h| h.name()).any(|name| {
+            name.eq_ignore_ascii_case("accept-encoding") || name.eq_ignore_ascii_case("range")
+        });
+        if should_add {
+            const GZ: bool = cfg!(feature = "gzip");
+            const BR: bool = cfg!(feature = "brotli");
+            const ACCEPT: &str = match (GZ, BR) {
+                (true, true) => "gzip, br",
+                (true, false) => "gzip",
+                (false, true) => "br",
+                (false, false) => "identity", // unreachable due to cfg feature on this fn
+            };
+            self.headers.push(Header::new("accept-encoding", ACCEPT));
+        }
+    }
+
+    #[cfg_attr(not(any(feature = "gzip", feature = "brotli")), allow(unused_mut))]
+    fn do_call(mut self, payload: Payload) -> Result<Response> {
         for h in &self.headers {
             h.validate()?;
         }
         let url = self.parse_url()?;
+
+        #[cfg(any(feature = "gzip", feature = "brotli"))]
+        self.add_accept_encoding();
 
         let deadline = match self.timeout.or(self.agent.config.timeout) {
             None => None,

--- a/src/response.rs
+++ b/src/response.rs
@@ -18,6 +18,12 @@ use serde::de::DeserializeOwned;
 #[cfg(feature = "charset")]
 use encoding_rs::Encoding;
 
+#[cfg(feature = "gzip")]
+use flate2::read::GzDecoder;
+
+#[cfg(feature = "brotli")]
+use brotli_decompressor::Decompressor;
+
 pub const DEFAULT_CONTENT_TYPE: &str = "text/plain";
 pub const DEFAULT_CHARACTER_SET: &str = "utf-8";
 const INTO_STRING_LIMIT: usize = 10 * 1_024 * 1_024;
@@ -281,6 +287,11 @@ impl Response {
                 .and_then(|l| l.parse::<usize>().ok())
         };
 
+        let compression = self
+            .header("content-encoding")
+            .map(Compression::from_header_value)
+            .flatten();
+
         let stream = self.stream;
         let unit = self.unit;
         if let Some(unit) = &unit {
@@ -292,12 +303,17 @@ impl Response {
         let deadline = unit.as_ref().and_then(|u| u.deadline);
         let stream = DeadlineStream::new(*stream, deadline);
 
-        match (use_chunked, limit_bytes) {
+        let body_reader: Box<dyn Read + Send> = match (use_chunked, limit_bytes) {
             (true, _) => Box::new(PoolReturnRead::new(unit, ChunkDecoder::new(stream))),
             (false, Some(len)) => {
                 Box::new(PoolReturnRead::new(unit, LimitedRead::new(stream, len)))
             }
             (false, None) => Box::new(stream),
+        };
+
+        match compression {
+            None => body_reader,
+            Some(c) => c.wrap_reader(body_reader),
         }
     }
 
@@ -505,6 +521,38 @@ impl Response {
         let previous_url = previous.get_url().to_string();
         self.history = previous.history;
         self.history.push(previous_url);
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Compression {
+    #[cfg(feature = "brotli")]
+    Brotli,
+    #[cfg(feature = "gzip")]
+    Gzip,
+}
+
+impl Compression {
+    /// Convert a string like "br" to an enum value
+    fn from_header_value(value: &str) -> Option<Compression> {
+        match value {
+            #[cfg(feature = "brotli")]
+            "br" => Some(Compression::Brotli),
+            #[cfg(feature = "gzip")]
+            "gzip" | "x-gzip" => Some(Compression::Gzip),
+            _ => None,
+        }
+    }
+
+    /// Wrap the raw reader with a decompressing reader
+    #[allow(unused_variables)] // when no features enabled, reader is unused (unreachable)
+    fn wrap_reader(self, reader: Box<dyn Read + Send>) -> Box<dyn Read + Send> {
+        match self {
+            #[cfg(feature = "brotli")]
+            Compression::Brotli => Box::new(Decompressor::new(reader, 4096)),
+            #[cfg(feature = "gzip")]
+            Compression::Gzip => Box::new(GzDecoder::new(reader)),
+        }
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,7 +22,7 @@ use encoding_rs::Encoding;
 use flate2::read::GzDecoder;
 
 #[cfg(feature = "brotli")]
-use brotli_decompressor::Decompressor;
+use brotli_decompressor::Decompressor as BrotliDecoder;
 
 pub const DEFAULT_CONTENT_TYPE: &str = "text/plain";
 pub const DEFAULT_CHARACTER_SET: &str = "utf-8";
@@ -549,7 +549,7 @@ impl Compression {
     fn wrap_reader(self, reader: Box<dyn Read + Send>) -> Box<dyn Read + Send> {
         match self {
             #[cfg(feature = "brotli")]
-            Compression::Brotli => Box::new(Decompressor::new(reader, 4096)),
+            Compression::Brotli => Box::new(BrotliDecoder::new(reader, 4096)),
             #[cfg(feature = "gzip")]
             Compression::Gzip => Box::new(GzDecoder::new(reader)),
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -74,6 +74,11 @@ pub struct Response {
     ///
     /// If this response was not redirected, the history is empty.
     pub(crate) history: Vec<String>,
+    /// The Content-Length value. The header itself may have been removed due to
+    /// the automatic decompression system.
+    length: Option<usize>,
+    /// The compression type of the response body.
+    compression: Option<Compression>,
 }
 
 /// index into status_line where we split: HTTP/1.1 200 OK
@@ -283,14 +288,8 @@ impl Response {
             // head requests never have a body
             Some(0)
         } else {
-            self.header("content-length")
-                .and_then(|l| l.parse::<usize>().ok())
+            self.length
         };
-
-        let compression = self
-            .header("content-encoding")
-            .map(Compression::from_header_value)
-            .flatten();
 
         let stream = self.stream;
         let unit = self.unit;
@@ -311,7 +310,7 @@ impl Response {
             (false, None) => Box::new(stream),
         };
 
-        match compression {
+        match self.compression {
             None => body_reader,
             Some(c) => c.wrap_reader(body_reader),
         }
@@ -487,6 +486,16 @@ impl Response {
             ));
         }
 
+        let length = get_header(&headers, "content-length").and_then(|v| v.parse::<usize>().ok());
+
+        let compression =
+            get_header(&headers, "content-encoding").and_then(Compression::from_header_value);
+
+        if compression.is_some() {
+            headers.retain(|h| h.name() != "content-encoding" && h.name() != "content-length");
+            // remove Content-Encoding and length due to automatic decompression
+        }
+
         Ok(Response {
             url: None,
             status_line,
@@ -496,6 +505,8 @@ impl Response {
             unit: unit.map(Box::new),
             stream: Box::new(stream.into()),
             history: vec![],
+            length,
+            compression,
         })
     }
 

--- a/src/test/body_read.rs
+++ b/src/test/body_read.rs
@@ -101,6 +101,8 @@ fn gzip_text() {
     // echo -n INPUT | gzip -9 -f | hexdump -ve '1/1 "0x%.2X,"'
     // INPUT is `hello world ` repeated 14 times, no trailing space
     let resp = get("test://host/gzip_text").call().unwrap();
+    assert_eq!(resp.header("content-encoding"), None);
+    assert_eq!(resp.header("content-length"), None);
     let text = resp.into_string().unwrap();
     assert_eq!(text, "hello world ".repeat(14).trim_end());
 }
@@ -121,6 +123,8 @@ fn brotli_text() {
     });
     // echo -n INPUT | brotli -Z -f | hexdump -ve '1/1 "0x%.2X,"'
     let resp = get("test://host/brotli_text").call().unwrap();
+    assert_eq!(resp.header("content-encoding"), None);
+    assert_eq!(resp.header("content-length"), None);
     let text = resp.into_string().unwrap();
     assert_eq!(text, "hello world ".repeat(14).trim_end());
 }

--- a/src/test/body_read.rs
+++ b/src/test/body_read.rs
@@ -82,3 +82,45 @@ fn no_reader_on_head() {
     reader.read_to_string(&mut text).unwrap();
     assert_eq!(text, "");
 }
+
+#[cfg(feature = "gzip")]
+#[test]
+fn gzip_text() {
+    test::set_handler("/gzip_text", |_unit| {
+        test::make_response(
+            200,
+            "OK",
+            vec!["content-length: 35", "content-encoding: gzip"],
+            vec![
+                0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x03, 0xCB, 0x48, 0xCD, 0xC9,
+                0xC9, 0x57, 0x28, 0xCF, 0x2F, 0xCA, 0x49, 0x51, 0xC8, 0x18, 0xBC, 0x6C, 0x00, 0xA5,
+                0x5C, 0x7C, 0xEF, 0xA7, 0x00, 0x00, 0x00,
+            ],
+        )
+    });
+    // echo -n INPUT | gzip -9 -f | hexdump -ve '1/1 "0x%.2X,"'
+    // INPUT is `hello world ` repeated 14 times, no trailing space
+    let resp = get("test://host/gzip_text").call().unwrap();
+    let text = resp.into_string().unwrap();
+    assert_eq!(text, "hello world ".repeat(14).trim_end());
+}
+
+#[cfg(feature = "brotli")]
+#[test]
+fn brotli_text() {
+    test::set_handler("/brotli_text", |_unit| {
+        test::make_response(
+            200,
+            "OK",
+            vec!["content-length: 24", "content-encoding: br"],
+            vec![
+                0x1F, 0xA6, 0x00, 0xF8, 0x8D, 0x94, 0x6E, 0xDE, 0x44, 0x55, 0x86, 0x96, 0x20, 0x6C,
+                0x6F, 0x35, 0x8B, 0x62, 0xB5, 0x40, 0x06, 0x54, 0xBB, 0x02,
+            ],
+        )
+    });
+    // echo -n INPUT | brotli -Z -f | hexdump -ve '1/1 "0x%.2X,"'
+    let resp = get("test://host/brotli_text").call().unwrap();
+    let text = resp.into_string().unwrap();
+    assert_eq!(text, "hello world ".repeat(14).trim_end());
+}


### PR DESCRIPTION
I wanted compression, found #35, and used it as starting point.

Automatically sends the Accept-Encoding header on requests when appropriate, so just enabling the features gets compression working.

I didn't add support for `deflate` as its implementation on some servers used to be buggy and it seems like most everyone is using gzip/br now anyway.

I tested this on ~1500 websites and it appears to be working.