### PR TITLE
allow send_json to send any serde::Serialize value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,8 +311,25 @@ pub use crate::response::Response;
 // re-export
 #[cfg(feature = "cookies")]
 pub use cookie::Cookie;
+
 #[cfg(feature = "json")]
-pub use serde_json::{to_value as serde_to_value, Map as SerdeMap, Value as SerdeValue};
+pub use {serde, serde_json};
+
+#[cfg(feature = "json")]
+#[deprecated(note = "use ureq::serde_json::Map instead")]
+pub type SerdeMap<K, V> = serde_json::Map<K, V>;
+
+#[cfg(feature = "json")]
+#[deprecated(note = "use ureq::serde_json::Value instead")]
+pub type SerdeValue = serde_json::Value;
+
+#[cfg(feature = "json")]
+#[deprecated(note = "use ureq::serde_json::to_value instead")]
+pub fn serde_to_value<T: serde::Serialize>(
+    value: T,
+) -> std::result::Result<serde_json::Value, serde_json::Error> {
+    serde_json::to_value(value)
+}
 
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/test/body_send.rs
+++ b/src/test/body_send.rs
@@ -35,7 +35,7 @@ fn content_length_on_json() {
     test::set_handler("/content_length_on_json", |_unit| {
         test::make_response(200, "OK", vec![], vec![])
     });
-    let mut json = SerdeMap::new();
+    let mut json = serde_json::Map::new();
     json.insert(
         "Hello".to_string(),
         serde_json::Value::String("World!!!".to_string()),
@@ -87,7 +87,7 @@ fn content_type_on_json() {
     test::set_handler("/content_type_on_json", |_unit| {
         test::make_response(200, "OK", vec![], vec![])
     });
-    let mut json = SerdeMap::new();
+    let mut json = serde_json::Map::new();
     json.insert(
         "Hello".to_string(),
         serde_json::Value::String("World!!!".to_string()),
@@ -106,7 +106,7 @@ fn content_type_not_overriden_on_json() {
     test::set_handler("/content_type_not_overriden_on_json", |_unit| {
         test::make_response(200, "OK", vec![], vec![])
     });
-    let mut json = SerdeMap::new();
+    let mut json = serde_json::Map::new();
     json.insert(
         "Hello".to_string(),
         serde_json::Value::String("World!!!".to_string()),

--- a/src/test/body_send.rs
+++ b/src/test/body_send.rs
@@ -38,10 +38,10 @@ fn content_length_on_json() {
     let mut json = SerdeMap::new();
     json.insert(
         "Hello".to_string(),
-        SerdeValue::String("World!!!".to_string()),
+        serde_json::Value::String("World!!!".to_string()),
     );
     let resp = post("test://host/content_length_on_json")
-        .send_json(SerdeValue::Object(json))
+        .send_json(serde_json::Value::Object(json))
         .unwrap();
     let vec = resp.to_write_vec();
     let s = String::from_utf8_lossy(&vec);
@@ -90,10 +90,10 @@ fn content_type_on_json() {
     let mut json = SerdeMap::new();
     json.insert(
         "Hello".to_string(),
-        SerdeValue::String("World!!!".to_string()),
+        serde_json::Value::String("World!!!".to_string()),
     );
     let resp = post("test://host/content_type_on_json")
-        .send_json(SerdeValue::Object(json))
+        .send_json(serde_json::Value::Object(json))
         .unwrap();
     let vec = resp.to_write_vec();
     let s = String::from_utf8_lossy(&vec);
@@ -109,11 +109,11 @@ fn content_type_not_overriden_on_json() {
     let mut json = SerdeMap::new();
     json.insert(
         "Hello".to_string(),
-        SerdeValue::String("World!!!".to_string()),
+        serde_json::Value::String("World!!!".to_string()),
     );
     let resp = post("test://host/content_type_not_overriden_on_json")
         .set("content-type", "text/plain")
-        .send_json(SerdeValue::Object(json))
+        .send_json(serde_json::Value::Object(json))
         .unwrap();
     let vec = resp.to_write_vec();
     let s = String::from_utf8_lossy(&vec);


### PR DESCRIPTION
I am currently writing a project using `ureq` with the `json` feature enabled and noticed the following which confused me while trying to understand the API:

- `send_json` does not allow users to send any `serde::Serialize`-able  data and instead requires converting data into a `serde_json::Value` before sending. This is inefficient, since data that could be serialize immediately needs to be converted into an intermediate in-memory JSON format instead.
- the API uses renamed versions of the `serde_json` types it uses

This PR:
- changes the signature of `send_json` to allow for any type implementing `serde::Serialize` (including `serde_json::Value`) to be sent. ¹
- replaces all uses of the renamed `serde_json` types in the API with the proper names from `serde_json`
- deprecates the renamed types from `serde_json`
- re-exports the used versions of `serde_json` and `serde`


¹ this is achieved by serializing the data into a `Vec<u8>` in `send_json` and passing that through `Payload::Bytes`.
This has the effect that the crate internal `Debug` implementation now prints the bytes of the json data instead. It would be possible to use `Payload::Text` with the `"utf8"` encoding instead, but the risk of encoding errors seems to outweight the minor benefit in debugging to me.