### PR TITLE
Fix chunked encoding with broken ending

### DIFF
--- a/src/chunked/decoder.rs
+++ b/src/chunked/decoder.rs
@@ -125,6 +125,39 @@ where
             _ => Err(IoError::new(ErrorKind::InvalidInput, DecoderError)),
         }
     }
+
+    // Sometimes the last \r\n is missing.
+    fn read_end(&mut self) -> IoResult<()> {
+        fn expect_or_end(
+            bytes: &mut impl Iterator<Item = IoResult<u8>>,
+            expected: u8,
+        ) -> IoResult<()> {
+            match bytes.next() {
+                Some(Ok(c)) => {
+                    if c == expected {
+                        Ok(())
+                    } else {
+                        Err(IoError::new(ErrorKind::InvalidInput, DecoderError))
+                    }
+                }
+                Some(Err(e)) => {
+                    match e.kind() {
+                        // Closed connections are ok.
+                        ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted => Ok(()),
+                        _ => Err(IoError::new(ErrorKind::InvalidInput, DecoderError)),
+                    }
+                }
+                None => Ok(()), // End of iterator is ok
+            }
+        }
+
+        let mut bytes = self.source.by_ref().bytes();
+
+        expect_or_end(&mut bytes, b'\r')?;
+        expect_or_end(&mut bytes, b'\n')?;
+
+        Ok(())
+    }
 }
 
 impl<R> Read for Decoder<R>
@@ -141,8 +174,7 @@ where
 
                 // if the chunk size is 0, we are at EOF
                 if chunk_size == 0 {
-                    self.read_carriage_return()?;
-                    self.read_line_feed()?;
+                    self.read_end()?;
                     return Ok(0);
                 }
 
@@ -302,5 +334,24 @@ mod test {
 
         let mut string = String::new();
         assert!(decoded.read_to_string(&mut string).is_err());
+    }
+
+    #[test]
+    fn test_decode_end_missing_last_crlf() {
+        // This has been observed in the wild.
+        // See https://github.com/algesten/ureq/issues/325
+
+        // Missing last \r\n
+        let source = io::Cursor::new(
+            "3\r\nhel\r\nb\r\nlo world!!!\r\n0\r\n"
+                .to_string()
+                .into_bytes(),
+        );
+        let mut decoded = Decoder::new(source);
+
+        let mut string = String::new();
+        assert!(decoded.read_to_string(&mut string).is_ok());
+
+        assert_eq!(string, "hello world!!!");
     }
 }


### PR DESCRIPTION
Some websites do not end chunked encoding correctly. The spec says the end should be:

```
0\r\n
\r\n
```

However some sites stop short after `0\r\n`. Curl handles this case fine.

Close #325 
