### PR TITLE
feat: Set multi query parameters

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -389,22 +389,28 @@ impl Request {
     /// ```
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
-    /// 
+    ///
     /// let query = vec![
     ///     ("format", "json"),
     ///     ("dest", "/login"),
     /// ];
-    /// 
+    ///
     /// let resp = ureq::get("http://httpbin.org/get")
-    ///     .query_vec(query)
+    ///     .query_pairs(query)
     ///     .call()?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn query_vec(mut self, queries: Vec<(&str, &str)>) -> Self {
+    pub fn query_pairs<'a, P>(mut self, pairs: P) -> Self
+    where
+        P: IntoIterator<Item = (&'a str, &'a str)>,
+    {
         if let Ok(mut url) = self.parse_url() {
-            for (param, value) in queries {
-                url.query_pairs_mut().append_pair(param, value);
+            {
+                let mut query_pairs = url.query_pairs_mut();
+                for (param, value) in pairs {
+                    query_pairs.append_pair(param, value);
+                }
             }
 
             // replace url

--- a/src/request.rs
+++ b/src/request.rs
@@ -382,6 +382,37 @@ impl Request {
         self
     }
 
+    /// Set multi query parameters.
+    ///
+    /// For example, to set `?format=json&dest=/login`
+    ///
+    /// ```
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # ureq::is_test(true);
+    /// 
+    /// let query = vec![
+    ///     ("format", "json"),
+    ///     ("dest", "/login"),
+    /// ];
+    /// 
+    /// let resp = ureq::get("http://httpbin.org/get")
+    ///     .query_vec(query)
+    ///     .call()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn query_vec(mut self, queries: Vec<(&str, &str)>) -> Self {
+        if let Ok(mut url) = self.parse_url() {
+            for (param, value) in queries {
+                url.query_pairs_mut().append_pair(param, value);
+            }
+
+            // replace url
+            self.url = url.to_string();
+        }
+        self
+    }
+
     /// Returns the value of the request method. Something like `GET`, `POST`, `PUT` etc.
     ///
     /// ```


### PR DESCRIPTION
Add a `query_vec` function for setting multi query parameters. To avoid repeated deserialization and serialization. 

Signed-off-by: zu1k <i@zu1k.com>