### PR TITLE
Return Err on deadline checked_add overflow instead of panic

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -3,13 +3,13 @@ use std::{fmt, time};
 
 use url::{form_urlencoded, ParseError, Url};
 
+use crate::agent::Agent;
 use crate::body::Payload;
+use crate::error::{Error, ErrorKind};
 use crate::header::{self, Header};
 use crate::middleware::MiddlewareNext;
 use crate::unit::{self, Unit};
 use crate::Response;
-use crate::agent::Agent;
-use crate::error::{Error, ErrorKind};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -126,7 +126,12 @@ impl Request {
                 let now = time::Instant::now();
                 match now.checked_add(timeout) {
                     Some(dl) => Some(dl),
-                    None => return Err(Error::new(ErrorKind::Io, Some("Request deadline overflowed".to_string())))
+                    None => {
+                        return Err(Error::new(
+                            ErrorKind::Io,
+                            Some("Request deadline overflowed".to_string()),
+                        ))
+                    }
                 }
             }
         };

--- a/src/request.rs
+++ b/src/request.rs
@@ -8,7 +8,8 @@ use crate::header::{self, Header};
 use crate::middleware::MiddlewareNext;
 use crate::unit::{self, Unit};
 use crate::Response;
-use crate::{agent::Agent, error::Error};
+use crate::agent::Agent;
+use crate::error::{Error, ErrorKind};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -123,7 +124,10 @@ impl Request {
             None => None,
             Some(timeout) => {
                 let now = time::Instant::now();
-                Some(now.checked_add(timeout).unwrap())
+                match now.checked_add(timeout) {
+                    Some(dl) => Some(dl),
+                    None => return Err(Error::new(ErrorKind::Io, Some("Request deadline overflowed".to_string())))
+                }
             }
         };
 


### PR DESCRIPTION
Previous call to `unwrap()` on the checked_add return value panicked when it was None.
This change returns an Err result instead of panicking. 