### PR TITLE
Access methods for error::Transport details

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -139,7 +139,7 @@ impl Transport {
     /// // classification
     /// assert_eq!(error.kind(), ErrorKind::InvalidUrl);
     /// assert_eq!(error.kind().to_string(), "Bad URL");
-///
+    ///
     /// // higher level message
     /// assert_eq!(error.message(), Some("failed to parse URL: RelativeUrlWithoutBase"));
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,7 +139,7 @@ impl Transport {
     /// // classification
     /// assert_eq!(error.kind(), ErrorKind::InvalidUrl);
     /// assert_eq!(error.kind().to_string(), "Bad URL");
-
+///
     /// // higher level message
     /// assert_eq!(error.message(), Some("failed to parse URL: RelativeUrlWithoutBase"));
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -356,8 +356,8 @@ impl ErrorKind {
         Error::new(self, None)
     }
 
-    pub(crate) fn msg(self, s: &str) -> Error {
-        Error::new(self, Some(s.to_string()))
+    pub(crate) fn msg(self, s: impl Into<String>) -> Error {
+        Error::new(self, Some(s.into()))
     }
 }
 
@@ -382,7 +382,7 @@ impl From<Transport> for Error {
 impl From<ParseError> for Error {
     fn from(err: ParseError) -> Self {
         ErrorKind::InvalidUrl
-            .msg(&format!("failed to parse URL: {:?}", err))
+            .msg(format!("failed to parse URL: {:?}", err))
             .src(err)
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -143,7 +143,7 @@ impl Header {
         let value_raw = &bytes[self.index + 1..];
 
         if !valid_name(name_raw) || !valid_value(value_raw) {
-            Err(ErrorKind::BadHeader.msg(&format!("invalid header '{}'", self.line)))
+            Err(ErrorKind::BadHeader.msg(format!("invalid header '{}'", self.line)))
         } else {
             Ok(())
         }

--- a/src/ntls.rs
+++ b/src/ntls.rs
@@ -16,8 +16,13 @@ impl TlsConnector for native_tls::TlsConnector {
         dns_name: &str,
         tcp_stream: TcpStream,
     ) -> Result<Box<dyn HttpsStream>, Error> {
-        let stream = native_tls::TlsConnector::connect(self, dns_name, tcp_stream)
-            .map_err(|e| ErrorKind::Dns.new().src(e))?;
+        let stream =
+            native_tls::TlsConnector::connect(self, dns_name, tcp_stream).map_err(|e| {
+                ErrorKind::ConnectionFailed
+                    .msg("native_tls connect failed")
+                    .src(e)
+            })?;
+
         Ok(Box::new(stream))
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -548,7 +548,9 @@ fn parse_status_line(line: &str) -> Result<(ResponseStatusIndex, u16), Error> {
         return Err(BadStatus.msg("Status code was wrong length"));
     }
 
-    let status: u16 = status_str.parse().map_err(|_| BadStatus.new())?;
+    let status: u16 = status_str
+        .parse()
+        .map_err(|_| BadStatus.msg(format!("unable to parse status as u16 ({})", status_str)))?;
 
     Ok((
         ResponseStatusIndex {

--- a/src/rtls.rs
+++ b/src/rtls.rs
@@ -97,7 +97,7 @@ impl TlsConnector for Arc<rustls::ClientConfig> {
     ) -> Result<Box<dyn HttpsStream>, Error> {
         let sni = rustls::ServerName::try_from(dns_name).map_err(|e| {
             ErrorKind::Dns
-                .msg(format!("dns server name failed ({})", dns_name))
+                .msg(format!("parsing '{}'", dns_name))
                 .src(e)
         })?;
 

--- a/src/rtls.rs
+++ b/src/rtls.rs
@@ -95,11 +95,8 @@ impl TlsConnector for Arc<rustls::ClientConfig> {
         dns_name: &str,
         mut tcp_stream: TcpStream,
     ) -> Result<Box<dyn HttpsStream>, Error> {
-        let sni = rustls::ServerName::try_from(dns_name).map_err(|e| {
-            ErrorKind::Dns
-                .msg(format!("parsing '{}'", dns_name))
-                .src(e)
-        })?;
+        let sni = rustls::ServerName::try_from(dns_name)
+            .map_err(|e| ErrorKind::Dns.msg(format!("parsing '{}'", dns_name)).src(e))?;
 
         let mut sess = rustls::ClientConnection::new(self.clone(), sni)
             .map_err(|e| ErrorKind::Io.msg("tls connection creation failed").src(e))?;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -352,7 +352,7 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
     // TODO: Find a way to apply deadline to DNS lookup.
     let sock_addrs = unit.resolver().resolve(&netloc).map_err(|e| {
         ErrorKind::Dns
-            .msg(format!("failed to resove dns ({})", netloc))
+            .msg(format!("resolve dns name '{}'", netloc))
             .src(e)
     })?;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -350,13 +350,14 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
     };
 
     // TODO: Find a way to apply deadline to DNS lookup.
-    let sock_addrs = unit
-        .resolver()
-        .resolve(&netloc)
-        .map_err(|e| ErrorKind::Dns.new().src(e))?;
+    let sock_addrs = unit.resolver().resolve(&netloc).map_err(|e| {
+        ErrorKind::Dns
+            .msg(format!("failed to resove dns ({})", netloc))
+            .src(e)
+    })?;
 
     if sock_addrs.is_empty() {
-        return Err(ErrorKind::Dns.msg(&format!("No ip address for {}", hostname)));
+        return Err(ErrorKind::Dns.msg(format!("No ip address for {}", hostname)));
     }
 
     let proto = proxy.as_ref().map(|proxy| proxy.proto);
@@ -621,5 +622,5 @@ pub(crate) fn connect_test(unit: &Unit) -> Result<Stream, Error> {
 
 #[cfg(not(test))]
 pub(crate) fn connect_test(unit: &Unit) -> Result<Stream, Error> {
-    Err(ErrorKind::UnknownScheme.msg(&format!("unknown scheme '{}'", unit.url.scheme())))
+    Err(ErrorKind::UnknownScheme.msg(format!("unknown scheme '{}'", unit.url.scheme())))
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -168,7 +168,10 @@ pub(crate) fn connect(
             break resp;
         }
         if history.len() + 1 >= unit.agent.config.redirects as usize {
-            return Err(ErrorKind::TooManyRedirects.new());
+            return Err(ErrorKind::TooManyRedirects.msg(format!(
+                "reached max redirects ({})",
+                unit.agent.config.redirects
+            )));
         }
         // the location header
         let location = match resp.header("location") {
@@ -181,7 +184,7 @@ pub(crate) fn connect(
         // join location header to current url in case it is relative
         let new_url = url.join(location).map_err(|e| {
             ErrorKind::InvalidUrl
-                .msg(&format!("Bad redirection: {}", location))
+                .msg(format!("Bad redirection: {}", location))
                 .src(e)
         })?;
 
@@ -340,7 +343,7 @@ fn extract_cookies(agent: &Agent, url: &Url) -> Option<Header> {
 fn connect_socket(unit: &Unit, hostname: &str, use_pooled: bool) -> Result<(Stream, bool), Error> {
     match unit.url.scheme() {
         "http" | "https" | "test" => (),
-        scheme => return Err(ErrorKind::UnknownScheme.msg(&format!("unknown scheme '{}'", scheme))),
+        scheme => return Err(ErrorKind::UnknownScheme.msg(format!("unknown scheme '{}'", scheme))),
     };
     if use_pooled {
         let pool = &unit.agent.state.pool;
@@ -360,7 +363,7 @@ fn connect_socket(unit: &Unit, hostname: &str, use_pooled: bool) -> Result<(Stre
         "http" => stream::connect_http(unit, hostname),
         "https" => stream::connect_https(unit, hostname),
         "test" => connect_test(unit),
-        scheme => Err(ErrorKind::UnknownScheme.msg(&format!("unknown scheme {}", scheme))),
+        scheme => Err(ErrorKind::UnknownScheme.msg(format!("unknown scheme {}", scheme))),
     };
     Ok((stream?, false))
 }


### PR DESCRIPTION
This PR provides access methods for `error::Transport` to make it easier
for a user to investigate errors arising.

Close #400

Additionally the PR attempts to provide `Transport::message()` where reasonably possible.