### PR TITLE
Remove sync_wrapper dep in favor of Mutex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ socks = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 encoding_rs = { version = "0.8", optional = true }
-sync_wrapper = { version = "0.1" } 
 cookie_store = { version = "0.16", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4"
 webpki = { version = "0.22", optional = true }


### PR DESCRIPTION
We unwrap the stream exactly once per response, and we know that case will be uncontended for the same reason `SyncWrapper` works: `into_reader()` takes `self`, so it must have exclusive ownership. Uncontended mutexes are extremely cheap. This saves us a dependency at a trivial performance cost.

Followup to discussion in https://github.com/algesten/ureq/pull/510#issuecomment-1114156889.