### PR TITLE
Preserve Authorization header in same host redirects

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -465,7 +465,7 @@ impl AgentBuilder {
     ///
     /// Defaults to [`RedirectAuthHeaders::Never`].
     ///
-    pub fn set_redirect_auth_headers(mut self, v: RedirectAuthHeaders) -> Self {
+    pub fn redirect_auth_headers(mut self, v: RedirectAuthHeaders) -> Self {
         self.config.redirect_auth_headers = v;
         self
     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -20,14 +20,16 @@ use {
 ///
 /// `Never` is the default strategy and never preserves `authorization` header in redirects.
 /// `SameHost` send the authorization header in redirects only if the host of the redirect is
-/// the same of the previous request, and both use the `https` scheme.
+/// the same of the previous request, and both use the same scheme (or switch to a more secure one, i.e
+/// we can redirect from `http` to `https`, but not the reverse).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum RedirectAuthHeaders {
     /// Never preserve the `authorization` header on redirect. This is the default.
     Never,
-    /// Preserve the `authorization` header when the redirect is to the same host. Must
-    /// be under the `https` scheme (though port can differ).
+    /// Preserve the `authorization` header when the redirect is to the same host. Both hosts must use
+    /// the same scheme (or switch to a more secure one, i.e we can redirect from `http` to `https`,
+    /// but not the reverse).
     SameHost,
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,13 +16,17 @@ use {
     cookie_store::CookieStore,
 };
 
-/// Specify the strategy for propagation of authorization headers during Redirects
+/// Strategy for keeping `authorization` headers during redirects.
 ///
-/// Never is the default strategy and never send authorization headers in Redirects
-/// SameHost send the authorization header in Redirects only if the host of the Redirect is the same of the previous request, and both use the Https scheme
+/// `Never` is the default strategy and never preserves `authorization` header in redirects.
+/// `SameHost` send the authorization header in redirects only if the host of the redirect is
+/// the same of the previous request, and both use the `https` scheme.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RedirectAuthHeaders {
+    /// Never preserve the `authorization` header on redirect. This is the default.
     Never,
+    /// Preserve the `authorization` header when the redirect is to the same host. Must
+    /// be under the `https` scheme (though port can differ).
     SameHost,
 }
 
@@ -459,7 +463,7 @@ impl AgentBuilder {
 
     /// Set the strategy for propagation of authorization headers in redirects.
     ///
-    /// Defaults to RedirectAuthHeaders::Never.
+    /// Defaults to [`RedirectAuthHeaders::Never`].
     ///
     pub fn set_redirect_auth_headers(mut self, v: RedirectAuthHeaders) -> Self {
         self.config.redirect_auth_headers = v;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,6 +16,16 @@ use {
     cookie_store::CookieStore,
 };
 
+/// Specify the strategy for propagation of authorization headers during Redirects
+///
+/// Never is the default strategy and never send authorization headers in Redirects
+/// SameHost send the authorization header in Redirects only if the host of the Redirect is the same of the previous request, and both use the Https scheme
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedirectAuthHeaders {
+    Never,
+    SameHost,
+}
+
 /// Accumulates options towards building an [Agent].
 #[derive(Debug)]
 pub struct AgentBuilder {
@@ -38,6 +48,7 @@ pub(crate) struct AgentConfig {
     pub timeout_write: Option<Duration>,
     pub timeout: Option<Duration>,
     pub redirects: u32,
+    pub redirect_auth_headers: RedirectAuthHeaders,
     pub user_agent: String,
     pub tls_config: Arc<dyn TlsConnector>,
 }
@@ -221,6 +232,7 @@ impl AgentBuilder {
                 timeout_write: None,
                 timeout: None,
                 redirects: 5,
+                redirect_auth_headers: RedirectAuthHeaders::Never,
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
                 tls_config: crate::default_tls_config(),
             },
@@ -442,6 +454,15 @@ impl AgentBuilder {
     /// ```
     pub fn redirects(mut self, n: u32) -> Self {
         self.config.redirects = n;
+        self
+    }
+
+    /// Set the strategy for propagation of authorization headers in redirects.
+    ///
+    /// Defaults to RedirectAuthHeaders::Never.
+    ///
+    pub fn set_redirect_auth_headers(mut self, v: RedirectAuthHeaders) -> Self {
+        self.config.redirect_auth_headers = v;
         self
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -22,6 +22,7 @@ use {
 /// `SameHost` send the authorization header in redirects only if the host of the redirect is
 /// the same of the previous request, and both use the `https` scheme.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RedirectAuthHeaders {
     /// Never preserve the `authorization` header on redirect. This is the default.
     Never,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,6 +387,7 @@ mod testserver;
 
 pub use crate::agent::Agent;
 pub use crate::agent::AgentBuilder;
+pub use crate::agent::RedirectAuthHeaders;
 pub use crate::error::{Error, ErrorKind, OrAnyStatus, Transport};
 pub use crate::header::Header;
 pub use crate::proxy::Proxy;

--- a/src/request.rs
+++ b/src/request.rs
@@ -106,7 +106,7 @@ impl Request {
             &self.agent,
             &self.method,
             &url,
-            &self.headers,
+            self.headers,
             &reader,
             deadline,
         );

--- a/src/response.rs
+++ b/src/response.rs
@@ -53,7 +53,7 @@ const MAX_HEADER_COUNT: usize = 100;
 /// # }
 /// ```
 pub struct Response {
-    url: Option<Url>,
+    pub(crate) url: Option<Url>,
     status_line: String,
     index: ResponseStatusIndex,
     status: u16,
@@ -67,7 +67,7 @@ pub struct Response {
     /// previous to this one.
     ///
     /// If this response was not redirected, the history is empty.
-    pub(crate) history: Vec<String>,
+    pub(crate) history: Vec<Url>,
 }
 
 /// index into status_line where we split: HTTP/1.1 200 OK
@@ -502,7 +502,7 @@ impl Response {
 
     #[cfg(test)]
     pub fn history_from_previous(&mut self, previous: Response) {
-        let previous_url = previous.get_url().to_string();
+        let previous_url = previous.url.expect("previous url");
         self.history = previous.history;
         self.history.push(previous_url);
     }
@@ -941,7 +941,7 @@ mod tests {
         response2.set_url("http://2.example.com/".parse().unwrap());
         response2.history_from_previous(response1);
 
-        let hist: Vec<&str> = response2.history.iter().map(|r| &**r).collect();
+        let hist: Vec<String> = response2.history.iter().map(|r| r.to_string()).collect();
         assert_eq!(hist, ["http://1.example.com/", "http://2.example.com/"])
     }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -378,16 +378,16 @@ fn send_prelude(unit: &Unit, stream: &mut Stream, previous: &[String]) -> io::Re
         unit.url.query().unwrap_or_default(),
     )?;
 
-    let scheme_default: u16 = match unit.url.scheme() {
-        "http" => 80,
-        "https" => 443,
-        _ => 0,
-    };
     // host header if not set by user.
     if !header::has_header(&unit.headers, "host") {
         let host = unit.url.host().unwrap();
         match unit.url.port() {
             Some(port) => {
+                let scheme_default: u16 = match unit.url.scheme() {
+                    "http" => 80,
+                    "https" => 443,
+                    _ => 0,
+                };
                 if scheme_default != 0 && scheme_default == port {
                     prelude.write_header("Host", host)?;
                 } else {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -383,7 +383,10 @@ fn can_propagate_authorization_on_redirect(
             let prev_host = prev_url.host_str();
             let prev_is_https = scheme_is_https(prev_url);
 
-            host == prev_host && prev_is_https && is_https
+            let same_scheme_or_more_secure =
+                is_https == prev_is_https || (!prev_is_https && is_https);
+
+            host == prev_host && same_scheme_or_more_secure
         }
     }
 }


### PR DESCRIPTION
This PR builds on the work by @llde in #443. 

Currently the stripping of auth headers on redirect is done at the last stage, just when serializing the `Unit` to the socket stream.

This PR moves the logic for stripping auth header to the construction of the `Unit` for the redirect. That makes the logic testable (and tests are added).

Close #442