### PR TITLE
Add Sync traits to ReadWrite trait

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,5 @@
 use std::io::{self, Read};
 use std::str::FromStr;
-use std::sync::Mutex;
 use std::{fmt, io::BufRead};
 
 use chunked_transfer::Decoder as ChunkDecoder;
@@ -69,7 +68,7 @@ pub struct Response {
     // Boxed to avoid taking up too much size.
     unit: Box<Unit>,
     // Boxed to avoid taking up too much size.
-    stream: Mutex<Box<Stream>>,
+    stream: Box<Stream>,
     /// The redirect history of this response, if any. The history starts with
     /// the first response received and ends with the response immediately
     /// previous to this one.
@@ -291,7 +290,7 @@ impl Response {
             self.length
         };
 
-        let stream = self.stream.into_inner().unwrap();
+        let stream = self.stream;
         let unit = self.unit;
         let result = stream.set_read_timeout(unit.agent.config.timeout_read);
         if let Err(e) = result {
@@ -514,7 +513,7 @@ impl Response {
             status,
             headers,
             unit: Box::new(unit),
-            stream: Mutex::new(Box::new(stream.into())),
+            stream: Box::new(stream.into()),
             history: vec![],
             length,
             compression,
@@ -524,7 +523,7 @@ impl Response {
     #[cfg(test)]
     pub fn into_written_bytes(self) -> Vec<u8> {
         // Deliberately consume `self` so that any access to `self.stream` must be non-shared.
-        self.stream.into_inner().unwrap().written_bytes()
+        self.stream.written_bytes()
     }
 
     #[cfg(test)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,7 +18,7 @@ use crate::error::ErrorKind;
 use crate::unit::Unit;
 
 /// Trait for things implementing [std::io::Read] + [std::io::Write]. Used in [TlsConnector].
-pub trait ReadWrite: Read + Write + Send + fmt::Debug + 'static {
+pub trait ReadWrite: Read + Write + Send + Sync + fmt::Debug + 'static {
     fn socket(&self) -> Option<&TcpStream>;
     fn is_poolable(&self) -> bool;
 


### PR DESCRIPTION
This allows us to get rid of a Mutex (and not take a dependency on sync_wrapper).

Implements my proposal from #515. Reverts #475.