### PR TITLE
Implement digest authentication middleware behind a feature flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           command: doc
           # Keep in sync with Cargo.toml's [package.metadata.docs.rs]
-          args: --no-default-features --no-deps --features "tls native-tls json charset cookies socks-proxy"
+          args: --no-default-features --no-deps --features "tls native-tls json charset cookies socks-proxy digest-auth"
   build_and_test:
     name: Test
     runs-on: ubuntu-latest
@@ -56,6 +56,7 @@ jobs:
           - cookies
           - socks-proxy
           - native-certs
+          - digest-auth
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 # Keep in sync with .github/workflows/test.yml
-features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy"]
+features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy", "digest-auth"]
 
 [features]
 default = ["tls", "gzip"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
 gzip = ["flate2"]
 brotli = ["brotli-decompressor"]
+digest-auth = ["digest_auth"]
 
 [dependencies]
 base64 = "0.13"
@@ -44,6 +45,7 @@ rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }
 brotli-decompressor = { version = "2.3.2", optional = true }
+digest_auth = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,9 @@ pub use crate::resolve::Resolver;
 pub use crate::response::Response;
 pub use crate::stream::TlsConnector;
 
+#[cfg(feature = "digest-auth")]
+pub use middleware::digest::DigestAuthMiddleware;
+
 // re-export
 #[cfg(feature = "cookies")]
 pub use cookie::Cookie;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -186,7 +186,7 @@ pub mod digest {
     /// let arbitrary_username = "MyUsername";
     /// let arbitrary_password = "MyPassword";
     /// let digest_auth_middleware =
-    ///     ureq::DigestAuthMiddleware::new(arbitrary_username.into(), arbitrary_password.into());
+    ///     ureq::DigestAuthMiddleware::new(arbitrary_username, arbitrary_password);
     /// # let url = String::new();
     ///
     /// let agent = ureq::AgentBuilder::new().middleware(digest_auth_middleware).build();
@@ -198,8 +198,14 @@ pub mod digest {
     }
 
     impl DigestAuthMiddleware {
-        pub fn new(username: Cow<'static, str>, password: Cow<'static, str>) -> Self {
-            Self { username, password }
+        pub fn new(
+            username: impl Into<Cow<'static, str>>,
+            password: impl Into<Cow<'static, str>>,
+        ) -> Self {
+            Self {
+                username: username.into(),
+                password: password.into(),
+            }
         }
 
         fn construct_answer_to_challenge(
@@ -208,7 +214,7 @@ pub mod digest {
             response: &Response,
         ) -> Option<String> {
             let challenge_string = response.header("www-authenticate")?;
-            let mut challenge = WwwAuthenticateHeader::from_str(&challenge_string).ok()?;
+            let mut challenge = WwwAuthenticateHeader::from_str(challenge_string).ok()?;
             let path = request.request_url().ok()?.path().to_string();
             let context = AuthContext::new(
                 self.username.as_ref(),

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -174,11 +174,13 @@ pub mod digest {
 
     /// Provides simple digest authentication powered by the `digest_auth` crate.
     ///
-    /// Any 401 response handled by this middleware is retried once with the
-    /// credentials provided on construction. If authentication fails or the middleware
-    /// is unable to generate an answer to the server challenge (such as a different authentication
-    /// scheme or a malformed challenge) the response is silently passed on to the rest
-    /// of the middleware chain.
+    /// Requests that receive a HTTP 401 response are retried once by this middleware with the
+    /// credentials provided on construction. The retry only happens under these conditions:
+    /// - there is no prior "authorization" header on the request set by the caller or other
+    ///   middleware, and
+    /// - the server provides HTTP Digest auth challenge in the "www-authenticate" header.
+    ///
+    /// In other cases, this middle ware acts as a no-op forwarder of requests and responses.
     ///
     /// ```
     /// let arbitrary_username = "MyUsername";

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -177,10 +177,10 @@ pub mod digest {
     /// Requests that receive a HTTP 401 response are retried once by this middleware with the
     /// credentials provided on construction. The retry only happens under these conditions:
     /// - there is no prior "authorization" header on the request set by the caller or other
-    ///   middleware, and
+    ///   middleware, and;
     /// - the server provides HTTP Digest auth challenge in the "www-authenticate" header.
     ///
-    /// In other cases, this middle ware acts as a no-op forwarder of requests and responses.
+    /// In other cases, this middleware acts as a no-op forwarder of requests and responses.
     ///
     /// ```
     /// let arbitrary_username = "MyUsername";
@@ -226,7 +226,7 @@ pub mod digest {
     impl Middleware for DigestAuthMiddleware {
         fn handle(&self, request: Request, next: MiddlewareNext) -> Result<Response, Error> {
             // Prevent infinite recursion when doing a nested request below.
-            if request.header("Authorization").is_some() {
+            if request.header("authorization").is_some() {
                 return next.handle(request);
             }
 
@@ -235,7 +235,7 @@ pub mod digest {
                 response.status(),
                 self.construct_answer_to_challenge(&request, &response),
             ) {
-                request.set("Authorization", &challenge_answer).call()
+                request.set("authorization", &challenge_answer).call()
             } else {
                 Ok(response)
             }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -201,12 +201,11 @@ pub mod digest {
                 self.password.as_ref(),
                 Cow::from(path),
             );
-            let answer = challenge
+            challenge
                 .respond(&context)
                 .as_ref()
                 .map(ToString::to_string)
-                .ok()?;
-            Some(answer)
+                .ok()
         }
     }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -177,7 +177,19 @@ pub mod digest {
     /// Any 401 response handled by this middleware is retried once with the
     /// credentials provided on construction. If authentication fails or the middleware
     /// is unable to generate an answer to the server challenge (such as a different authentication
-    /// scheme or a malformed challenge) the response is silently passed on.
+    /// scheme or a malformed challenge) the response is silently passed on to the rest
+    /// of the middleware chain.
+    ///
+    /// ```
+    /// let arbitrary_username = "MyUsername";
+    /// let arbitrary_password = "MyPassword";
+    /// let digest_auth_middleware =
+    ///     ureq::DigestAuthMiddleware::new(arbitrary_username.into(), arbitrary_password.into());
+    /// # let url = String::new();
+    ///
+    /// let agent = ureq::AgentBuilder::new().middleware(digest_auth_middleware).build();
+    /// agent.get(&url).call();
+    /// ```
     pub struct DigestAuthMiddleware {
         username: Cow<'static, str>,
         password: Cow<'static, str>,

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -1,0 +1,80 @@
+use crate::{Request, Response, Error, Middleware, MiddlewareNext};
+use digest_auth::{AuthContext, WwwAuthenticateHeader};
+use std::{borrow::Cow, str::FromStr};
+
+/// Provides simple digest authentication powered by the `digest_auth` crate.
+///
+/// Requests that receive a HTTP 401 response are retried once by this middleware with the
+/// credentials provided on construction. The retry only happens under these conditions:
+/// - there is no prior "authorization" header on the request set by the caller or other
+///   middleware, and;
+/// - the server provides HTTP Digest auth challenge in the "www-authenticate" header.
+///
+/// In other cases, this middleware acts as a no-op forwarder of requests and responses.
+///
+/// ```
+/// let arbitrary_username = "MyUsername";
+/// let arbitrary_password = "MyPassword";
+/// let digest_auth_middleware =
+///     ureq::DigestAuthMiddleware::new(arbitrary_username, arbitrary_password);
+/// # let url = String::new();
+///
+/// let agent = ureq::AgentBuilder::new().middleware(digest_auth_middleware).build();
+/// agent.get(&url).call();
+/// ```
+pub struct DigestAuthMiddleware {
+    username: Cow<'static, str>,
+    password: Cow<'static, str>,
+}
+
+impl DigestAuthMiddleware {
+    pub fn new(
+        username: impl Into<Cow<'static, str>>,
+        password: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+
+    fn construct_answer_to_challenge(
+        &self,
+        request: &Request,
+        response: &Response,
+    ) -> Option<String> {
+        let challenge_string = response.header("www-authenticate")?;
+        let mut challenge = WwwAuthenticateHeader::from_str(challenge_string).ok()?;
+        let path = request.request_url().ok()?.path().to_string();
+        let context = AuthContext::new(
+            self.username.as_ref(),
+            self.password.as_ref(),
+            Cow::from(path),
+        );
+        challenge
+            .respond(&context)
+            .as_ref()
+            .map(ToString::to_string)
+            .ok()
+    }
+}
+
+impl Middleware for DigestAuthMiddleware {
+    fn handle(&self, request: Request, next: MiddlewareNext) -> Result<Response, Error> {
+        // Prevent infinite recursion when doing a nested request below.
+        if request.header("authorization").is_some() {
+            return next.handle(request);
+        }
+
+        let response = next.handle(request.clone())?;
+        if let (401, Some(challenge_answer)) = (
+            response.status(),
+            self.construct_answer_to_challenge(&request, &response),
+        ) {
+            request.set("authorization", &challenge_answer).call()
+        } else {
+            Ok(response)
+        }
+    }
+}
+

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -35,11 +35,7 @@ impl DigestAuthMiddleware {
         }
     }
 
-    fn respond_to_challenge(
-        &self,
-        request: &Request,
-        response: &Response,
-    ) -> Option<String> {
+    fn respond_to_challenge(&self, request: &Request, response: &Response) -> Option<String> {
         let challenge_string = response.header("www-authenticate")?;
         let mut challenge = WwwAuthenticateHeader::from_str(challenge_string).ok()?;
         let url = request.request_url().ok()?;

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -35,7 +35,7 @@ impl DigestAuthMiddleware {
         }
     }
 
-    fn construct_answer_to_challenge(
+    fn respond_to_challenge(
         &self,
         request: &Request,
         response: &Response,
@@ -63,7 +63,7 @@ impl Middleware for DigestAuthMiddleware {
         let response = next.handle(request.clone())?;
         if let (401, Some(challenge_answer)) = (
             response.status(),
-            self.construct_answer_to_challenge(&request, &response),
+            self.respond_to_challenge(&request, &response),
         ) {
             request.set("authorization", &challenge_answer).call()
         } else {

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,5 +1,8 @@
 use crate::{Error, Request, Response};
 
+#[cfg(feature = "digest-auth")]
+pub mod digest;
+
 /// Chained processing of request (and response).
 ///
 /// # Middleware as `fn`
@@ -162,89 +165,5 @@ where
 {
     fn handle(&self, request: Request, next: MiddlewareNext) -> Result<Response, Error> {
         (self)(request, next)
-    }
-}
-
-#[cfg(feature = "digest-auth")]
-pub mod digest {
-    use super::*;
-    use crate::{Request, Response};
-    use digest_auth::{AuthContext, WwwAuthenticateHeader};
-    use std::{borrow::Cow, str::FromStr};
-
-    /// Provides simple digest authentication powered by the `digest_auth` crate.
-    ///
-    /// Requests that receive a HTTP 401 response are retried once by this middleware with the
-    /// credentials provided on construction. The retry only happens under these conditions:
-    /// - there is no prior "authorization" header on the request set by the caller or other
-    ///   middleware, and;
-    /// - the server provides HTTP Digest auth challenge in the "www-authenticate" header.
-    ///
-    /// In other cases, this middleware acts as a no-op forwarder of requests and responses.
-    ///
-    /// ```
-    /// let arbitrary_username = "MyUsername";
-    /// let arbitrary_password = "MyPassword";
-    /// let digest_auth_middleware =
-    ///     ureq::DigestAuthMiddleware::new(arbitrary_username, arbitrary_password);
-    /// # let url = String::new();
-    ///
-    /// let agent = ureq::AgentBuilder::new().middleware(digest_auth_middleware).build();
-    /// agent.get(&url).call();
-    /// ```
-    pub struct DigestAuthMiddleware {
-        username: Cow<'static, str>,
-        password: Cow<'static, str>,
-    }
-
-    impl DigestAuthMiddleware {
-        pub fn new(
-            username: impl Into<Cow<'static, str>>,
-            password: impl Into<Cow<'static, str>>,
-        ) -> Self {
-            Self {
-                username: username.into(),
-                password: password.into(),
-            }
-        }
-
-        fn construct_answer_to_challenge(
-            &self,
-            request: &Request,
-            response: &Response,
-        ) -> Option<String> {
-            let challenge_string = response.header("www-authenticate")?;
-            let mut challenge = WwwAuthenticateHeader::from_str(challenge_string).ok()?;
-            let path = request.request_url().ok()?.path().to_string();
-            let context = AuthContext::new(
-                self.username.as_ref(),
-                self.password.as_ref(),
-                Cow::from(path),
-            );
-            challenge
-                .respond(&context)
-                .as_ref()
-                .map(ToString::to_string)
-                .ok()
-        }
-    }
-
-    impl Middleware for DigestAuthMiddleware {
-        fn handle(&self, request: Request, next: MiddlewareNext) -> Result<Response, Error> {
-            // Prevent infinite recursion when doing a nested request below.
-            if request.header("authorization").is_some() {
-                return next.handle(request);
-            }
-
-            let response = next.handle(request.clone())?;
-            if let (401, Some(challenge_answer)) = (
-                response.status(),
-                self.construct_answer_to_challenge(&request, &response),
-            ) {
-                request.set("authorization", &challenge_answer).call()
-            } else {
-                Ok(response)
-            }
-        }
     }
 }

--- a/src/test/digest.rs
+++ b/src/test/digest.rs
@@ -34,8 +34,5 @@ fn invalid_credentials() {
         .middleware(digest_auth_middleware)
         .build();
     let result = agent.get(&test_url).call();
-    match result {
-        Err(Error::Status(401, _)) => (),
-        _ => panic!("Expected 401 error, received {:?}", result),
-    }
+    assert!(matches!(result, Err(Error::Status(401, _))), "Expected 401 error, received {:?}", result);
 }

--- a/src/test/digest.rs
+++ b/src/test/digest.rs
@@ -8,8 +8,10 @@ fn valid_credentials() {
     let arbitrary_password = "MyPassword";
     let digest_auth_middleware =
         DigestAuthMiddleware::new(arbitrary_username.into(), arbitrary_password.into());
-    let test_url =
-        format!("http://httpbin.org/digest-auth/auth/{arbitrary_username}/{arbitrary_password}");
+    let test_url = format!(
+        "http://httpbin.org/digest-auth/auth/{}/{}",
+        arbitrary_username, arbitrary_password
+    );
     let agent = AgentBuilder::new()
         .timeout_read(Duration::from_secs(5))
         .timeout_write(Duration::from_secs(5))
@@ -26,13 +28,19 @@ fn invalid_credentials() {
     let bad_password = "BadPassword";
     let digest_auth_middleware =
         DigestAuthMiddleware::new(arbitrary_username.into(), bad_password.into());
-    let test_url =
-        format!("http://httpbin.org/digest-auth/auth/{arbitrary_username}/{arbitrary_password}");
+    let test_url = format!(
+        "http://httpbin.org/digest-auth/auth/{}/{}",
+        arbitrary_username, arbitrary_password
+    );
     let agent = AgentBuilder::new()
         .timeout_read(Duration::from_secs(5))
         .timeout_write(Duration::from_secs(5))
         .middleware(digest_auth_middleware)
         .build();
     let result = agent.get(&test_url).call();
-    assert!(matches!(result, Err(Error::Status(401, _))), "Expected 401 error, received {:?}", result);
+    assert!(
+        matches!(result, Err(Error::Status(401, _))),
+        "Expected 401 error, received {:?}",
+        result
+    );
 }

--- a/src/test/digest.rs
+++ b/src/test/digest.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use super::super::*;
+
+#[test]
+fn valid_credentials() {
+    let arbitrary_username = "MyUsername";
+    let arbitrary_password = "MyPassword";
+    let digest_auth_middleware =
+        DigestAuthMiddleware::new(arbitrary_username.into(), arbitrary_password.into());
+    let test_url =
+        format!("http://httpbin.org/digest-auth/auth/{arbitrary_username}/{arbitrary_password}");
+    let agent = AgentBuilder::new()
+        .timeout_read(Duration::from_secs(5))
+        .timeout_write(Duration::from_secs(5))
+        .middleware(digest_auth_middleware)
+        .build();
+    let result = agent.get(&test_url).call();
+    assert_eq!(result.unwrap().status(), 200);
+}
+
+#[test]
+fn invalid_credentials() {
+    let arbitrary_username = "MyUsername";
+    let arbitrary_password = "MyPassword";
+    let bad_password = "BadPassword";
+    let digest_auth_middleware =
+        DigestAuthMiddleware::new(arbitrary_username.into(), bad_password.into());
+    let test_url =
+        format!("http://httpbin.org/digest-auth/auth/{arbitrary_username}/{arbitrary_password}");
+    let agent = AgentBuilder::new()
+        .timeout_read(Duration::from_secs(5))
+        .timeout_write(Duration::from_secs(5))
+        .middleware(digest_auth_middleware)
+        .build();
+    let result = agent.get(&test_url).call();
+    match result {
+        Err(Error::Status(401, _)) => (),
+        _ => panic!("Expected 401 error, received {:?}", result),
+    }
+}

--- a/src/test/digest.rs
+++ b/src/test/digest.rs
@@ -6,8 +6,7 @@ use super::super::*;
 fn valid_credentials() {
     let arbitrary_username = "MyUsername";
     let arbitrary_password = "MyPassword";
-    let digest_auth_middleware =
-        DigestAuthMiddleware::new(arbitrary_username.into(), arbitrary_password.into());
+    let digest_auth_middleware = DigestAuthMiddleware::new(arbitrary_username, arbitrary_password);
     let test_url = format!(
         "http://httpbin.org/digest-auth/auth/{}/{}",
         arbitrary_username, arbitrary_password
@@ -26,8 +25,7 @@ fn invalid_credentials() {
     let arbitrary_username = "MyUsername";
     let arbitrary_password = "MyPassword";
     let bad_password = "BadPassword";
-    let digest_auth_middleware =
-        DigestAuthMiddleware::new(arbitrary_username.into(), bad_password.into());
+    let digest_auth_middleware = DigestAuthMiddleware::new(arbitrary_username, bad_password);
     let test_url = format!(
         "http://httpbin.org/digest-auth/auth/{}/{}",
         arbitrary_username, arbitrary_password

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -9,6 +9,8 @@ use std::sync::{Arc, Mutex};
 mod agent_test;
 mod body_read;
 mod body_send;
+#[cfg(feature = "digest-auth")]
+mod digest;
 mod query_string;
 mod range;
 mod redirect;

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ set -eu
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D dead_code -D unused-variables -D unused"
 
-for feature in "" tls json charset cookies socks-proxy "tls native-certs" native-tls; do
+for feature in "" tls json charset cookies socks-proxy "tls native-certs" native-tls digest-auth; do
   if ! cargo test --no-default-features --features "${feature}" ; then
     echo Command failed: cargo test --no-default-features --features \"${feature}\"
     exit 1


### PR DESCRIPTION
In #392 , @algesten mentioned that it could be possible to consider default middleware for common features like Digest authentication. Here's a simple implementation, in case it's general enough to add to the main crate.

Some thoughts:
* I realized the structure of the project is pretty nice and flat, so it felt wrong to create a subfolder for particular middlewares. I ended up adding this as a feature-flagged embedded module under `digest`. Is this a good approach?
* I'm not sure about using external services like httpbin for unit tests, but I saw other tests doing a similar thing so I went with what seemed to be the simplest approach. I'm happy to take directions on how to mock this instead to fully test it offline.
* The recursive solution helps transparently navigate the "back and forth" between server and client without needing any `Arc<Mutex<>>` state in the middleware itself, but this may be erring on the "too smart" side. I don't directly see any problems it might cause but I could definitely be missing some.