### PR TITLE
Use buffered reader when converting into json

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -436,7 +436,7 @@ impl Response {
         use crate::stream::io_err_timeout;
         use std::error::Error;
 
-        let reader = self.into_reader();
+        let reader = io::BufReader::new(self.into_reader());
         serde_json::from_reader(reader).map_err(|e| {
             // This is to unify TimedOut io::Error in the API.
             // We make a clone of the original error since serde_json::Error doesn't


### PR DESCRIPTION
In my experience, with a 10Mb JSON, using `resp.into_json()` is taking more than twice the time than `serde_json::from_reader(BufReader::new(resp.into_reader()))` and I think there aren't big disadvantage to always buffer

UPDATE: performance degradation only happens when using timeout