### PR TITLE
Fix rustls version spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ cookie_store = { version = "0.15", optional = true, default-features = false, fe
 log = "0.4"
 webpki = { version = "0.22", optional = true }
 webpki-roots = { version = "0.22", optional = true }
-rustls = { version = ">=0.20.1", optional = true }
+rustls = { version = "0.20.1", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }


### PR DESCRIPTION
`>=0.20.1` doesn't have an upper bound and will accept 0.21 (and higher) once they're available, but they'd presumably have breaking changes.
`0.20.1` means `^0.20.1`, which means `>=0.20.1, <0.21.0`.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements