### PR TITLE
Feature/http compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
 gzip = ["flate2"]
 brotli = ["brotli-decompressor"]
-http-compat = ["http", "bytes"]
+http-compat = ["http"]
 
 [dependencies]
 base64 = "0.13"
@@ -33,7 +33,6 @@ cookie = { version = "0.16", default-features = false, optional = true}
 once_cell = "1"
 url = "2"
 http = { version = "0.2.7", optional = true }
-bytes = { version = "1.1.0", optional = true }
 socks = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
 gzip = ["flate2"]
 brotli = ["brotli-decompressor"]
+http-compat = ["http", "bytes"]
 
 [dependencies]
 base64 = "0.13"
@@ -31,6 +32,8 @@ chunked_transfer = "1.2"
 cookie = { version = "0.16", default-features = false, optional = true}
 once_cell = "1"
 url = "2"
+http = { version = "0.2.7", optional = true }
+bytes = { version = "1.1.0", optional = true }
 socks = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }

--- a/examples/http-compat.rs
+++ b/examples/http-compat.rs
@@ -1,0 +1,13 @@
+use ureq::Agent;
+
+fn main() {
+    let agent = Agent::new();
+    let request = http::Request::builder()
+        .method(http::Method::GET)
+        .uri(http::Uri::from_static("http://localhost:9000"))
+        .body("Hello, world!")
+        .unwrap();
+    let response = agent.send_http(request).unwrap();
+    let body = String::from_utf8_lossy(response.body());
+    println!("Response Body: {}", body);
+}

--- a/src/http_compat.rs
+++ b/src/http_compat.rs
@@ -1,6 +1,6 @@
-use std::io::Read;
-use http::Method;
 use crate::{Agent, Error};
+use http::Method;
+use std::io::Read;
 
 pub struct UreqBody(Vec<u8>);
 
@@ -61,7 +61,10 @@ impl Agent {
     /// let response: http::Response<Vec<u8>> = agent.send_http(request).unwrap();
     /// # }
     /// ```
-    pub fn send_http<T: Into<UreqBody>>(&self, request: http::Request<T>) -> Result<http::Response<Vec<u8>>, Error> {
+    pub fn send_http<T: Into<UreqBody>>(
+        &self,
+        request: http::Request<T>,
+    ) -> Result<http::Response<Vec<u8>>, Error> {
         // Convert the http::Request to ureq::Request and execute it
         let (parts, body) = request.map(T::into).into_parts();
         let method = parts.method.as_str();
@@ -80,7 +83,8 @@ impl Agent {
         }
 
         // We need to read the whole body now, otherwise the socket will be dropped with the ureq::Response
-        let body_len = response.header("Content-Length")
+        let body_len = response
+            .header("Content-Length")
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(0);
         let mut buffer = Vec::with_capacity(body_len);

--- a/src/http_compat.rs
+++ b/src/http_compat.rs
@@ -1,0 +1,79 @@
+use std::io::Read;
+use bytes::Bytes;
+use http::Method;
+use crate::{Agent, Error};
+
+pub struct UreqBody(Bytes);
+
+impl From<Bytes> for UreqBody {
+    #[inline]
+    fn from(bytes: Bytes) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<()> for UreqBody {
+    fn from(_: ()) -> Self {
+        Self(Bytes::new())
+    }
+}
+
+impl From<Vec<u8>> for UreqBody {
+    #[inline]
+    fn from(buffer: Vec<u8>) -> Self {
+        Self(buffer.into())
+    }
+}
+
+impl From<&'static [u8]> for UreqBody {
+    #[inline]
+    fn from(slice: &'static [u8]) -> Self {
+        Self(Bytes::from_static(slice))
+    }
+}
+
+impl From<String> for UreqBody {
+    #[inline]
+    fn from(buffer: String) -> Self {
+        buffer.into_bytes().into()
+    }
+}
+
+impl From<&'static str> for UreqBody {
+    #[inline]
+    fn from(slice: &'static str) -> Self {
+        slice.as_bytes().into()
+    }
+}
+
+impl Agent {
+    pub fn send_http<T: Into<UreqBody>>(&self, request: http::Request<T>) -> Result<http::Response<Bytes>, Error> {
+        // Convert the http::Request to ureq::Request and execute it
+        let (parts, body) = request.map(T::into).into_parts();
+        let method = parts.method.as_str();
+        let url = parts.uri.to_string();
+        let response = self.request(method, &url).send(body.0)?;
+
+        // Construct the http::Response from the ureq::Response
+        let mut builder = http::Response::builder();
+        let status = http::StatusCode::from_u16(response.status())?;
+        builder = builder.status(status);
+
+        for header_key in response.headers_names() {
+            // Safety: We know this header exists because we got this key from the response
+            let header_value = response.header(&header_key).unwrap();
+            builder = builder.header(header_key, header_value);
+        }
+
+        // We need to read the whole body now, otherwise the socket will be dropped with the ureq::Response
+        let body_len = response.header("Content-Length")
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(0);
+        let mut buffer = Vec::with_capacity(body_len);
+        response.into_reader().read_to_end(&mut buffer)?;
+        let bytes = Bytes::from(buffer);
+
+        let http_response = builder.body(bytes)?;
+        Ok(http_response)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,9 @@ pub(crate) fn default_tls_config() -> std::sync::Arc<dyn TlsConnector> {
 #[cfg(feature = "cookies")]
 mod cookies;
 
+#[cfg(feature = "http-compat")]
+mod http_compat;
+
 #[cfg(feature = "json")]
 pub use serde_json::json;
 use url::Url;


### PR DESCRIPTION
Here's my first attempt at solving #501, I'd like to hear your opinions on it. Unfortunately I wasn't able to run this locally because something about the build was failing for me. This introduces an `http-compat` feature which pulls in the optional dependencies on `http` and `bytes`. It adds a new `UreqBody` type like was mentioned in #501, and has a few basic conversions (though we'll probably want to support more).