### PR TITLE
implement https_only flag

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -54,6 +54,7 @@ pub(crate) struct AgentConfig {
     pub timeout_read: Option<Duration>,
     pub timeout_write: Option<Duration>,
     pub timeout: Option<Duration>,
+    pub https_only: bool,
     pub no_delay: bool,
     pub redirects: u32,
     pub redirect_auth_headers: RedirectAuthHeaders,
@@ -239,6 +240,7 @@ impl AgentBuilder {
                 timeout_read: None,
                 timeout_write: None,
                 timeout: None,
+                https_only: false,
                 no_delay: true,
                 redirects: 5,
                 redirect_auth_headers: RedirectAuthHeaders::Never,
@@ -290,6 +292,21 @@ impl AgentBuilder {
     /// ```
     pub fn proxy(mut self, proxy: Proxy) -> Self {
         self.config.proxy = Some(proxy);
+        self
+    }
+
+    /// Enforce the client to only perform HTTPS requests.
+    /// This setting also makes the client refuse HTTPS to HTTP redirects.
+    /// Default is false
+    ///
+    /// Example:
+    /// ```
+    /// let agent = ureq::AgentBuilder::new()
+    ///     .https_only(true)
+    ///     .build();
+    /// ```
+    pub fn https_only(mut self, enforce: bool) -> Self {
+        self.config.https_only = enforce;
         self
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -336,6 +336,8 @@ pub enum ErrorKind {
     UnknownScheme,
     /// DNS lookup failed.
     Dns,
+    /// Insecure request attempted with https only set
+    InsecureRequestHttpsOnly,
     /// Connection to server failed.
     ConnectionFailed,
     /// Too many redirects.
@@ -402,6 +404,9 @@ impl fmt::Display for ErrorKind {
             ErrorKind::InvalidUrl => write!(f, "Bad URL"),
             ErrorKind::UnknownScheme => write!(f, "Unknown Scheme"),
             ErrorKind::Dns => write!(f, "Dns Failed"),
+            ErrorKind::InsecureRequestHttpsOnly => {
+                write!(f, "Insecure request attempted with https_only set")
+            }
             ErrorKind::ConnectionFailed => write!(f, "Connection Failed"),
             ErrorKind::TooManyRedirects => write!(f, "Too Many Redirects"),
             ErrorKind::BadStatus => write!(f, "Bad Status"),

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -349,9 +349,8 @@ fn connect_socket(unit: &Unit, hostname: &str, use_pooled: bool) -> Result<(Stre
         scheme => return Err(ErrorKind::UnknownScheme.msg(format!("unknown scheme '{}'", scheme))),
     };
     if unit.url.scheme() != "https" && unit.agent.config.https_only {
-        return Err(ErrorKind::InsecureRequestHttpsOnly.msg(format!(
-            "can't perform non https request with https_only set"
-        )));
+        return Err(ErrorKind::InsecureRequestHttpsOnly
+            .msg("can't perform non https request with https_only set"));
     }
     if use_pooled {
         let pool = &unit.agent.state.pool;

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -348,6 +348,11 @@ fn connect_socket(unit: &Unit, hostname: &str, use_pooled: bool) -> Result<(Stre
         "http" | "https" | "test" => (),
         scheme => return Err(ErrorKind::UnknownScheme.msg(format!("unknown scheme '{}'", scheme))),
     };
+    if unit.url.scheme() != "https" && unit.agent.config.https_only {
+        return Err(ErrorKind::InsecureRequestHttpsOnly.msg(format!(
+            "can't perform non https request with https_only set"
+        )));
+    }
     if use_pooled {
         let pool = &unit.agent.state.pool;
         let proxy = &unit.agent.config.proxy;


### PR DESCRIPTION
hi - this should solve #481. I tested it against both `http` and `https -> http` redirect, and both cases are detected properly.
I'll add a test in a subsequent commit - as it needs to implement tls support from the test harness.
cheers !