### PR TITLE
get rid of warnings when building

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -94,7 +94,8 @@ pub struct Transport {
     message: Option<String>,
     url: Option<Url>,
     source: Option<Box<dyn error::Error + Send + Sync + 'static>>,
-    response: Option<Response>,
+    #[allow(dead_code)]
+    response: Option<Response>,  // when building without tls, only tests read this.
 }
 
 /// Extension to [`Result<Response, Error>`] for handling all status codes as [`Response`].

--- a/src/request.rs
+++ b/src/request.rs
@@ -30,7 +30,6 @@ pub struct Request {
     agent: Agent,
     method: String,
     url: String,
-    error_on_non_2xx: bool,
     headers: Vec<Header>,
     timeout: Option<time::Duration>,
 }
@@ -52,7 +51,6 @@ impl Request {
             method,
             url,
             headers: vec![],
-            error_on_non_2xx: true,
             timeout: None,
         }
     }


### PR DESCRIPTION
While I started this branch testing --no-default-features, I later realized that TLS had nothing to do with these warnings.
But, I wanted a clean slate for work to add mbedtls support.
