### PR TITLE
Buffer short responses (2)

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -258,7 +258,7 @@ impl Response {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn into_reader(self) -> Box<dyn Read + Send> {
+    pub fn into_reader(self) -> Box<dyn Read + Send + Sync + 'static> {
         self.reader
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -311,7 +311,7 @@ impl Response {
                 let mut pooler =
                     PoolReturnRead::new(&unit.agent, &unit.url, LimitedRead::new(stream, len));
                 if len <= buffer_len {
-                    let mut buf = [0u8].repeat(len);
+                    let mut buf = vec![0; len];
                     pooler
                         .read_exact(&mut buf)
                         .expect("failed to read exact buffer length from stream");

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -50,7 +50,7 @@ impl<T: ReadWrite + ?Sized> ReadWrite for Box<T> {
 // after the provided deadline, and sets timeouts on the underlying
 // TcpStream to ensure read() doesn't block beyond the deadline.
 // When the From trait is used to turn a DeadlineStream back into a
-// Stream (by PoolReturningRead), the timeouts are removed.
+// Stream (by PoolReturnRead), the timeouts are removed.
 pub(crate) struct DeadlineStream {
     stream: Stream,
     deadline: Option<Instant>,
@@ -182,6 +182,10 @@ impl Stream {
     fn logged_create(stream: Stream) -> Stream {
         debug!("created stream: {:?}", stream);
         stream
+    }
+
+    pub(crate) fn buffer(&self) -> &[u8] {
+        self.inner.buffer()
     }
 
     fn from_tcp_stream(t: TcpStream) -> Stream {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -60,6 +60,10 @@ impl DeadlineStream {
     pub(crate) fn new(stream: Stream, deadline: Option<Instant>) -> Self {
         DeadlineStream { stream, deadline }
     }
+
+    pub(crate) fn inner_ref(&self) -> &Stream {
+        &self.stream
+    }
 }
 
 impl From<DeadlineStream> for Stream {


### PR DESCRIPTION
In Response, rather than storing a `Box<Stream>` and turning it into a `Box<dyn Read + Send>`, do that transformation at construction time and store a `reader` on the Response.

This allows us to use the same length calculations as we use for LimitedRead, and avoid turning Stream into an enum. Since `Cursor<Vec<u8>>` is naturally `Read + Send`, we don't need a wrapper type; we can Box it an return it directly.

This happens to save us an allocation, since we never box the Stream, just the reader.

This is an alternative implementation to #513 and #526

Closes https://github.com/algesten/ureq/issues/505
Closes https://github.com/algesten/ureq/issues/264

This is built on top of #530, because written_bytes was getting in the way of this implementation. The commit that is unique to this branch is 9ecb86a7fc4d142d0a15aa7f93acbbc3e9467b3b.