### PR TITLE
Fix broken TLS anchor link in docs overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HTTPS, and charset decoding.
 Ureq is in pure Rust for safety and ease of understanding. It avoids using
 `unsafe` directly. It [uses blocking I/O][blocking] instead of async I/O, because that keeps
 the API simple and and keeps dependencies to a minimum. For TLS, ureq uses
-[rustls or native-tls](#tls).
+[rustls or native-tls](#https--tls--ssl).
 
 Version 2.0.0 was released recently and changed some APIs. See the [changelog] for details.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! Ureq is in pure Rust for safety and ease of understanding. It avoids using
 //! `unsafe` directly. It [uses blocking I/O][blocking] instead of async I/O, because that keeps
 //! the API simple and and keeps dependencies to a minimum. For TLS, ureq uses
-//! [rustls or native-tls](#tls).
+//! [rustls or native-tls](#https--tls--ssl).
 //!
 //! Version 2.0.0 was released recently and changed some APIs. See the [changelog] for details.
 //!

--- a/src/response.rs
+++ b/src/response.rs
@@ -152,7 +152,7 @@ impl Response {
     /// The header value for the given name, or None if not found.
     ///
     /// For historical reasons, the HTTP spec allows for header values
-    /// to be encoded using encodigs like iso-8859-1. Such encodings
+    /// to be encoded using encodings like iso-8859-1. Such encodings
     /// means the values are not possible to interpret as utf-8.
     ///
     /// In case the header value can't be read as utf-8, this function


### PR DESCRIPTION
Now correctly links to:
https://docs.rs/ureq/latest/ureq/#https--tls--ssl

Introduced in 56276c3742979e28decbe05110ea661a0c58a857.

Also fixes a rustdoc typo in `Response::header()` spotted by my IDE's spell checker whilst the project was open.