### PR TITLE
Simplify Response object

### DIFF
--- a/src/unit.rs
+++ b/src/unit.rs
@@ -109,10 +109,6 @@ impl Unit {
         }
     }
 
-    pub fn is_head(&self) -> bool {
-        self.method.eq_ignore_ascii_case("head")
-    }
-
     pub fn resolver(&self) -> ArcResolver {
         self.agent.state.resolver.clone()
     }


### PR DESCRIPTION
Now that we create a Reader immediately on construction, we can get rid of `unit`, `length`, and `compression` by passing the necessary parameters directly to stream_to_reader. This also lets us avoid temporarily making a half-constructed Response so we can call stream_to_reader on it. Now stream_to_reader is an associated method that doesn't take `Self` so it can be called during construction.

Followup to #531.