### PR TITLE
Switch to MultiGzDecoder

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -304,10 +304,8 @@ impl<R: Read + Sized + Done + Into<Stream>> Read for PoolReturnRead<R> {
 mod tests {
     use std::io;
 
-    use crate::response::Compression;
     use crate::stream::{remote_addr_for_test, Stream};
     use crate::ReadWrite;
-    use chunked_transfer::Decoder as ChunkDecoder;
 
     use super::*;
 
@@ -446,7 +444,11 @@ mod tests {
     // decoder reads the exact amount from a chunked stream, not past the 0. This
     // happens because gzip has built-in knowledge of the length to read.
     #[test]
+    #[cfg(feature = "gzip")]
     fn read_exact_chunked_gzip() {
+        use crate::response::Compression;
+        use chunked_transfer::Decoder as ChunkDecoder;
+
         let gz_body = vec![
             b'E', b'\r', b'\n', // 14 first chunk
             0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x03, 0xCB, 0x48, 0xCD, 0xC9,

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,7 +22,7 @@ use serde::de::DeserializeOwned;
 use encoding_rs::Encoding;
 
 #[cfg(feature = "gzip")]
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 
 #[cfg(feature = "brotli")]
 use brotli_decompressor::Decompressor as BrotliDecoder;
@@ -600,7 +600,7 @@ impl Compression {
             #[cfg(feature = "brotli")]
             Compression::Brotli => Box::new(BrotliDecoder::new(reader, 4096)),
             #[cfg(feature = "gzip")]
-            Compression::Gzip => Box::new(GzDecoder::new(reader)),
+            Compression::Gzip => Box::new(MultiGzDecoder::new(reader)),
         }
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -571,7 +571,7 @@ impl Response {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum Compression {
+pub(crate) enum Compression {
     #[cfg(feature = "brotli")]
     Brotli,
     #[cfg(feature = "gzip")]
@@ -592,7 +592,7 @@ impl Compression {
 
     /// Wrap the raw reader with a decompressing reader
     #[allow(unused_variables)] // when no features enabled, reader is unused (unreachable)
-    fn wrap_reader(
+    pub(crate) fn wrap_reader(
         self,
         reader: Box<dyn Read + Send + Sync + 'static>,
     ) -> Box<dyn Read + Send + Sync + 'static> {


### PR DESCRIPTION
This is more correct, since all gzip streams can consist of multiple members. It has the happy side effect that it causes gzipped responses to reliably return their streams to the pool.

Small fix for #549. Uses @algesten's nice unittest from #550.