### PR TITLE
Add HTTPS proxy support

### DIFF
--- a/examples/custom-tls.rs
+++ b/examples/custom-tls.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::net::TcpStream;
 use std::sync::Arc;
 
-use ureq::{Error, ReadWrite, TlsConnector};
+use ureq::{Error, ReadWrite, Stream, TlsConnector};
 
 pub fn main() -> Result<(), Error> {
     let pass = PassThrough {
@@ -31,7 +31,7 @@ struct PassThrough {
 }
 
 impl TlsConnector for PassThrough {
-    fn connect(&self, _dns_name: &str, tcp_stream: TcpStream) -> Result<Box<dyn ReadWrite>, Error> {
+    fn connect(&self, _dns_name: &str, tcp_stream: Stream) -> Result<Box<dyn ReadWrite>, Error> {
         if self.handshake_fail {
             let io_err = io::Error::new(io::ErrorKind::InvalidData, PassThroughError);
             return Err(io_err.into());
@@ -41,11 +41,11 @@ impl TlsConnector for PassThrough {
     }
 }
 
-struct CustomTlsStream(TcpStream);
+struct CustomTlsStream(Stream);
 
 impl ReadWrite for CustomTlsStream {
     fn socket(&self) -> Option<&TcpStream> {
-        Some(&self.0)
+        self.0.socket()
     }
 }
 

--- a/examples/mbedtls/mbedtls_connector.rs
+++ b/examples/mbedtls/mbedtls_connector.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::io;
-use ureq::{Error, ReadWrite, TlsConnector};
+use ureq::{Error, ReadWrite, Stream, TlsConnector};
 
 use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
@@ -53,7 +53,7 @@ impl MbedTlsConnector {
 }
 
 impl TlsConnector for MbedTlsConnector {
-    fn connect(&self, _dns_name: &str, tcp_stream: TcpStream) -> Result<Box<dyn ReadWrite>, Error> {
+    fn connect(&self, _dns_name: &str, tcp_stream: Stream) -> Result<Box<dyn ReadWrite>, Error> {
         let mut ctx = self.context.lock().unwrap();
         match ctx.establish(tcp_stream, None) {
             Err(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,6 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
 // calls at the top of the crate (`ureq::get` etc).
 #[cfg(not(feature = "tls"))]
 pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
-    use std::net::TcpStream;
     use std::sync::Arc;
 
     struct NoTlsConfig;
@@ -365,7 +364,7 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
         fn connect(
             &self,
             _dns_name: &str,
-            _tcp_stream: TcpStream,
+            _tcp_stream: Stream,
         ) -> Result<Box<dyn ReadWrite>, crate::error::Error> {
             Err(ErrorKind::UnknownScheme
                 .msg("cannot make HTTPS request because no TLS backend is configured"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,7 @@ pub use crate::proxy::Proxy;
 pub use crate::request::{Request, RequestUrl};
 pub use crate::resolve::Resolver;
 pub use crate::response::Response;
-pub use crate::stream::{ReadWrite, TlsConnector};
+pub use crate::stream::{ReadWrite, Stream, TlsConnector};
 
 // re-export
 #[cfg(feature = "cookies")]

--- a/src/ntls.rs
+++ b/src/ntls.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::error::ErrorKind;
-use crate::stream::{ReadWrite, TlsConnector};
+use crate::stream::{ReadWrite, Stream, TlsConnector};
 
 use std::net::TcpStream;
 use std::sync::Arc;
@@ -11,7 +11,7 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
 }
 
 impl TlsConnector for native_tls::TlsConnector {
-    fn connect(&self, dns_name: &str, tcp_stream: TcpStream) -> Result<Box<dyn ReadWrite>, Error> {
+    fn connect(&self, dns_name: &str, tcp_stream: Stream) -> Result<Box<dyn ReadWrite>, Error> {
         let stream =
             native_tls::TlsConnector::connect(self, dns_name, tcp_stream).map_err(|e| {
                 ErrorKind::ConnectionFailed
@@ -24,8 +24,8 @@ impl TlsConnector for native_tls::TlsConnector {
 }
 
 #[cfg(feature = "native-tls")]
-impl ReadWrite for native_tls::TlsStream<TcpStream> {
+impl ReadWrite for native_tls::TlsStream<Stream> {
     fn socket(&self) -> Option<&TcpStream> {
-        Some(self.get_ref())
+        self.get_ref().socket()
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -4,6 +4,7 @@ use crate::error::{Error, ErrorKind};
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Proto {
     HTTPConnect,
+    HTTPSConnect,
     SOCKS4,
     SOCKS4A,
     SOCKS5,
@@ -90,6 +91,7 @@ impl Proxy {
         let proto = if proxy_parts.len() == 2 {
             match proxy_parts.next() {
                 Some("http") => Proto::HTTPConnect,
+                Some("https") => Proto::HTTPSConnect,
                 Some("socks4") => Proto::SOCKS4,
                 Some("socks4a") => Proto::SOCKS4A,
                 Some("socks") => Proto::SOCKS5,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -267,7 +267,7 @@ impl Stream {
         Ok(())
     }
 
-    pub(crate) fn socket(&self) -> Option<&TcpStream> {
+    pub fn socket(&self) -> Option<&TcpStream> {
         self.inner.get_ref().socket()
     }
 


### PR DESCRIPTION
This has a lot of interface changes, every change should be mentioned in the commit message.

Some things are still not clear to me, one is how to handle different TLS implementations when the connection to the proxy is made. We can't just reuse the TlsConnector for both the proxy connection as well as the connection to the target.