### PR TITLE
Fix: discards cookie header while redirection

### DIFF
--- a/src/unit.rs
+++ b/src/unit.rs
@@ -218,10 +218,10 @@ pub(crate) fn connect(
         // reuse the previous header vec on redirects.
         let mut headers = unit.headers;
 
-        // on redirects we don't want to keep "content-length". we also might want to
+        // on redirects we don't want to keep "content-length" and "cookie". we also might want to
         // strip away "authorization" to ensure credentials are not leaked.
         headers.retain(|h| {
-            !h.is_name("content-length") && (!h.is_name("authorization") || keep_auth_header)
+            !h.is_name("content-length") && !h.is_name("cookie") && (!h.is_name("authorization") || keep_auth_header)
         });
 
         // recreate the unit to get a new hostname and cookies for the new host.


### PR DESCRIPTION
When ureq receives 302 redirect, it calls `Unit::new` without discarding the cookie header.
https://github.com/algesten/ureq/blob/134d82ecf4f8905f4ec84080adb1839f2de115ea/src/unit.rs#L224

So, the request header which being sent to redirected target will contain cookies both before and after the redirect.

Is is intended action?

When using ureq for http scraping, ureq failure to login some web sites because of session disruption.