### PR TITLE
Add support for arbitrary TLS backends (rebased, some fixes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           command: doc
           # Keep in sync with Cargo.toml's [package.metadata.docs.rs]
-          args: --no-default-features --no-deps --features "tls json charset cookies socks-proxy"
+          args: --no-default-features --no-deps --features "tls native-tls json charset cookies socks-proxy"
   build_and_test:
     name: Test
     runs-on: ubuntu-latest
@@ -48,6 +48,8 @@ jobs:
         tls:
           - ""
           - tls
+          - native-tls
+          - "tls native-tls"
         feature:
           - ""
           - json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 # Keep in sync with .github/workflows/test.yml
-features = [ "tls", "json", "charset", "cookies", "socks-proxy" ]
+features = [ "tls", "native-tls", "json", "charset", "cookies", "socks-proxy" ]
 
 [features]
 default = ["tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 cookie_store = { version = "0.15", optional = true, default-features = false, features = ["preserve_order"] }
-log = "0.4"
+log = "0.4.11"
+native-tls = "0.2.7"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 cookie_store = { version = "0.15", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4.11"
-native-tls = "0.2.7"
+native-tls = { version = "0.2.7", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HTTPS, and charset decoding.
 Ureq is in pure Rust for safety and ease of understanding. It avoids using
 `unsafe` directly. It [uses blocking I/O][blocking] instead of async I/O, because that keeps
 the API simple and and keeps dependencies to a minimum. For TLS, ureq uses
-[rustls].
+[rustls] or [native-tls](https://docs.rs/native-tls/).
 
 Version 2.0.0 was released recently and changed some APIs. See the [changelog] for details.
 
@@ -210,6 +210,34 @@ fn proxy_example_2() -> std::result::Result<(), ureq::Error> {
     Ok(())
 }
 ```
+
+## HTTPS / TLS / SSL
+
+By default, ureq uses rustls. You can add native-tls support by enableing the native-tls feature
+and calling AgentBuilder::tls_connector():
+
+```rust
+  use ureq::Agent;
+
+  let agent = ureq::AgentBuilder::new()
+      .tls_connector(native_tls::TlsConnector::new())
+      .build();
+```
+
+You might want to use native-tls if rustls is not supported on your platform, or if you need to
+interoperate with servers that only support less-secure ciphersuites and/or TLS versions older
+than 1.2. You can turn off TLS support entirely with `--no-default-features`.
+
+### Trusted Roots
+
+When you use rustls, ureq defaults to trusting [webpki-roots](https://docs.rs/webpki-roots/), a
+copy of the Mozilla Root program that is bundled into your program (and so won't update if your
+program isn't updated). You can alternately configure
+[rustls-native-certs](https://docs.rs/rustls-native-certs/) which extracts the roots from your
+OS' trust store. That means it will update when your OS is updated, and also that it will
+include locally installed roots.
+
+When you use native-tls, ureq will use your OS' certificate verifier and root store.
 
 ## Blocking I/O for simplicity
 

--- a/examples/cureq/main.rs
+++ b/examples/cureq/main.rs
@@ -9,7 +9,6 @@ use rustls::{
     Certificate, ClientConfig, RootCertStore, ServerCertVerified, ServerCertVerifier, TLSError,
 };
 use ureq;
-use webpki::DNSNameRef;
 
 #[derive(Debug)]
 struct StringError(String);
@@ -97,12 +96,13 @@ fn perform(
 
 struct AcceptAll {}
 
+#[cfg(feature = "tls")]
 impl ServerCertVerifier for AcceptAll {
     fn verify_server_cert(
         &self,
         _roots: &RootCertStore,
         _presented_certs: &[Certificate],
-        _dns_name: DNSNameRef<'_>,
+        _dns_name: webpki::DNSNameRef<'_>,
         _ocsp_response: &[u8],
     ) -> Result<ServerCertVerified, TLSError> {
         Ok(ServerCertVerified::assertion())
@@ -159,6 +159,7 @@ Fetch url and copy it to stdout.
                 let wait_seconds: u64 = wait_string.parse().expect("invalid --wait flag");
                 wait = Duration::from_secs(wait_seconds);
             }
+            #[cfg(feature = "tls")]
             "-k" => {
                 let mut client_config = ClientConfig::new();
                 client_config

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -465,7 +465,9 @@ impl AgentBuilder {
         self
     }
 
-    /// Set the TLS client config to use for the connection. See [`ClientConfig`](https://docs.rs/rustls/latest/rustls/struct.ClientConfig.html).
+    /// Use rustls for connections from this agent and set the
+    /// [`rustls::ClientConfig`](https://docs.rs/rustls/0.19.1/rustls/struct.ClientConfig.html)
+    /// to use. Overrides any previous calls to [AgentBuilder::tls_connector]
     ///
     /// Example:
     /// ```
@@ -485,8 +487,9 @@ impl AgentBuilder {
         self
     }
 
-    /// Set the [native_tls::TlsConnector](https://docs.rs/native-tls/0.2.7/native_tls/struct.TlsConnector.html)
-    /// to use for the connection.
+    /// Use native-tls for connections from this agent and set the
+    /// [`native_tls::TlsConnector`](https://docs.rs/native-tls/0.2.7/native_tls/struct.TlsConnector.html)
+    /// to use. Overrides any previous calls to [AgentBuilder::tls_config].
     ///
     /// Example:
     /// ```

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -7,6 +7,7 @@ use crate::pool::ConnectionPool;
 use crate::proxy::Proxy;
 use crate::request::Request;
 use crate::resolve::{ArcResolver, StdResolver};
+#[cfg(any(feature = "tls", feature = "native-tls"))]
 use crate::stream::HttpsConnector;
 use std::time::Duration;
 
@@ -39,6 +40,7 @@ pub(crate) struct AgentConfig {
     pub timeout: Option<Duration>,
     pub redirects: u32,
     pub user_agent: String,
+    #[cfg(any(feature = "tls", feature = "native-tls"))]
     pub tls_config: Option<Arc<dyn HttpsConnector>>,
 }
 
@@ -217,6 +219,7 @@ impl AgentBuilder {
                 timeout: None,
                 redirects: 5,
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
+                #[cfg(any(feature = "tls", feature = "native-tls"))]
                 tls_config: None,
             },
             max_idle_connections: DEFAULT_MAX_IDLE_CONNECTIONS,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -483,7 +483,7 @@ impl AgentBuilder {
     /// ```
     #[cfg(feature = "tls")]
     pub fn tls_config(mut self, tls_config: Arc<rustls::ClientConfig>) -> Self {
-        self.config.tls_config = Some(TLSClientConfig(tls_config));
+        self.config.tls_config = Some(TLSClientConfig::Rustls(tls_config));
         self
     }
 
@@ -522,7 +522,10 @@ impl AgentBuilder {
 
 #[cfg(feature = "tls")]
 #[derive(Clone)]
-pub(crate) struct TLSClientConfig(pub(crate) Arc<rustls::ClientConfig>);
+pub(crate) enum TLSClientConfig {
+    Rustls(Arc<rustls::ClientConfig>),
+    Native,
+}
 
 #[cfg(feature = "tls")]
 impl std::fmt::Debug for TLSClientConfig {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -499,7 +499,9 @@ impl AgentBuilder {
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
     /// use std::sync::Arc;
+    /// # #[cfg(feature = "native-tls")]
     /// let tls_connector = Arc::new(native_tls::TlsConnector::new().unwrap());
+    /// # #[cfg(feature = "native-tls")]
     /// let agent = ureq::builder()
     ///     .tls_connector(tls_connector.clone())
     ///     .build();
@@ -507,8 +509,8 @@ impl AgentBuilder {
     /// # }
     /// ```
     #[cfg(feature = "tls")]
-    pub fn tls_config<T: HttpsConnector + 'static>(mut self, tls_config: Arc<T>) -> Self {
-        self.config.tls_config = Some(tls_config);
+    pub fn tls_config<T: HttpsConnector + 'static>(mut self, tls_config: T) -> Self {
+        self.config.tls_config = Some(Arc::new(tls_config));
         self
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -486,11 +486,14 @@ impl AgentBuilder {
     /// ```
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
+    /// # #[cfg(feature = "tls")]
+    /// # {
     /// use std::sync::Arc;
     /// let tls_config = Arc::new(rustls::ClientConfig::new());
     /// let agent = ureq::builder()
     ///     .tls_config(tls_config.clone())
     ///     .build();
+    /// # }
     /// # Ok(())
     /// # }
     /// ```
@@ -498,7 +501,7 @@ impl AgentBuilder {
     /// Example using native-tls:
     ///
     /// ```
-    /// # #[cfg(feature = "tls")]
+    /// # #[cfg(feature = "native-tls")]
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
     /// use std::sync::Arc;
@@ -506,12 +509,12 @@ impl AgentBuilder {
     /// let tls_connector = Arc::new(native_tls::TlsConnector::new().unwrap());
     /// # #[cfg(feature = "native-tls")]
     /// let agent = ureq::builder()
-    ///     .tls_connector(tls_connector.clone())
+    ///     .tls_config(tls_connector.clone())
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "tls")]
+    #[cfg(any(feature = "tls", feature = "native-tls"))]
     pub fn tls_config<T: HttpsConnector + 'static>(mut self, tls_config: T) -> Self {
         self.config.tls_config = Some(Arc::new(tls_config));
         self

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -477,7 +477,7 @@ impl AgentBuilder {
     /// The parameter can be a
     /// [`rustls::ClientConfig`](https://docs.rs/rustls/0.19.1/rustls/struct.ClientConfig.html),
     /// a [`native_tls::TlsConnector`](https://docs.rs/native-tls/0.2.7/native_tls/struct.TlsConnector.html),
-    /// or any time for which you implement the [HttpsConnector] trait.
+    /// or any type for which you implement the [HttpsConnector] trait.
     ///
     /// Example using rustls:
     /// ```

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -501,16 +501,16 @@ impl AgentBuilder {
     /// Example using native-tls:
     ///
     /// ```
-    /// # #[cfg(feature = "native-tls")]
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
+    /// # #[cfg(feature = "native-tls")]
+    /// # {
     /// use std::sync::Arc;
-    /// # #[cfg(feature = "native-tls")]
     /// let tls_connector = Arc::new(native_tls::TlsConnector::new().unwrap());
-    /// # #[cfg(feature = "native-tls")]
     /// let agent = ureq::builder()
     ///     .tls_config(tls_connector.clone())
     ///     .build();
+    /// # }
     /// # Ok(())
     /// # }
     /// ```

--- a/src/header.rs
+++ b/src/header.rs
@@ -64,7 +64,7 @@ impl fmt::Display for HeaderLine {
 
 #[derive(Clone, PartialEq)]
 /// Wrapper type for a header field.
-/// https://tools.ietf.org/html/rfc7230#section-3.2
+/// <https://tools.ietf.org/html/rfc7230#section-3.2>
 pub struct Header {
     // Line contains the unmodified bytes of single header field.
     // It does not contain the final CRLF.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! Ureq is in pure Rust for safety and ease of understanding. It avoids using
 //! `unsafe` directly. It [uses blocking I/O][blocking] instead of async I/O, because that keeps
 //! the API simple and keeps dependencies to a minimum. For TLS, ureq uses
-//! [rustls].
+//! [rustls] or [native-tls](https://docs.rs/native-tls/).
 //!
 //! Version 2.0.0 was released recently and changed some APIs. See the [changelog] for details.
 //!
@@ -233,6 +233,38 @@
 //! }
 //! # fn main() {}
 //! ```
+//!
+//! # HTTPS / TLS / SSL
+//!
+//! By default, ureq uses rustls. You can add native-tls support by enableing the native-tls feature
+//! and calling AgentBuilder::tls_connector():
+//!
+//! ```no_run
+//! # fn main() -> std::result::Result<(), ureq::Error> {
+//! # ureq::is_test(true);
+//!   use ureq::Agent;
+//!
+//!   let agent = ureq::AgentBuilder::new()
+//!       .tls_connector(native_tls::TlsConnector::new())
+//!       .build();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You might want to use native-tls if rustls is not supported on your platform, or if you need to
+//! interoperate with servers that only support less-secure ciphersuites and/or TLS versions older
+//! than 1.2. You can turn off TLS support entirely with `--no-default-features`.
+//!
+//! ## Trusted Roots
+//!
+//! When you use rustls, ureq defaults to trusting [webpki-roots](https://docs.rs/webpki-roots/), a
+//! copy of the Mozilla Root program that is bundled into your program (and so won't update if your
+//! program isn't updated). You can alternately configure
+//! [rustls-native-certs](https://docs.rs/rustls-native-certs/) which extracts the roots from your
+//! OS' trust store. That means it will update when your OS is updated, and also that it will
+//! include locally installed roots.
+//!
+//! When you use native-tls, ureq will use your OS' certificate verifier and root store.
 //!
 //! # Blocking I/O for simplicity
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,10 +236,11 @@
 //!
 //! # HTTPS / TLS / SSL
 //!
-//! By default, ureq uses rustls. You can add native-tls support by enableing the native-tls feature
+//! By default, ureq uses rustls. You can add native-tls support by enabling the native-tls feature
 //! and calling AgentBuilder::tls_connector():
 //!
 //! ```no_run
+//! # #[cfg(feature = "native-tls")]
 //! # fn main() -> std::result::Result<(), ureq::Error> {
 //! # ureq::is_test(true);
 //!   use ureq::Agent;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,7 @@
 //! # #[cfg(feature = "native-tls")]
 //! # fn build() -> std::result::Result<(), ureq::Error> {
 //! # ureq::is_test(true);
+//!   use std::sync::Arc;
 //!   use ureq::Agent;
 //!
 //!   let agent = ureq::AgentBuilder::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@
 //!   use ureq::Agent;
 //!
 //!   let agent = ureq::AgentBuilder::new()
-//!       .tls_connector(Arc::new(native_tls::TlsConnector::new()))
+//!       .tls_config(Arc::new(native_tls::TlsConnector::new().unwrap()))
 //!       .build();
 //! # Ok(())
 //! # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@
 //!
 //! ```no_run
 //! # #[cfg(feature = "native-tls")]
-//! # fn main() -> std::result::Result<(), ureq::Error> {
+//! # fn build() -> std::result::Result<(), ureq::Error> {
 //! # ureq::is_test(true);
 //!   use ureq::Agent;
 //!
@@ -250,6 +250,7 @@
 //!       .build();
 //! # Ok(())
 //! # }
+//! # fn main() {}
 //! ```
 //!
 //! You might want to use native-tls if rustls is not supported on your platform, or if you need to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@
 //!   use ureq::Agent;
 //!
 //!   let agent = ureq::AgentBuilder::new()
-//!       .tls_connector(native_tls::TlsConnector::new())
+//!       .tls_connector(Arc::new(native_tls::TlsConnector::new()))
 //!       .build();
 //! # Ok(())
 //! # }

--- a/src/response.rs
+++ b/src/response.rs
@@ -491,8 +491,8 @@ impl Response {
     }
 
     #[cfg(test)]
-    pub fn to_write_vec(self) -> Vec<u8> {
-        self.stream.to_write_vec()
+    pub fn as_write_vec(&self) -> &[u8] {
+        self.stream.as_write_vec()
     }
 
     #[cfg(test)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,8 +1,10 @@
 use log::debug;
+#[cfg(feature = "tls")]
 use rustls::Session;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::SocketAddr;
 use std::net::TcpStream;
+#[cfg(any(feature = "tls", feature = "native-tls"))]
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,7 +4,7 @@ use rustls::Session;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::SocketAddr;
 use std::net::TcpStream;
-#[cfg(any(feature = "tls", feature = "native-tls"))]
+#[cfg(any(feature = "tls", feature = "native-tls", feature = "socks-proxy"))]
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -643,7 +643,7 @@ fn connect_socks(
     #[allow(clippy::mutex_atomic)]
     let stream = if let Some(deadline) = deadline {
         use std::sync::mpsc::channel;
-        use std::sync::{Arc, Condvar, Mutex};
+        use std::sync::{Condvar, Mutex};
         use std::thread;
         let master_signal = Arc::new((Mutex::new(false), Condvar::new()));
         let slave_signal = master_signal.clone();

--- a/src/test/body_send.rs
+++ b/src/test/body_send.rs
@@ -10,7 +10,7 @@ fn content_length_on_str() {
     let resp = post("test://host/content_length_on_str")
         .send_string("Hello World!!!")
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nContent-Length: 14\r\n"));
 }
@@ -24,7 +24,7 @@ fn user_set_content_length_on_str() {
         .set("Content-Length", "12345")
         .send_string("Hello World!!!")
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nContent-Length: 12345\r\n"));
 }
@@ -43,7 +43,7 @@ fn content_length_on_json() {
     let resp = post("test://host/content_length_on_json")
         .send_json(SerdeValue::Object(json))
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nContent-Length: 20\r\n"));
 }
@@ -57,7 +57,7 @@ fn content_length_and_chunked() {
         .set("Transfer-Encoding", "chunked")
         .send_string("Hello World!!!")
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("Transfer-Encoding: chunked\r\n"));
     assert!(!s.contains("\r\nContent-Length:\r\n"));
@@ -73,7 +73,7 @@ fn str_with_encoding() {
         .set("Content-Type", "text/plain; charset=iso-8859-1")
         .send_string("Hällo Wörld!!!")
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     assert_eq!(
         &vec[vec.len() - 14..],
         //H  ä    l    l    o    _   W   ö    r    l    d    !   !   !
@@ -95,7 +95,7 @@ fn content_type_on_json() {
     let resp = post("test://host/content_type_on_json")
         .send_json(SerdeValue::Object(json))
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nContent-Type: application/json\r\n"));
 }
@@ -115,7 +115,7 @@ fn content_type_not_overriden_on_json() {
         .set("content-type", "text/plain")
         .send_json(SerdeValue::Object(json))
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\ncontent-type: text/plain\r\n"));
 }

--- a/src/test/query_string.rs
+++ b/src/test/query_string.rs
@@ -8,7 +8,7 @@ fn no_query_string() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://host/no_query_string").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("GET /no_query_string HTTP/1.1"))
 }
@@ -23,7 +23,7 @@ fn escaped_query_string() {
         .query("baz", "yo lo")
         .call()
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(
         s.contains("GET /escaped_query_string?foo=bar&baz=yo+lo HTTP/1.1"),
@@ -38,7 +38,7 @@ fn query_in_path() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://host/query_in_path?foo=bar").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("GET /query_in_path?foo=bar HTTP/1.1"))
 }
@@ -52,7 +52,7 @@ fn query_in_path_and_req() {
         .query("baz", "1 2 3")
         .call()
         .unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("GET /query_in_path_and_req?foo=bar&baz=1+2+3 HTTP/1.1"))
 }

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -120,7 +120,7 @@ fn escape_path() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://host/escape_path here").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("GET /escape_path%20here HTTP/1.1"))
 }
@@ -198,7 +198,7 @@ pub fn host_no_port() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://myhost/host_no_port").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nHost: myhost\r\n"));
 }
@@ -209,7 +209,7 @@ pub fn host_with_port() {
         test::make_response(200, "OK", vec![], vec![])
     });
     let resp = get("test://myhost:234/host_with_port").call().unwrap();
-    let vec = resp.to_write_vec();
+    let vec = resp.as_write_vec();
     let s = String::from_utf8_lossy(&vec);
     assert!(s.contains("\r\nHost: myhost:234\r\n"));
 }


### PR DESCRIPTION
This rebases #391 on origin/main, and adds some work to make doctests and --no-default-features work.
The pattern of Arc<> may not be as intended, as I had to update some doctests.
Also the way I omitted the "tls" doctests is probably not the best solution.
