### PR TITLE
Warn if `Request`s aren't sent

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -24,6 +24,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// # }
 /// ```
 #[derive(Clone)]
+#[must_use = "Requests do nothing until consumed by `call()`"]
 pub struct Request {
     agent: Agent,
     method: String,


### PR DESCRIPTION
I added `ureq::get("http://example.com")` to a toy program and was very confused when it did nothing.
Change `Request` to give a warning if unsent:
```
warning: unused `ureq::Request` that must be used
  --> src/main.rs:48:5
   |
48 |     ureq::get("http://example.com");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_must_use)]` on by default
   = note: Requests do nothing until consumed by `call()`
```