### PR TITLE
Remove Sync requirement of ReadWrite trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ socks = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
+sync_wrapper = { version = "0.1" } 
 cookie_store = { version = "0.15", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4"
 webpki = { version = "0.22", optional = true }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,7 +18,7 @@ use crate::error::ErrorKind;
 use crate::unit::Unit;
 
 /// Trait for things implementing [std::io::Read] + [std::io::Write]. Used in [TlsConnector].
-pub trait ReadWrite: Read + Write + Send + Sync + 'static {
+pub trait ReadWrite: Read + Write + Send + 'static {
     fn socket(&self) -> Option<&TcpStream>;
 }
 
@@ -31,7 +31,7 @@ pub trait TlsConnector: Send + Sync {
 }
 
 pub(crate) struct Stream {
-    inner: BufReader<Box<dyn Inner + Send + Sync + 'static>>,
+    inner: BufReader<Box<dyn Inner + Send + 'static>>,
 }
 
 trait Inner: Read + Write {
@@ -188,7 +188,7 @@ impl fmt::Debug for Stream {
 }
 
 impl Stream {
-    fn new(t: impl Inner + Send + Sync + 'static) -> Stream {
+    fn new(t: impl Inner + Send + 'static) -> Stream {
         Stream::logged_create(Stream {
             inner: BufReader::new(Box::new(t)),
         })


### PR DESCRIPTION
3rd party TLS connections are currently required to provide a Sync
guarantee. Since ureq will only ever use the connection on a single
thread, this is not necessary.

The reason we end up with this bound is because we want Response and
Error to be Sync, in which case Rust's automatic inferral of Sync
fails.

This change "masks" the Stream in a wrapper making it Sync.

Close #474