### PR TITLE
Make webpki-roots opt-in, and native-certs the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 2.4.0
+# UNRELEASED
+ * Make `native-certs` the default when using the `tls` feature, and make `webpki-roots` opt-in.
 
+# 2.4.0
  * Enable `gzip` feature by default (#455)
  * `gzip` and `brotli` feature flags to enable decompression (#453, #421)
  * Middleware function on agent (#448)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy"]
 
 [features]
 default = ["tls", "gzip"]
-tls = ["webpki", "webpki-roots", "rustls"]
+tls = ["webpki", "rustls", "native-certs"]
 native-certs = ["rustls-native-certs"]
 json = ["serde", "serde_json"]
 charset = ["encoding_rs"]
@@ -35,11 +35,11 @@ socks = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
-sync_wrapper = { version = "0.1" } 
+sync_wrapper = { version = "0.1" }
 cookie_store = { version = "0.15", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4"
 webpki = { version = "0.22", optional = true }
-webpki-roots = { version = "0.22", optional = true }
+webpki-roots = { version = "0.22", optional = true } # webpki-roots uses the MPL-2.0 copy-left license, so it is opt-in
 rustls = { version = "0.20.1", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -244,14 +244,13 @@ Here's an example of constructing an Agent that uses native-tls. It requires the
 ### Trusted Roots
 
 When you use rustls (`tls` feature), ureq defaults to trusting
-[webpki-roots](https://docs.rs/webpki-roots/), a
-copy of the Mozilla Root program that is bundled into your program (and so won't update if your
-program isn't updated). You can alternately configure
 [rustls-native-certs](https://docs.rs/rustls-native-certs/) which extracts the roots from your
 OS' trust store. That means it will update when your OS is updated, and also that it will
-include locally installed roots.
+include locally installed roots. Thus ureq will use your OS' certificate verifier and root store.
 
-When you use `native-tls`, ureq will use your OS' certificate verifier and root store.
+Alternatively, you can opt-in to using [webpki-roots](https://docs.rs/webpki-roots/), a
+copy of the Mozilla Root program that is bundled into your program (and so won't update if your
+program isn't updated). Just enable the `"webpki-roots"` feature in `ureq` to use this instead.
 
 ## Blocking I/O for simplicity
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,14 +273,14 @@
 //! ## Trusted Roots
 //!
 //! When you use rustls (`tls` feature), ureq defaults to trusting
-//! [webpki-roots](https://docs.rs/webpki-roots/), a
-//! copy of the Mozilla Root program that is bundled into your program (and so won't update if your
-//! program isn't updated). You can alternately configure
 //! [rustls-native-certs](https://docs.rs/rustls-native-certs/) which extracts the roots from your
 //! OS' trust store. That means it will update when your OS is updated, and also that it will
-//! include locally installed roots.
+//! include locally installed roots. Thus ureq will use your OS' certificate verifier and root store.
 //!
-//! When you use `native-tls`, ureq will use your OS' certificate verifier and root store.
+//! Alternatively, you can opt-in to using [webpki-roots](https://docs.rs/webpki-roots/), a
+//! copy of the Mozilla Root program that is bundled into your program (and so won't update if your
+//! program isn't updated). Just enable the `"webpki-roots"` feature in `ureq` to use this instead.
+//! When you use rustls (`tls` feature), ureq defaults to trusting
 //!
 //! # Blocking I/O for simplicity
 //!

--- a/src/rtls.rs
+++ b/src/rtls.rs
@@ -58,7 +58,7 @@ impl Write for RustlsStream {
     }
 }
 
-#[cfg(feature = "native-certs")]
+#[cfg(not(feature = "webpki-roots"))]
 fn root_certs() -> rustls::RootCertStore {
     let mut root_store = rustls::RootCertStore::empty();
 
@@ -76,7 +76,7 @@ fn root_certs() -> rustls::RootCertStore {
     root_store
 }
 
-#[cfg(not(feature = "native-certs"))]
+#[cfg(feature = "webpki-roots")]
 fn root_certs() -> rustls::RootCertStore {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {


### PR DESCRIPTION
https://github.com/rustls/webpki-roots has a copy-left license (MPL-2.0) making it unsuitable for any closed-source use.

Therefore it is wiser if it is opt-in, rather than a default feature.

Closes https://github.com/algesten/ureq/issues/478