### PR TITLE
Fix doctests

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -216,7 +216,7 @@ impl Agent {
     ///
     /// // Saves (persistent) cookies
     /// let mut file = File::create("cookies.json")?;
-    /// agent.cookie_store().save_json(&mut file)?;
+    /// agent.cookie_store().save_json(&mut file).unwrap();
     /// # Ok(())
     /// # }
     /// ```
@@ -546,7 +546,7 @@ impl AgentBuilder {
     /// This overrides any previous call to tls_config or tls_connector.
     ///
     /// ```
-    /// # fn main() -> Result<(), ureq::Error> {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # ureq::is_test(true);
     /// use std::sync::Arc;
     /// # #[cfg(feature = "native-tls")]
@@ -580,7 +580,7 @@ impl AgentBuilder {
     /// let read = BufReader::new(file);
     ///
     /// // Read persisted cookies from cookies.json
-    /// let my_store = CookieStore::load_json(read)?;
+    /// let my_store = CookieStore::load_json(read).unwrap();
     ///
     /// // Cookies will be used for requests done through agent.
     /// let agent = ureq::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@
 //!
 //! ```no_run
 //! # #[cfg(feature = "native-tls")]
-//! # fn build() -> std::result::Result<(), ureq::Error> {
+//! # fn build() -> std::result::Result<(), Box<dyn std::error::Error>> {
 //! # ureq::is_test(true);
 //!   use std::sync::Arc;
 //!   use ureq::Agent;


### PR DESCRIPTION
#458 broke the doctests when run with `--all-features`. I'm not sure why this wasn't caught by the tests. The [cookie test run says](https://github.com/algesten/ureq/runs/4578224840?check_suite_focus=true):

```
/home/runner/.cargo/bin/cargo test --no-default-features --features  cookies
...
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.00s
```