### PR TITLE
Add Request::call_writer for writing request body using std::io::Write

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,9 +392,12 @@ pub use crate::agent::AgentBuilder;
 pub use crate::agent::RedirectAuthHeaders;
 pub use crate::error::{Error, ErrorKind, OrAnyStatus, Transport};
 pub use crate::header::Header;
-pub use crate::middleware::{Middleware, MiddlewareNext};
+pub use crate::middleware::{
+    Middleware, MiddlewareRequestNext, MiddlewareResponseNext, RequestMiddleware,
+    ResponseMiddleware,
+};
 pub use crate::proxy::Proxy;
-pub use crate::request::{Request, RequestUrl};
+pub use crate::request::{Request, RequestStream, RequestUrl};
 pub use crate::resolve::Resolver;
 pub use crate::response::Response;
 pub use crate::stream::{ReadWrite, TlsConnector};


### PR DESCRIPTION
Request.call_writer() sends the request headers, and returns a RequestStream
object that can be used to write the request body. This is more convenient
than trying to create a Read object that does the same thing.

This also makes some major changes to the middleware trait, to support the
call_writer API. It's now split into `handle_request` and `handle_response`.