### PR TITLE
Add new feature "tls_native_certs"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy"]
 [features]
 default = ["tls", "gzip"]
 tls = ["webpki", "webpki-roots", "rustls"]
+tls_native_certs = ["native-certs", "rustls"]
 native-certs = ["rustls-native-certs"]
 json = ["serde", "serde_json"]
 charset = ["encoding_rs"]
@@ -35,7 +36,7 @@ socks = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
-sync_wrapper = { version = "0.1" } 
+sync_wrapper = { version = "0.1" }
 cookie_store = { version = "0.15", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4"
 webpki = { version = "0.22", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ mod unit;
 
 // rustls is our default tls engine. If the feature is on, it will be
 // used for the shortcut calls the top of the crate (`ureq::get` etc).
-#[cfg(feature = "tls")]
+#[cfg(feature = "rustls")]
 mod rtls;
 
 // native-tls is a feature that must be configured via the AgentBuilder.
@@ -347,14 +347,14 @@ mod rtls;
 mod ntls;
 
 // If we have rustls compiled, that is the default.
-#[cfg(feature = "tls")]
+#[cfg(feature = "rustls")]
 pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
     rtls::default_tls_config()
 }
 
 // Without rustls compiled, we just fail on https when using the shortcut
 // calls at the top of the crate (`ureq::get` etc).
-#[cfg(not(feature = "tls"))]
+#[cfg(not(feature = "rustls"))]
 pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
     use std::net::TcpStream;
     use std::sync::Arc;


### PR DESCRIPTION
This adds the following feature:

`tls_native_certs = ["native-certs", "rustls"]`

This is an alternative to the `tls` feature, that uses `native-certs` instead of `webpki-roots`.

Closes https://github.com/algesten/ureq/issues/478