### PR TITLE
Bump rustls to >=0.20.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ cookie_store = { version = "0.15", optional = true, default-features = false, fe
 log = "0.4"
 webpki = { version = "0.22", optional = true }
 webpki-roots = { version = "0.22", optional = true }
-rustls = { version = "0.20", optional = true }
+rustls = { version = ">=0.20.1", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }


### PR DESCRIPTION
Without this we get a build error because we depend on an impl of Error
on InvalidDnsNameError.

```
error[E0277]: the trait bound `client::client_conn::InvalidDnsNameError: std::error::Error` is not satisfied
  --> src/rtls.rs:99:89
   |
99 |             rustls::ServerName::try_from(dns_name).map_err(|e| ErrorKind::Dns.new().src(e))?;
   |                                                                                     --- ^ the trait `std::error::Error` is not implemented for `client::client_conn::InvalidDnsNameError`
   |                                                                                     |
   |                                                                                     required by a bound introduced by this call

For more information about this error, try `rustc --explain E0277`.
```