### PR TITLE
Return stream to pool on exact read

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 
 use crate::response::LimitedRead;
 use crate::stream::Stream;
-use crate::{Proxy, Agent};
+use crate::{Agent, Proxy};
 
 use chunked_transfer::Decoder;
 use log::debug;
@@ -379,8 +379,11 @@ mod tests {
 
         pool.add(&pool_key, Stream::from_vec(vec![]));
         assert_eq!(pool.len(), 2);
-            
-        let pool_key = PoolKey::new(&url, Some(Proxy::new("user:password@localhost:9999").unwrap()));
+
+        let pool_key = PoolKey::new(
+            &url,
+            Some(Proxy::new("user:password@localhost:9999").unwrap()),
+        );
 
         pool.add(&pool_key, Stream::from_vec(vec![]));
         assert_eq!(pool.len(), 3);

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -144,7 +144,7 @@ impl ConnectionPool {
                         streams.len(),
                         stream
                     );
-                    remove_first_match(&mut inner.lru, &key)
+                    remove_first_match(&mut inner.lru, key)
                         .expect("invariant failed: key in recycle but not in lru");
                 }
             }

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,12 +6,13 @@ use chunked_transfer::Decoder as ChunkDecoder;
 use sync_wrapper::SyncWrapper;
 use url::Url;
 
+use crate::body::SizedReader;
 use crate::error::{Error, ErrorKind::BadStatus};
 use crate::header::{get_all_headers, get_header, Header, HeaderLine};
 use crate::pool::PoolReturnRead;
 use crate::stream::{DeadlineStream, Stream};
 use crate::unit::Unit;
-use crate::{stream, ErrorKind};
+use crate::{stream, ErrorKind, Agent};
 
 #[cfg(feature = "json")]
 use serde::de::DeserializeOwned;
@@ -60,13 +61,13 @@ const MAX_HEADER_COUNT: usize = 100;
 /// # }
 /// ```
 pub struct Response {
-    pub(crate) url: Option<Url>,
+    pub(crate) url: Url,
     status_line: String,
     index: ResponseStatusIndex,
     status: u16,
     headers: Vec<Header>,
     // Boxed to avoid taking up too much size.
-    unit: Option<Box<Unit>>,
+    unit: Box<Unit>,
     // Boxed to avoid taking up too much size.
     stream: SyncWrapper<Box<Stream>>,
     /// The redirect history of this response, if any. The history starts with
@@ -93,14 +94,11 @@ impl fmt::Debug for Response {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Response[status: {}, status_text: {}",
+            "Response[status: {}, status_text: {}, url: {}]",
             self.status(),
             self.status_text(),
-        )?;
-        if let Some(url) = &self.url {
-            write!(f, ", url: {}", url)?;
-        }
-        write!(f, "]")
+            self.url,
+        )
     }
 }
 
@@ -128,7 +126,7 @@ impl Response {
     /// The URL we ended up at. This can differ from the request url when
     /// we have followed redirects.
     pub fn get_url(&self) -> &str {
-        self.url.as_ref().map(|s| &s[..]).unwrap_or("")
+        &self.url[..]
     }
 
     /// The http version: `HTTP/1.1`
@@ -270,7 +268,7 @@ impl Response {
             .map(|c| c.eq_ignore_ascii_case("close"))
             .unwrap_or(false);
 
-        let is_head = self.unit.as_ref().map(|u| u.is_head()).unwrap_or(false);
+        let is_head = self.unit.is_head();
         let has_no_body = is_head
             || match self.status {
                 204 | 304 => true,
@@ -295,19 +293,17 @@ impl Response {
 
         let stream = self.stream.into_inner();
         let unit = self.unit;
-        if let Some(unit) = &unit {
             let result = stream.set_read_timeout(unit.agent.config.timeout_read);
             if let Err(e) = result {
                 return Box::new(ErrorReader(e)) as Box<dyn Read + Send>;
             }
-        }
-        let deadline = unit.as_ref().and_then(|u| u.deadline);
+        let deadline = unit.deadline;
         let stream = DeadlineStream::new(*stream, deadline);
 
         let body_reader: Box<dyn Read + Send> = match (use_chunked, limit_bytes) {
-            (true, _) => Box::new(PoolReturnRead::new(unit, ChunkDecoder::new(stream))),
+            (true, _) => Box::new(PoolReturnRead::new(&unit.agent, &unit.url, ChunkDecoder::new(stream))),
             (false, Some(len)) => {
-                Box::new(PoolReturnRead::new(unit, LimitedRead::new(stream, len)))
+                Box::new(PoolReturnRead::new(&unit.agent, &unit.url, LimitedRead::new(stream, len)))
             }
             (false, None) => Box::new(stream),
         };
@@ -467,11 +463,10 @@ impl Response {
     /// let resp = ureq::Response::do_from_read(read);
     ///
     /// assert_eq!(resp.status(), 401);
-    pub(crate) fn do_from_stream(stream: Stream, unit: Option<Unit>) -> Result<Response, Error> {
+    pub(crate) fn do_from_stream(stream: Stream, unit: Unit) -> Result<Response, Error> {
         //
         // HTTP/1.1 200 OK\r\n
-        let mut stream =
-            stream::DeadlineStream::new(stream, unit.as_ref().and_then(|u| u.deadline));
+        let mut stream = stream::DeadlineStream::new(stream, unit.deadline);
 
         // The status line we can ignore non-utf8 chars and parse as_str_lossy().
         let status_line = read_next_line(&mut stream, "the status line")?.into_string_lossy();
@@ -504,7 +499,7 @@ impl Response {
             headers.retain(|h| !h.is_name("content-encoding") && !h.is_name("content-length"));
         }
 
-        let url = unit.as_ref().map(|u| u.url.clone());
+        let url = unit.url.clone();
 
         Ok(Response {
             url,
@@ -512,7 +507,7 @@ impl Response {
             index,
             status,
             headers,
-            unit: unit.map(Box::new),
+            unit: Box::new(unit),
             stream: SyncWrapper::new(Box::new(stream.into())),
             history: vec![],
             length,
@@ -528,14 +523,13 @@ impl Response {
 
     #[cfg(test)]
     pub fn set_url(&mut self, url: Url) {
-        self.url = Some(url);
+        self.url = url;
     }
 
     #[cfg(test)]
     pub fn history_from_previous(&mut self, previous: Response) {
-        let previous_url = previous.url.expect("previous url");
         self.history = previous.history;
-        self.history.push(previous_url);
+        self.history.push(previous.url);
     }
 }
 
@@ -645,7 +639,10 @@ impl FromStr for Response {
     /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let stream = Stream::from_vec(s.as_bytes().to_owned());
-        Self::do_from_stream(stream, None)
+        let request_url = "https://example.com".parse().unwrap();
+        let request_reader = SizedReader{size: crate::body::BodySize::Empty, reader: Box::new(std::io::empty())};
+        let unit = Unit::new(&Agent::new(), "GET", &request_url, vec![], &request_reader, None);
+        Self::do_from_stream(stream, unit)
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1006,7 +1006,20 @@ mod tests {
         );
         let v = cow.to_vec();
         let s = Stream::from_vec(v);
-        let resp = Response::do_from_stream(s.into(), None).unwrap();
+        let request_url = "https://example.com".parse().unwrap();
+        let request_reader = SizedReader {
+            size: crate::body::BodySize::Empty,
+            reader: Box::new(std::io::empty()),
+        };
+        let unit = Unit::new(
+            &Agent::new(),
+            "GET",
+            &request_url,
+            vec![],
+            &request_reader,
+            None,
+        );
+        let resp = Response::do_from_stream(s.into(), unit).unwrap();
         assert_eq!(resp.status(), 200);
         assert_eq!(resp.header("x-geo-header"), None);
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -699,7 +699,7 @@ pub(crate) struct LimitedRead<R> {
 }
 
 impl<R: Read> LimitedRead<R> {
-    fn new(reader: R, limit: usize) -> Self {
+    pub(crate) fn new(reader: R, limit: usize) -> Self {
         LimitedRead {
             reader,
             limit,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -69,11 +69,11 @@ impl Inner for TcpStream {
     }
 }
 
-struct TestStream(Box<dyn Read + Send + Sync>, Vec<u8>);
+struct TestStream(Box<dyn Read + Send + Sync>, Vec<u8>, bool);
 
 impl Inner for TestStream {
     fn is_poolable(&self) -> bool {
-        false
+        self.2
     }
     fn socket(&self) -> Option<&TcpStream> {
         None
@@ -201,7 +201,14 @@ impl Stream {
 
     pub(crate) fn from_vec(v: Vec<u8>) -> Stream {
         Stream::logged_create(Stream {
-            inner: BufReader::new(Box::new(TestStream(Box::new(Cursor::new(v)), vec![]))),
+            inner: BufReader::new(Box::new(TestStream(Box::new(Cursor::new(v)), vec![], false))),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_vec_poolable(v: Vec<u8>) -> Stream {
+        Stream::logged_create(Stream {
+            inner: BufReader::new(Box::new(TestStream(Box::new(Cursor::new(v)), vec![], true))),
         })
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -201,7 +201,11 @@ impl Stream {
 
     pub(crate) fn from_vec(v: Vec<u8>) -> Stream {
         Stream::logged_create(Stream {
-            inner: BufReader::new(Box::new(TestStream(Box::new(Cursor::new(v)), vec![], false))),
+            inner: BufReader::new(Box::new(TestStream(
+                Box::new(Cursor::new(v)),
+                vec![],
+                false,
+            ))),
         })
     }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -284,7 +284,7 @@ fn connect_inner(
     // TODO: this unit.clone() bothers me. At this stage, we're not
     // going to use the unit (much) anymore, and it should be possible
     // to have ownership of it and pass it into the Response.
-    let result = Response::do_from_stream(stream, Some(unit.clone()));
+    let result = Response::do_from_stream(stream, unit.clone());
 
     // https://tools.ietf.org/html/rfc7230#section-6.3.1
     // When an inbound connection is closed prematurely, a client MAY


### PR DESCRIPTION
This makes PoolReturnRead aware of LimitedRead (via a new `Done` trait), so it can return a stream to the pool if the user reads the exact right number of bytes (but not more). For instance, if a response body will be 500 bytes (per Content-Length), and the user allocated a 500-byte buffer, and `read_exact`s into it, the stream should get returned to the pool.

This PR consists of 3 meaningful commits: 682d874 is a standalone refactoring that made writing the test easier, and should be reviewed on its own. I can also make that a separate PR if you prefer. 268413c adds the behavior, and a6652b2. I've checked that the test fails without the behavior.

This also makes TestStream optionally poolable, which was necessary to test pooling behavior with a TestStream.

Alternate fix for #498