### PR TITLE
Simplify ReadWrite interface

### DIFF
--- a/examples/custom-tls.rs
+++ b/examples/custom-tls.rs
@@ -52,9 +52,6 @@ impl ReadWrite for CustomTlsStream {
     fn socket(&self) -> Option<&TcpStream> {
         self.0.socket()
     }
-    fn is_poolable(&self) -> bool {
-        self.0.is_poolable()
-    }
 }
 
 impl io::Read for CustomTlsStream {

--- a/examples/mbedtls/mbedtls_connector.rs
+++ b/examples/mbedtls/mbedtls_connector.rs
@@ -116,9 +116,6 @@ impl ReadWrite for MbedTlsStream {
     fn socket(&self) -> Option<&TcpStream> {
         None
     }
-    fn is_poolable(&self) -> bool {
-        true
-    }
 }
 
 impl io::Read for MbedTlsStream {

--- a/src/ntls.rs
+++ b/src/ntls.rs
@@ -31,7 +31,4 @@ impl ReadWrite for native_tls::TlsStream<Box<dyn ReadWrite>> {
     fn socket(&self) -> Option<&TcpStream> {
         self.get_ref().socket()
     }
-    fn is_poolable(&self) -> bool {
-        self.get_ref().is_poolable()
-    }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -248,10 +248,6 @@ impl<R: Read + Sized + Into<Stream>> PoolReturnRead<R> {
         if let Some(reader) = self.reader.take() {
             // bring back stream here to either go into pool or dealloc
             let mut stream = reader.into();
-            if !stream.is_poolable() {
-                // just let it deallocate
-                return Ok(());
-            }
 
             // ensure stream can be reused
             stream.reset()?;
@@ -338,10 +334,6 @@ mod tests {
     impl ReadWrite for NoopStream {
         fn socket(&self) -> Option<&std::net::TcpStream> {
             None
-        }
-
-        fn is_poolable(&self) -> bool {
-            true
         }
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -998,7 +998,7 @@ mod tests {
             OK",
         );
         let v = cow.to_vec();
-        let s = Stream::from_vec(v);
+        let s = Stream::new(ReadOnlyStream::new(v));
         let request_url = "https://example.com".parse().unwrap();
         let request_reader = SizedReader {
             size: crate::body::BodySize::Empty,

--- a/src/response.rs
+++ b/src/response.rs
@@ -9,7 +9,7 @@ use crate::body::SizedReader;
 use crate::error::{Error, ErrorKind::BadStatus};
 use crate::header::{get_all_headers, get_header, Header, HeaderLine};
 use crate::pool::PoolReturnRead;
-use crate::stream::{DeadlineStream, Stream, ReadOnlyStream};
+use crate::stream::{DeadlineStream, ReadOnlyStream, Stream};
 use crate::unit::Unit;
 use crate::{stream, Agent, ErrorKind};
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -9,7 +9,7 @@ use crate::body::SizedReader;
 use crate::error::{Error, ErrorKind::BadStatus};
 use crate::header::{get_all_headers, get_header, Header, HeaderLine};
 use crate::pool::PoolReturnRead;
-use crate::stream::{DeadlineStream, Stream};
+use crate::stream::{DeadlineStream, Stream, ReadOnlyStream};
 use crate::unit::Unit;
 use crate::{stream, Agent, ErrorKind};
 
@@ -521,12 +521,6 @@ impl Response {
     }
 
     #[cfg(test)]
-    pub fn into_written_bytes(self) -> Vec<u8> {
-        // Deliberately consume `self` so that any access to `self.stream` must be non-shared.
-        self.stream.written_bytes()
-    }
-
-    #[cfg(test)]
     pub fn set_url(&mut self, url: Url) {
         self.url = url;
     }
@@ -643,7 +637,7 @@ impl FromStr for Response {
     /// # }
     /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let stream = Stream::from_vec(s.as_bytes().to_owned());
+        let stream = Stream::new(ReadOnlyStream::new(s.into()));
         let request_url = "https://example.com".parse().unwrap();
         let request_reader = SizedReader {
             size: crate::body::BodySize::Empty,

--- a/src/rtls.rs
+++ b/src/rtls.rs
@@ -33,9 +33,6 @@ impl ReadWrite for RustlsStream {
     fn socket(&self) -> Option<&TcpStream> {
         self.0.get_ref().socket()
     }
-    fn is_poolable(&self) -> bool {
-        self.0.get_ref().is_poolable()
-    }
 }
 
 // TODO: After upgrading to rustls 0.20 or higher, we can remove these Read

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -21,12 +21,6 @@ use crate::unit::Unit;
 pub trait ReadWrite: Read + Write + Send + Sync + fmt::Debug + 'static {
     fn socket(&self) -> Option<&TcpStream>;
     fn is_poolable(&self) -> bool;
-
-    /// The bytes written to the stream as a Vec<u8>. This is used for tests only.
-    #[cfg(test)]
-    fn written_bytes(&self) -> Vec<u8> {
-        panic!("written_bytes on non Test stream");
-    }
 }
 
 impl ReadWrite for TcpStream {
@@ -56,48 +50,6 @@ impl<T: ReadWrite + ?Sized> ReadWrite for Box<T> {
     }
     fn is_poolable(&self) -> bool {
         ReadWrite::is_poolable(self.as_ref())
-    }
-    #[cfg(test)]
-    fn written_bytes(&self) -> Vec<u8> {
-        ReadWrite::written_bytes(self.as_ref())
-    }
-}
-
-struct TestStream(Box<dyn Read + Send + Sync>, Vec<u8>, bool);
-
-impl ReadWrite for TestStream {
-    fn is_poolable(&self) -> bool {
-        self.2
-    }
-    fn socket(&self) -> Option<&TcpStream> {
-        None
-    }
-
-    #[cfg(test)]
-    fn written_bytes(&self) -> Vec<u8> {
-        self.1.clone()
-    }
-}
-
-impl Read for TestStream {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
-    }
-}
-
-impl Write for TestStream {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.1.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl fmt::Debug for TestStream {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("TestStream").finish()
     }
 }
 
@@ -187,6 +139,41 @@ pub(crate) fn io_err_timeout(error: String) -> io::Error {
     io::Error::new(io::ErrorKind::TimedOut, error)
 }
 
+#[derive(Debug)]
+pub(crate) struct ReadOnlyStream(Cursor<Vec<u8>>);
+
+impl ReadOnlyStream {
+    pub(crate) fn new(v: Vec<u8>) -> Self {
+        Self(Cursor::new(v))
+    }
+}
+
+impl Read for ReadOnlyStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl std::io::Write for ReadOnlyStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl ReadWrite for ReadOnlyStream {
+    fn socket(&self) -> Option<&std::net::TcpStream> {
+        None
+    }
+
+    fn is_poolable(&self) -> bool {
+        true
+    }
+}
+
 impl fmt::Debug for Stream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.inner.get_ref().socket() {
@@ -197,7 +184,7 @@ impl fmt::Debug for Stream {
 }
 
 impl Stream {
-    fn new(t: impl ReadWrite) -> Stream {
+    pub(crate) fn new(t: impl ReadWrite) -> Stream {
         Stream::logged_create(Stream {
             inner: BufReader::new(Box::new(t)),
         })
@@ -206,23 +193,6 @@ impl Stream {
     fn logged_create(stream: Stream) -> Stream {
         debug!("created stream: {:?}", stream);
         stream
-    }
-
-    pub(crate) fn from_vec(v: Vec<u8>) -> Stream {
-        Stream::logged_create(Stream {
-            inner: BufReader::new(Box::new(TestStream(
-                Box::new(Cursor::new(v)),
-                vec![],
-                false,
-            ))),
-        })
-    }
-
-    #[cfg(test)]
-    pub(crate) fn from_vec_poolable(v: Vec<u8>) -> Stream {
-        Stream::logged_create(Stream {
-            inner: BufReader::new(Box::new(TestStream(Box::new(Cursor::new(v)), vec![], true))),
-        })
     }
 
     fn from_tcp_stream(t: TcpStream) -> Stream {
@@ -295,11 +265,6 @@ impl Stream {
         } else {
             Ok(())
         }
-    }
-
-    #[cfg(test)]
-    pub fn written_bytes(&self) -> Vec<u8> {
-        self.inner.get_ref().written_bytes()
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -20,15 +20,11 @@ use crate::unit::Unit;
 /// Trait for things implementing [std::io::Read] + [std::io::Write]. Used in [TlsConnector].
 pub trait ReadWrite: Read + Write + Send + Sync + fmt::Debug + 'static {
     fn socket(&self) -> Option<&TcpStream>;
-    fn is_poolable(&self) -> bool;
 }
 
 impl ReadWrite for TcpStream {
     fn socket(&self) -> Option<&TcpStream> {
         Some(self)
-    }
-    fn is_poolable(&self) -> bool {
-        true
     }
 }
 
@@ -47,9 +43,6 @@ pub(crate) struct Stream {
 impl<T: ReadWrite + ?Sized> ReadWrite for Box<T> {
     fn socket(&self) -> Option<&TcpStream> {
         ReadWrite::socket(self.as_ref())
-    }
-    fn is_poolable(&self) -> bool {
-        ReadWrite::is_poolable(self.as_ref())
     }
 }
 
@@ -168,10 +161,6 @@ impl ReadWrite for ReadOnlyStream {
     fn socket(&self) -> Option<&std::net::TcpStream> {
         None
     }
-
-    fn is_poolable(&self) -> bool {
-        true
-    }
 }
 
 impl fmt::Debug for Stream {
@@ -239,9 +228,6 @@ impl Stream {
             Some(socket) => Stream::serverclosed_stream(socket),
             None => Ok(false),
         }
-    }
-    pub fn is_poolable(&self) -> bool {
-        self.inner.get_ref().is_poolable()
     }
 
     pub(crate) fn reset(&mut self) -> io::Result<()> {
@@ -656,10 +642,6 @@ mod tests {
 
     impl ReadWrite for ReadRecorder {
         fn socket(&self) -> Option<&TcpStream> {
-            unimplemented!()
-        }
-
-        fn is_poolable(&self) -> bool {
             unimplemented!()
         }
     }

--- a/src/test/body_send.rs
+++ b/src/test/body_send.rs
@@ -81,7 +81,7 @@ fn content_type_on_json() {
 #[test]
 #[cfg(feature = "json")]
 fn content_type_not_overriden_on_json() {
-    let recorder = Recoder::register("/content_type_not_overriden_on_json");
+    let recorder = Recorder::register("/content_type_not_overriden_on_json");
     let mut json = serde_json::Map::new();
     json.insert(
         "Hello".to_string(),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -120,9 +120,6 @@ impl TestStream {
 }
 
 impl ReadWrite for TestStream {
-    fn is_poolable(&self) -> bool {
-        self.2
-    }
     fn socket(&self) -> Option<&TcpStream> {
         None
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,9 +1,12 @@
+use crate::ReadWrite;
 use crate::error::Error;
-use crate::stream::Stream;
+use crate::stream::{Stream, ReadOnlyStream};
 use crate::unit::Unit;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::io::Write;
+use std::fmt;
+use std::io::{Write, Cursor, Read, self};
+use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 
 mod agent_test;
@@ -48,7 +51,7 @@ pub(crate) fn make_response(
     }
     write!(&mut buf, "\r\n").ok();
     buf.append(&mut body);
-    Ok(Stream::from_vec(buf))
+    Ok(Stream::new(ReadOnlyStream::new(buf)))
 }
 
 pub(crate) fn resolve_handler(unit: &Unit) -> Result<Stream, Error> {
@@ -65,4 +68,84 @@ pub(crate) fn resolve_handler(unit: &Unit) -> Result<Stream, Error> {
         .unwrap_or_else(|| panic!("call make_response(\"{}\") before fetching it in tests (or if you did make it, avoid fetching it more than once)", path));
     drop(handlers);
     handler(unit)
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct Recorder {
+    contents: Arc<Mutex<Vec<u8>>>
+}
+
+impl Recorder {
+    fn register(path: &str) -> Self {
+        let recorder = Recorder::default();
+        let recorder2 = recorder.clone();
+        set_handler(path, move |_unit| {
+            Ok(recorder.stream())
+        });
+        recorder2
+    }
+
+    #[cfg(feature = "charset")]
+    fn to_vec(self) -> Vec<u8> {
+        self.contents.lock().unwrap().clone()
+    }
+
+    fn contains(&self, s: &str) -> bool {
+        std::str::from_utf8(&self.contents.lock().unwrap()).unwrap().contains(s)
+    }
+
+    fn stream(&self) -> Stream {
+        let cursor = Cursor::new(b"HTTP/1.1 200 OK\r\n\r\n");
+        Stream::new(TestStream::new(cursor, self.clone()))
+    }
+}
+
+impl Write for Recorder {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.contents.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+pub(crate) struct TestStream(Box<dyn Read + Send + Sync>, Box<dyn Write + Send + Sync>, bool);
+
+impl TestStream {
+    #[cfg(test)]
+    pub(crate) fn new(response: impl Read + Send + Sync + 'static, recorder: impl Write + Send + Sync + 'static) -> Self {
+        Self(Box::new(response), Box::new(recorder), false)
+    }
+}
+
+impl ReadWrite for TestStream {
+    fn is_poolable(&self) -> bool {
+        self.2
+    }
+    fn socket(&self) -> Option<&TcpStream> {
+        None
+    }
+}
+
+impl Read for TestStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl Write for TestStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.1.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl fmt::Debug for TestStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TestStream").finish()
+    }
 }

--- a/src/test/query_string.rs
+++ b/src/test/query_string.rs
@@ -1,58 +1,37 @@
-use crate::test;
-
-use super::super::*;
+use crate::get;
+use super::Recorder;
 
 #[test]
 fn no_query_string() {
-    test::set_handler("/no_query_string", |_unit| {
-        test::make_response(200, "OK", vec![], vec![])
-    });
-    let resp = get("test://host/no_query_string").call().unwrap();
-    let vec = resp.into_written_bytes();
-    let s = String::from_utf8_lossy(&vec);
-    assert!(s.contains("GET /no_query_string HTTP/1.1"))
+    let recorder = Recorder::register("/no_query_string");
+    get("test://host/no_query_string").call().unwrap();
+    assert!(recorder.contains("GET /no_query_string HTTP/1.1"))
 }
 
 #[test]
 fn escaped_query_string() {
-    test::set_handler("/escaped_query_string", |_unit| {
-        test::make_response(200, "OK", vec![], vec![])
-    });
-    let resp = get("test://host/escaped_query_string")
+    let recorder = Recorder::register("/escaped_query_string");
+    get("test://host/escaped_query_string")
         .query("foo", "bar")
         .query("baz", "yo lo")
         .call()
         .unwrap();
-    let vec = resp.into_written_bytes();
-    let s = String::from_utf8_lossy(&vec);
-    assert!(
-        s.contains("GET /escaped_query_string?foo=bar&baz=yo+lo HTTP/1.1"),
-        "req: {}",
-        s
-    );
+    assert!(recorder.contains("GET /escaped_query_string?foo=bar&baz=yo+lo HTTP/1.1"));
 }
 
 #[test]
 fn query_in_path() {
-    test::set_handler("/query_in_path", |_unit| {
-        test::make_response(200, "OK", vec![], vec![])
-    });
-    let resp = get("test://host/query_in_path?foo=bar").call().unwrap();
-    let vec = resp.into_written_bytes();
-    let s = String::from_utf8_lossy(&vec);
-    assert!(s.contains("GET /query_in_path?foo=bar HTTP/1.1"))
+    let recorder = Recorder::register("/query_in_path");
+    get("test://host/query_in_path?foo=bar").call().unwrap();
+    assert!(recorder.contains("GET /query_in_path?foo=bar HTTP/1.1"))
 }
 
 #[test]
 fn query_in_path_and_req() {
-    test::set_handler("/query_in_path_and_req", |_unit| {
-        test::make_response(200, "OK", vec![], vec![])
-    });
-    let resp = get("test://host/query_in_path_and_req?foo=bar")
+    let recorder = Recorder::register("/query_in_path_and_req");
+    get("test://host/query_in_path_and_req?foo=bar")
         .query("baz", "1 2 3")
         .call()
         .unwrap();
-    let vec = resp.into_written_bytes();
-    let s = String::from_utf8_lossy(&vec);
-    assert!(s.contains("GET /query_in_path_and_req?foo=bar&baz=1+2+3 HTTP/1.1"))
+    assert!(recorder.contains("GET /query_in_path_and_req?foo=bar&baz=1+2+3 HTTP/1.1"));
 }

--- a/src/test/query_string.rs
+++ b/src/test/query_string.rs
@@ -1,5 +1,5 @@
-use crate::get;
 use super::Recorder;
+use crate::get;
 
 #[test]
 fn no_query_string() {

--- a/src/test/simple.rs
+++ b/src/test/simple.rs
@@ -1,7 +1,7 @@
 use crate::test;
 use std::io::Read;
 
-use super::super::*;
+use super::{super::*, Recorder};
 
 #[test]
 fn header_passing() {
@@ -116,13 +116,9 @@ fn body_as_reader() {
 
 #[test]
 fn escape_path() {
-    test::set_handler("/escape_path%20here", |_unit| {
-        test::make_response(200, "OK", vec![], vec![])
-    });
-    let resp = get("test://host/escape_path here").call().unwrap();
-    let vec = resp.into_written_bytes();
-    let s = String::from_utf8_lossy(&vec);
-    assert!(s.contains("GET /escape_path%20here HTTP/1.1"))
+    let recorder = Recorder::register("/escape_path%20here");
+    get("test://host/escape_path here").call().unwrap();
+    assert!(recorder.contains("GET /escape_path%20here HTTP/1.1"))
 }
 
 #[test]
@@ -194,22 +190,14 @@ pub fn header_with_spaces_before_value() {
 
 #[test]
 pub fn host_no_port() {
-    test::set_handler("/host_no_port", |_| {
-        test::make_response(200, "OK", vec![], vec![])
-    });
-    let resp = get("test://myhost/host_no_port").call().unwrap();
-    let vec = resp.into_written_bytes();
-    let s = String::from_utf8_lossy(&vec);
-    assert!(s.contains("\r\nHost: myhost\r\n"));
+    let recorder = Recorder::register("/host_no_port");
+    get("test://myhost/host_no_port").call().unwrap();
+    assert!(recorder.contains("\r\nHost: myhost\r\n"));
 }
 
 #[test]
 pub fn host_with_port() {
-    test::set_handler("/host_with_port", |_| {
-        test::make_response(200, "OK", vec![], vec![])
-    });
-    let resp = get("test://myhost:234/host_with_port").call().unwrap();
-    let vec = resp.into_written_bytes();
-    let s = String::from_utf8_lossy(&vec);
-    assert!(s.contains("\r\nHost: myhost:234\r\n"));
+    let recorder = Recorder::register("/host_with_port");
+    get("test://myhost:234/host_with_port").call().unwrap();
+    assert!(recorder.contains("\r\nHost: myhost:234\r\n"));
 }


### PR DESCRIPTION
Previously, ReadWrite had methods `is_poolable` and `written_bytes`, which were solely for the use of unittests.

This replaces `written_bytes` and `TestStream` with a `struct Recorder` that implements `ReadWrite` and allows unittests to access its recorded bytes via an `Arc<Mutex<Vec<u8>>>`. It eliminates `is_poolable`; it's fine to pool a Stream of any kind.

The new `Recorder` also has some convenience methods that abstract away boilerplate code from many of our unittests.

I got rid of `Stream::from_vec` and `Stream::from_vec_poolable` because they depended on `TestStream`. They've been replaced by `NoopStream` for the pool.rs tests, and `ReadOnlyStream` for constructing `Response`s from `&str` and some test cases.