### PR TITLE
Add tcp no_delay option

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -54,6 +54,7 @@ pub(crate) struct AgentConfig {
     pub timeout_read: Option<Duration>,
     pub timeout_write: Option<Duration>,
     pub timeout: Option<Duration>,
+    pub no_delay: Option<bool>,
     pub redirects: u32,
     pub redirect_auth_headers: RedirectAuthHeaders,
     pub user_agent: String,
@@ -238,6 +239,7 @@ impl AgentBuilder {
                 timeout_read: None,
                 timeout_write: None,
                 timeout: None,
+                no_delay: None,
                 redirects: 5,
                 redirect_auth_headers: RedirectAuthHeaders::Never,
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
@@ -430,6 +432,26 @@ impl AgentBuilder {
     /// ```
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.config.timeout = Some(timeout);
+        self
+    }
+
+    /// Whether no_delay will be set on the tcp socket.
+    /// Setting this to true disables Nagle's algorithm.
+    ///
+    /// Defaults to true.
+    ///
+    /// ```
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # ureq::is_test(true);
+    /// let agent = ureq::builder()
+    ///     .no_delay(false)
+    ///     .build();
+    /// let result = agent.get("http://httpbin.org/get").call();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn no_delay(mut self, no_delay: bool) -> Self {
+        self.config.no_delay = Some(no_delay);
         self
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -54,7 +54,7 @@ pub(crate) struct AgentConfig {
     pub timeout_read: Option<Duration>,
     pub timeout_write: Option<Duration>,
     pub timeout: Option<Duration>,
-    pub no_delay: Option<bool>,
+    pub no_delay: bool,
     pub redirects: u32,
     pub redirect_auth_headers: RedirectAuthHeaders,
     pub user_agent: String,
@@ -239,7 +239,7 @@ impl AgentBuilder {
                 timeout_read: None,
                 timeout_write: None,
                 timeout: None,
-                no_delay: None,
+                no_delay: true,
                 redirects: 5,
                 redirect_auth_headers: RedirectAuthHeaders::Never,
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
@@ -451,7 +451,7 @@ impl AgentBuilder {
     /// # }
     /// ```
     pub fn no_delay(mut self, no_delay: bool) -> Self {
-        self.config.no_delay = Some(no_delay);
+        self.config.no_delay = no_delay;
         self
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -407,7 +407,7 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
         panic!("shouldn't happen: failed to connect to all IPs, but no error");
     };
 
-    stream.set_nodelay(unit.agent.config.no_delay.unwrap_or(true))?;
+    stream.set_nodelay(unit.agent.config.no_delay)?;
 
     if let Some(deadline) = unit.deadline {
         stream.set_read_timeout(Some(time_until_deadline(deadline)?))?;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -407,6 +407,8 @@ pub(crate) fn connect_host(unit: &Unit, hostname: &str, port: u16) -> Result<Tcp
         panic!("shouldn't happen: failed to connect to all IPs, but no error");
     };
 
+    stream.set_nodelay(unit.agent.config.no_delay.unwrap_or(true))?;
+
     if let Some(deadline) = unit.deadline {
         stream.set_read_timeout(Some(time_until_deadline(deadline)?))?;
     } else {


### PR DESCRIPTION
Closes #390.

Defaults to set no_delay but can be overwritten by calling `agent.no_delay(false)`.