### PR TITLE
Run cargo test with minimal versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,21 @@ jobs:
         with:
           command: test
           args: --no-default-features --features "${{ matrix.tls }}" "${{ matrix.feature }}"
+  minver:
+    name: Check minimum versions
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          default: true
+
+      - name: cargo test (debug; all features; -Z minimal-versions)
+        run: cargo -Z minimal-versions test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ gzip = ["flate2"]
 brotli = ["brotli-decompressor"]
 
 [dependencies]
+# We don't depend directly on proc-macro-hack, but our dependencies do.
+# And proc-macro-hack <0.5.9 breaks when built with -Z minimal-versions.
+# So we force 0.5.9 to allow building with -Z minimal-versions in our tests.
+# https://github.com/dtolnay/proc-macro-hack/issues/60
+proc-macro-hack = "0.5.9"
 base64 = "0.13"
 chunked_transfer = "1.2"
 cookie = { version = "0.15", default-features = false, optional = true}


### PR DESCRIPTION
This can catch breakages that are hidden by latest version selection.