### PR TITLE
Box<dyn ReadWrite> for TlsConnector::connect

### DIFF
--- a/examples/custom-tls.rs
+++ b/examples/custom-tls.rs
@@ -34,7 +34,7 @@ impl TlsConnector for PassThrough {
     fn connect(
         &self,
         _dns_name: &str,
-        io: Box<dyn ReadWrite + Sync>,
+        io: Box<dyn ReadWrite>,
     ) -> Result<Box<dyn ReadWrite>, Error> {
         if self.handshake_fail {
             let io_err = io::Error::new(io::ErrorKind::InvalidData, PassThroughError);

--- a/examples/custom-tls.rs
+++ b/examples/custom-tls.rs
@@ -34,7 +34,7 @@ impl TlsConnector for PassThrough {
     fn connect(
         &self,
         _dns_name: &str,
-        io: Box<dyn ReadWrite>,
+        io: Box<dyn ReadWrite + Sync>,
     ) -> Result<Box<dyn ReadWrite>, Error> {
         if self.handshake_fail {
             let io_err = io::Error::new(io::ErrorKind::InvalidData, PassThroughError);
@@ -45,6 +45,7 @@ impl TlsConnector for PassThrough {
     }
 }
 
+#[derive(Debug)]
 struct CustomTlsStream(Box<dyn ReadWrite>);
 
 impl ReadWrite for CustomTlsStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,6 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
 // calls at the top of the crate (`ureq::get` etc).
 #[cfg(not(feature = "tls"))]
 pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
-    use std::net::TcpStream;
     use std::sync::Arc;
 
     struct NoTlsConfig;
@@ -365,7 +364,7 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
         fn connect(
             &self,
             _dns_name: &str,
-            _tcp_stream: TcpStream,
+            _io: Box<dyn ReadWrite>,
         ) -> Result<Box<dyn ReadWrite>, crate::error::Error> {
             Err(ErrorKind::UnknownScheme
                 .msg("cannot make HTTPS request because no TLS backend is configured"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
         fn connect(
             &self,
             _dns_name: &str,
-            _io: Box<dyn ReadWrite + Sync>,
+            _io: Box<dyn ReadWrite>,
         ) -> Result<Box<dyn ReadWrite>, crate::error::Error> {
             Err(ErrorKind::UnknownScheme
                 .msg("cannot make HTTPS request because no TLS backend is configured"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
         fn connect(
             &self,
             _dns_name: &str,
-            _io: Box<dyn ReadWrite>,
+            _io: Box<dyn ReadWrite + Sync>,
         ) -> Result<Box<dyn ReadWrite>, crate::error::Error> {
             Err(ErrorKind::UnknownScheme
                 .msg("cannot make HTTPS request because no TLS backend is configured"))

--- a/src/ntls.rs
+++ b/src/ntls.rs
@@ -11,12 +11,15 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
 }
 
 impl TlsConnector for native_tls::TlsConnector {
-    fn connect(&self, dns_name: &str, tcp_stream: TcpStream) -> Result<Box<dyn ReadWrite>, Error> {
+    fn connect(&self, dns_name: &str, io: Box<dyn ReadWrite>) -> Result<Box<dyn ReadWrite>, Error> {
         let stream =
-            native_tls::TlsConnector::connect(self, dns_name, tcp_stream).map_err(|e| {
-                ErrorKind::ConnectionFailed
+            native_tls::TlsConnector::connect(self, dns_name, io).map_err(|e| match e {
+                native_tls::HandshakeError::Failure(e) => ErrorKind::ConnectionFailed
                     .msg("native_tls connect failed")
-                    .src(e)
+                    .src(e),
+                native_tls::HandshakeError::WouldBlock(_) => {
+                    ErrorKind::Io.msg("Unexpected native_tls::HandshakeError::WouldBlock")
+                }
             })?;
 
         Ok(Box::new(stream))
@@ -24,8 +27,11 @@ impl TlsConnector for native_tls::TlsConnector {
 }
 
 #[cfg(feature = "native-tls")]
-impl ReadWrite for native_tls::TlsStream<TcpStream> {
+impl ReadWrite for native_tls::TlsStream<Box<dyn ReadWrite>> {
     fn socket(&self) -> Option<&TcpStream> {
-        Some(self.get_ref())
+        self.get_ref().socket()
+    }
+    fn is_poolable(&self) -> bool {
+        self.get_ref().is_poolable()
     }
 }

--- a/src/ntls.rs
+++ b/src/ntls.rs
@@ -11,7 +11,11 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
 }
 
 impl TlsConnector for native_tls::TlsConnector {
-    fn connect(&self, dns_name: &str, io: Box<dyn ReadWrite>) -> Result<Box<dyn ReadWrite>, Error> {
+    fn connect(
+        &self,
+        dns_name: &str,
+        io: Box<dyn ReadWrite + Sync>,
+    ) -> Result<Box<dyn ReadWrite>, Error> {
         let stream =
             native_tls::TlsConnector::connect(self, dns_name, io).map_err(|e| match e {
                 native_tls::HandshakeError::Failure(e) => ErrorKind::ConnectionFailed
@@ -27,7 +31,7 @@ impl TlsConnector for native_tls::TlsConnector {
 }
 
 #[cfg(feature = "native-tls")]
-impl ReadWrite for native_tls::TlsStream<Box<dyn ReadWrite>> {
+impl ReadWrite for native_tls::TlsStream<Box<dyn ReadWrite + Sync>> {
     fn socket(&self) -> Option<&TcpStream> {
         self.get_ref().socket()
     }

--- a/src/ntls.rs
+++ b/src/ntls.rs
@@ -11,11 +11,7 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
 }
 
 impl TlsConnector for native_tls::TlsConnector {
-    fn connect(
-        &self,
-        dns_name: &str,
-        io: Box<dyn ReadWrite + Sync>,
-    ) -> Result<Box<dyn ReadWrite>, Error> {
+    fn connect(&self, dns_name: &str, io: Box<dyn ReadWrite>) -> Result<Box<dyn ReadWrite>, Error> {
         let stream =
             native_tls::TlsConnector::connect(self, dns_name, io).map_err(|e| match e {
                 native_tls::HandshakeError::Failure(e) => ErrorKind::ConnectionFailed
@@ -31,7 +27,7 @@ impl TlsConnector for native_tls::TlsConnector {
 }
 
 #[cfg(feature = "native-tls")]
-impl ReadWrite for native_tls::TlsStream<Box<dyn ReadWrite + Sync>> {
+impl ReadWrite for native_tls::TlsStream<Box<dyn ReadWrite>> {
     fn socket(&self) -> Option<&TcpStream> {
         self.get_ref().socket()
     }

--- a/src/rtls.rs
+++ b/src/rtls.rs
@@ -27,7 +27,7 @@ fn is_close_notify(e: &std::io::Error) -> bool {
     false
 }
 
-struct RustlsStream(rustls::StreamOwned<rustls::ClientConnection, Box<dyn ReadWrite + Sync>>);
+struct RustlsStream(rustls::StreamOwned<rustls::ClientConnection, Box<dyn ReadWrite>>);
 
 impl ReadWrite for RustlsStream {
     fn socket(&self) -> Option<&TcpStream> {
@@ -97,7 +97,7 @@ impl TlsConnector for Arc<rustls::ClientConfig> {
     fn connect(
         &self,
         dns_name: &str,
-        mut io: Box<dyn ReadWrite + Sync>,
+        mut io: Box<dyn ReadWrite>,
     ) -> Result<Box<dyn ReadWrite>, Error> {
         let sni = rustls::ServerName::try_from(dns_name)
             .map_err(|e| ErrorKind::Dns.msg(format!("parsing '{}'", dns_name)).src(e))?;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -20,58 +20,52 @@ use crate::unit::Unit;
 /// Trait for things implementing [std::io::Read] + [std::io::Write]. Used in [TlsConnector].
 pub trait ReadWrite: Read + Write + Send + 'static {
     fn socket(&self) -> Option<&TcpStream>;
+    fn is_poolable(&self) -> bool;
+
+    /// The bytes written to the stream as a Vec<u8>. This is used for tests only.
+    #[cfg(test)]
+    fn written_bytes(&self) -> Vec<u8> {
+        panic!("written_bytes on non Test stream");
+    }
+}
+
+impl ReadWrite for TcpStream {
+    fn socket(&self) -> Option<&TcpStream> {
+        Some(self)
+    }
+    fn is_poolable(&self) -> bool {
+        true
+    }
 }
 
 pub trait TlsConnector: Send + Sync {
     fn connect(
         &self,
         dns_name: &str,
-        tcp_stream: TcpStream,
+        io: Box<dyn ReadWrite>,
     ) -> Result<Box<dyn ReadWrite>, crate::error::Error>;
 }
 
 pub(crate) struct Stream {
-    inner: BufReader<Box<dyn Inner + Send + 'static>>,
-}
-
-trait Inner: Read + Write {
-    fn is_poolable(&self) -> bool;
-    fn socket(&self) -> Option<&TcpStream>;
-
-    /// The bytes written to the stream as a Vec<u8>. This is used for tests only.
-    fn written_bytes(&self) -> Vec<u8> {
-        panic!("written_bytes on non Test stream");
-    }
+    inner: BufReader<Box<dyn ReadWrite>>,
 }
 
 impl<T: ReadWrite + ?Sized> ReadWrite for Box<T> {
     fn socket(&self) -> Option<&TcpStream> {
         ReadWrite::socket(self.as_ref())
     }
-}
-
-impl<T: ReadWrite> Inner for T {
     fn is_poolable(&self) -> bool {
-        true
+        ReadWrite::is_poolable(self.as_ref())
     }
-
-    fn socket(&self) -> Option<&TcpStream> {
-        ReadWrite::socket(self)
-    }
-}
-
-impl Inner for TcpStream {
-    fn is_poolable(&self) -> bool {
-        true
-    }
-    fn socket(&self) -> Option<&TcpStream> {
-        Some(self)
+    #[cfg(test)]
+    fn written_bytes(&self) -> Vec<u8> {
+        ReadWrite::written_bytes(self.as_ref())
     }
 }
 
 struct TestStream(Box<dyn Read + Send + Sync>, Vec<u8>);
 
-impl Inner for TestStream {
+impl ReadWrite for TestStream {
     fn is_poolable(&self) -> bool {
         false
     }
@@ -79,7 +73,7 @@ impl Inner for TestStream {
         None
     }
 
-    /// For tests only
+    #[cfg(test)]
     fn written_bytes(&self) -> Vec<u8> {
         self.1.clone()
     }
@@ -188,7 +182,7 @@ impl fmt::Debug for Stream {
 }
 
 impl Stream {
-    fn new(t: impl Inner + Send + 'static) -> Stream {
+    fn new(t: impl ReadWrite) -> Stream {
         Stream::logged_create(Stream {
             inner: BufReader::new(Box::new(t)),
         })
@@ -337,7 +331,7 @@ pub(crate) fn connect_https(unit: &Unit, hostname: &str) -> Result<Stream, Error
     let sock = connect_host(unit, hostname, port)?;
 
     let tls_conf = &unit.agent.config.tls_config;
-    let https_stream = tls_conf.connect(hostname, sock)?;
+    let https_stream = tls_conf.connect(hostname, Box::new(sock))?;
     Ok(Stream::new(https_stream))
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -42,7 +42,7 @@ pub trait TlsConnector: Send + Sync {
     fn connect(
         &self,
         dns_name: &str,
-        io: Box<dyn ReadWrite + Sync>,
+        io: Box<dyn ReadWrite>,
     ) -> Result<Box<dyn ReadWrite>, crate::error::Error>;
 }
 


### PR DESCRIPTION
This PR explores the possibility of changing the signature of `TlsConnector::connect`.

Current situation

```rs
pub trait TlsConnector: Send + Sync {
    fn connect(
        &self,
        dns_name: &str,
        tcp_stream: TcpStream,
    ) -> Result<Box<dyn ReadWrite>, crate::error::Error>;
}
```

Proposed change in this PR:

```rs
pub trait TlsConnector: Send + Sync {
    fn connect(
        &self,
        dns_name: &str,
       io: Box<dyn ReadWrite>,
    ) -> Result<Box<dyn ReadWrite>, crate::error::Error>;
}
```

----------

## Motivation

#495 wants to add HTTPS proxy support (today we only have HTTP proxy). This means we would have one HTTPS connection to the proxy, and inside that we would tunnel the HTTPS traffic to the actual site being requested. That means we get a TLS stream inside a TLS stream.

The current `TlsConnector` works by wrapping `TcpStream` directly, which means we can at most have one layer of TLS. in #495 this is solved by publicly exposing the internal `Stream`.

This technically changes already released public API, however, because of bug #461 no one has been able to implement `TlsConnector` using our released versions, which is why I think we can allow ourselves to explore this space a bit more.

I'm keen on not exposing more types than we need, and `Stream` is not necessary. `Box<dyn ReadWrite>` is a more general alternative. The downside is that the current `TcpStream` is concrete, and so is `Stream` – a solution using `Box<dyn ReadWrite` directly, commits us to having an extra vtable lookup per read/write operation (`Stream` currently has a `Box<dyn>` internally, but we could potentially make that an enum).

### Future user provided transport

If we go down the path of `Box<dyn ReadWrite>`, one cool future possibility is to make ureq transport agnostic. We could let the user provide the transport in the agent. The API could look like this:

```rust
pub trait TransportProvider: Send + Sync {
    fn connect(
        &self,
        dns_name: &str,
    ) -> Result<Box<dyn ReadWrite>, crate::error::Error>;
}
```

`Agent::set_transport_provider(provider: impl TransportProvider)`

Our default implementation would provide a boxed up `TcpStream`, but a user implementation could let ureq work over any transport that is `Read + Write`.