### PR TITLE
feat: Add Connector trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "socks"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +821,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_json",
+ "socket2",
  "socks",
  "url",
  "webpki-roots",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ serde = { version = "1", features = ["derive"] }
 env_logger = "0.10"
 rustls = { version = "0.22.0" }
 rustls-pemfile = { version = "2.0" }
+socket2 = "0.5"
 
 [[example]]
 name = "cureq"

--- a/examples/bind_connect.rs
+++ b/examples/bind_connect.rs
@@ -1,6 +1,6 @@
 use socket2::{Domain, Socket, Type};
 use std::net::SocketAddr;
-use ureq::Connector;
+use ureq::TcpConnector;
 
 #[derive(Debug)]
 pub(crate) struct BindConnector {
@@ -13,7 +13,7 @@ impl BindConnector {
     }
 }
 
-impl Connector for BindConnector {
+impl TcpConnector for BindConnector {
     fn connect(&self, addr: &std::net::SocketAddr) -> std::io::Result<std::net::TcpStream> {
         let socket = Socket::new(Domain::for_address(addr.to_owned()), Type::STREAM, None)?;
         socket.bind(&self.bind_addr.into())?;
@@ -35,7 +35,7 @@ impl Connector for BindConnector {
 
 pub fn main() {
     let agent = ureq::builder()
-        .connector(BindConnector::new_bind("127.0.0.1:54321".parse().unwrap()))
+        .tcp_connector(BindConnector::new_bind("127.0.0.1:54321".parse().unwrap()))
         .build();
 
     let result = agent.get("http://127.0.0.1:8080/").call();

--- a/examples/bind_connect.rs
+++ b/examples/bind_connect.rs
@@ -1,0 +1,52 @@
+use socket2::{Domain, Socket, Type};
+use std::net::SocketAddr;
+use ureq::Connector;
+
+#[derive(Debug)]
+pub(crate) struct BindConnector {
+    bind_addr: SocketAddr,
+}
+
+impl BindConnector {
+    pub fn new_bind(bind_addr: SocketAddr) -> Self {
+        Self { bind_addr }
+    }
+}
+
+impl Connector for BindConnector {
+    fn connect(&self, addr: &std::net::SocketAddr) -> std::io::Result<std::net::TcpStream> {
+        let socket = Socket::new(Domain::for_address(addr.to_owned()), Type::STREAM, None)?;
+        socket.bind(&self.bind_addr.into())?;
+        socket.connect(&addr.to_owned().into())?;
+        Ok(socket.into())
+    }
+
+    fn connect_timeout(
+        &self,
+        addr: &std::net::SocketAddr,
+        timeout: std::time::Duration,
+    ) -> std::io::Result<std::net::TcpStream> {
+        let socket = Socket::new(Domain::for_address(addr.to_owned()), Type::STREAM, None)?;
+        socket.bind(&self.bind_addr.into())?;
+        socket.connect_timeout(&addr.to_owned().into(), timeout)?;
+        Ok(socket.into())
+    }
+}
+
+pub fn main() {
+    let agent = ureq::builder()
+        .connector(BindConnector::new_bind("127.0.0.1:54321".parse().unwrap()))
+        .build();
+
+    let result = agent.get("http://127.0.0.1:8080/").call();
+
+    match result {
+        Err(err) => {
+            println!("{:?}", err);
+            std::process::exit(1);
+        }
+        Ok(response) => {
+            assert_eq!(response.status(), 200);
+        }
+    }
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
-use crate::connect::{ArcConnector, StdTcpConnector};
+use crate::connect::{ArcTcpConnector, StdTcpConnector};
 use crate::middleware::Middleware;
 use crate::pool::ConnectionPool;
 use crate::proxy::Proxy;
@@ -46,7 +46,7 @@ pub struct AgentBuilder {
     #[cfg(feature = "cookies")]
     cookie_store: Option<CookieStore>,
     resolver: ArcResolver,
-    connector: ArcConnector,
+    tcp_connector: ArcTcpConnector,
     middleware: Vec<Box<dyn Middleware>>,
 }
 
@@ -128,7 +128,7 @@ pub(crate) struct AgentState {
     #[cfg(feature = "cookies")]
     pub(crate) cookie_tin: CookieTin,
     pub(crate) resolver: ArcResolver,
-    pub(crate) connector: ArcConnector,
+    pub(crate) tcp_connector: ArcTcpConnector,
     pub(crate) middleware: Vec<Box<dyn Middleware>>,
 }
 
@@ -274,7 +274,7 @@ impl AgentBuilder {
             max_idle_connections: DEFAULT_MAX_IDLE_CONNECTIONS,
             max_idle_connections_per_host: DEFAULT_MAX_IDLE_CONNECTIONS_PER_HOST,
             resolver: StdResolver.into(),
-            connector: StdTcpConnector.into(),
+            tcp_connector: StdTcpConnector.into(),
             #[cfg(feature = "cookies")]
             cookie_store: None,
             middleware: vec![],
@@ -302,7 +302,7 @@ impl AgentBuilder {
                 #[cfg(feature = "cookies")]
                 cookie_tin: CookieTin::new(self.cookie_store.unwrap_or_else(CookieStore::default)),
                 resolver: self.resolver,
-                connector: self.connector,
+                tcp_connector: self.tcp_connector,
                 middleware: self.middleware,
             }),
         }
@@ -407,13 +407,13 @@ impl AgentBuilder {
         self
     }
 
-    /// Configures a custom connector to be used by this agent. By default,
-    /// tcp-connect is done by std::net::TcpStream. This allows you
-    /// to override that connection with your own alternative.
+    /// Configures a custom TCP connector to be used by this agent.
+    /// By default, tcp-connect is done by std::net::TcpStream.
+    /// This allows you to override that connection with your own alternative.
     ///
     /// See `examples/bind_connect.rs` for example.
-    pub fn connector(mut self, connector: impl crate::Connector + 'static) -> Self {
-        self.connector = connector.into();
+    pub fn tcp_connector(mut self, tcp_connector: impl crate::TcpConnector + 'static) -> Self {
+        self.tcp_connector = tcp_connector.into();
         self
     }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,0 +1,47 @@
+use std::fmt;
+use std::io::Result as IoResult;
+use std::net::{SocketAddr, TcpStream};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// A custom Connector to override the default TcpStream connector.
+pub trait Connector: Send + Sync {
+    fn connect(&self, addr: &SocketAddr) -> IoResult<TcpStream> {
+        TcpStream::connect(addr)
+    }
+
+    fn connect_timeout(&self, addr: &SocketAddr, timeout: Duration) -> IoResult<TcpStream> {
+        TcpStream::connect_timeout(addr, timeout)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct StdTcpConnector;
+
+impl Connector for StdTcpConnector {}
+
+#[derive(Clone)]
+pub(crate) struct ArcConnector(Arc<dyn Connector>);
+
+impl<R> From<R> for ArcConnector
+where
+    R: Connector + 'static,
+{
+    fn from(r: R) -> Self {
+        Self(Arc::new(r))
+    }
+}
+
+impl fmt::Debug for ArcConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ArcConnector(...)")
+    }
+}
+
+impl std::ops::Deref for ArcConnector {
+    type Target = dyn Connector;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// A custom Connector to override the default TcpStream connector.
-pub trait Connector: Send + Sync {
+pub trait TcpConnector: Send + Sync {
     fn connect(&self, addr: &SocketAddr) -> IoResult<TcpStream> {
         TcpStream::connect(addr)
     }
@@ -18,28 +18,28 @@ pub trait Connector: Send + Sync {
 #[derive(Debug)]
 pub(crate) struct StdTcpConnector;
 
-impl Connector for StdTcpConnector {}
+impl TcpConnector for StdTcpConnector {}
 
 #[derive(Clone)]
-pub(crate) struct ArcConnector(Arc<dyn Connector>);
+pub(crate) struct ArcTcpConnector(Arc<dyn TcpConnector>);
 
-impl<R> From<R> for ArcConnector
+impl<R> From<R> for ArcTcpConnector
 where
-    R: Connector + 'static,
+    R: TcpConnector + 'static,
 {
     fn from(r: R) -> Self {
         Self(Arc::new(r))
     }
 }
 
-impl fmt::Debug for ArcConnector {
+impl fmt::Debug for ArcTcpConnector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ArcConnector(...)")
+        write!(f, "ArcTcpConnector(...)")
     }
 }
 
-impl std::ops::Deref for ArcConnector {
-    type Target = dyn Connector;
+impl std::ops::Deref for ArcTcpConnector {
+    type Target = dyn TcpConnector;
 
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ mod http_crate;
 pub use crate::agent::Agent;
 pub use crate::agent::AgentBuilder;
 pub use crate::agent::RedirectAuthHeaders;
-pub use crate::connect::Connector;
+pub use crate::connect::TcpConnector;
 pub use crate::error::{Error, ErrorKind, OrAnyStatus, Transport};
 pub use crate::middleware::{Middleware, MiddlewareNext};
 pub use crate::proxy::Proxy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,7 @@
 mod agent;
 mod body;
 mod chunked;
+mod connect;
 mod error;
 mod header;
 mod middleware;
@@ -429,6 +430,7 @@ mod http_crate;
 pub use crate::agent::Agent;
 pub use crate::agent::AgentBuilder;
 pub use crate::agent::RedirectAuthHeaders;
+pub use crate::connect::Connector;
 pub use crate::error::{Error, ErrorKind, OrAnyStatus, Transport};
 pub use crate::middleware::{Middleware, MiddlewareNext};
 pub use crate::proxy::Proxy;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -406,9 +406,9 @@ pub(crate) fn connect_host(
                 proto.unwrap(),
             )
         } else if let Some(timeout) = timeout {
-            TcpStream::connect_timeout(&sock_addr, timeout)
+            unit.connector().connect_timeout(&sock_addr, timeout)
         } else {
-            TcpStream::connect(sock_addr)
+            unit.connector().connect(&sock_addr)
         };
 
         if let Ok(stream) = stream {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -406,9 +406,9 @@ pub(crate) fn connect_host(
                 proto.unwrap(),
             )
         } else if let Some(timeout) = timeout {
-            unit.connector().connect_timeout(&sock_addr, timeout)
+            unit.tcp_connector().connect_timeout(&sock_addr, timeout)
         } else {
-            unit.connector().connect(&sock_addr)
+            unit.tcp_connector().connect(&sock_addr)
         };
 
         if let Ok(stream) = stream {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -12,7 +12,7 @@ use cookie::Cookie;
 
 use crate::agent::RedirectAuthHeaders;
 use crate::body::{self, BodySize, Payload, SizedReader};
-use crate::connect::ArcConnector;
+use crate::connect::ArcTcpConnector;
 use crate::error::{Error, ErrorKind};
 use crate::header;
 use crate::header::{get_header, Header};
@@ -116,8 +116,8 @@ impl Unit {
         self.agent.state.resolver.clone()
     }
 
-    pub fn connector(&self) -> ArcConnector {
-        self.agent.state.connector.clone()
+    pub fn tcp_connector(&self) -> ArcTcpConnector {
+        self.agent.state.tcp_connector.clone()
     }
 
     #[cfg(test)]

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -12,6 +12,7 @@ use cookie::Cookie;
 
 use crate::agent::RedirectAuthHeaders;
 use crate::body::{self, BodySize, Payload, SizedReader};
+use crate::connect::ArcConnector;
 use crate::error::{Error, ErrorKind};
 use crate::header;
 use crate::header::{get_header, Header};
@@ -113,6 +114,10 @@ impl Unit {
 
     pub fn resolver(&self) -> ArcResolver {
         self.agent.state.resolver.clone()
+    }
+
+    pub fn connector(&self) -> ArcConnector {
+        self.agent.state.connector.clone()
     }
 
     #[cfg(test)]


### PR DESCRIPTION
I need to get a tcpStream established from a specific source IP, but I didn't find a proper `bind_connect` implementation in `ureq`.

I checked the historical issue and found a lot of discussions on related content. #301 #419 #251

At the beginning, I added the `bind_connect` implementation to `ureq`, but I quickly relized that `ureq` needs to be kept lightweight, and there may be similar requirements in the future, such as establishing connections from socks files, or other special requirements, so finally I abstracted a most basic implementation of the `Connector` trait, and implemented `BindConnector` based on this.

The definition of the `Connector` trait is the same as the `connect` and `connect_timeout` of std `TcpStream`. I think it may need to be improved according to the needs in the future, but it should be enough for now.

Signed-off-by: zu1k <i@zu1k.com>