### PR TITLE
Remove trailing newline from testing response

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -109,7 +109,7 @@ impl Response {
     /// # }
     /// ```
     pub fn new(status: u16, status_text: &str, body: &str) -> Result<Response, Error> {
-        let r = format!("HTTP/1.1 {} {}\r\n\r\n{}\n", status, status_text, body);
+        let r = format!("HTTP/1.1 {} {}\r\n\r\n{}", status, status_text, body);
         (r.as_ref() as &str).parse()
     }
 


### PR DESCRIPTION
The newline becomes part of the response body, even though it was not passed in
as `body`, which makes `Response::new` difficult to use with anything that
checksums data contents for example. Arguably there should also be a mechanism
for passing in `[u8]` bodies, but that's for a separate feature request.