### PR TITLE
Store response in vec for short responses

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -282,7 +282,7 @@ impl AgentBuilder {
                     self.max_idle_connections_per_host,
                 ),
                 #[cfg(feature = "cookies")]
-                cookie_tin: CookieTin::new(self.cookie_store.unwrap_or_else(CookieStore::default)),
+                cookie_tin: CookieTin::new(self.cookie_store.unwrap_or_default()),
                 resolver: self.resolver,
                 middleware: self.middleware,
             }),

--- a/src/response.rs
+++ b/src/response.rs
@@ -287,7 +287,7 @@ impl Response {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn into_reader(self) -> Box<dyn Read + Send> {
+    pub fn into_reader(self) -> impl Read + Send {
         let is_http10 = self.http_version().eq_ignore_ascii_case("HTTP/1.0");
         let is_close = self
             .header("connection")
@@ -938,7 +938,6 @@ mod tests {
             .unwrap();
         let stream = res.stream.get_mut();
         drop(stream);
-        println!("Prefetched {}", res.partial_body().len());
         let stream = res.stream.get_mut();
         assert!(matches!(stream, ResponseStream::Buffer(_)));
     }
@@ -953,7 +952,6 @@ mod tests {
             .unwrap();
         let stream = res.stream.get_mut();
         drop(stream);
-        println!("Prefetched {}", res.partial_body().len());
         let stream = res.stream.get_mut();
         assert!(matches!(stream, ResponseStream::Stream(_)));
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -22,7 +22,7 @@ pub trait ReadWrite: Read + Write + Send + fmt::Debug + 'static {
     fn socket(&self) -> Option<&TcpStream>;
     fn is_poolable(&self) -> bool;
 
-    /// The bytes written to the stream as a Vec<u8>. This is used for tests only.
+    /// The bytes written to the stream as a Vec<u8>.
     #[cfg(test)]
     fn written_bytes(&self) -> Vec<u8> {
         panic!("written_bytes on non Test stream");


### PR DESCRIPTION
closes #505 
closes #264 

When receiving a response internal buffers get filled right away. If the fetched size is the same as declared content length then the data is copied and the stream is released.

Somewhat related although as I found out not as much is an added API to access the internal buffer so that at least part (in effect 8 kB) of the response can be obtained without consuming the response.