### PR TITLE
Redesign pooling mechanic

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -448,8 +448,8 @@ mod tests {
     #[cfg(feature = "gzip")]
     fn read_exact_chunked_gzip() {
         use crate::response::Compression;
-        use std::io::Cursor;
         use chunked_transfer::Decoder as ChunkDecoder;
+        use std::io::Cursor;
 
         let gz_body = vec![
             b'E', b'\r', b'\n', // 14 first chunk
@@ -470,7 +470,11 @@ mod tests {
         assert_eq!(agent.state.pool.len(), 0);
 
         let ro = crate::test::TestStream::new(Cursor::new(gz_body), std::io::sink());
-        let stream = Stream::new(ro, "1.1.1.1:4343".parse().unwrap(), PoolReturner::new(agent.clone(), PoolKey::from_parts("http", "1.1.1.1", 8080)));
+        let stream = Stream::new(
+            ro,
+            "1.1.1.1:4343".parse().unwrap(),
+            PoolReturner::new(agent.clone(), PoolKey::from_parts("http", "1.1.1.1", 8080)),
+        );
 
         let chunked = ChunkDecoder::new(stream);
         let pool_return_read: Box<(dyn Read + Send + Sync + 'static)> =

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -466,7 +466,7 @@ mod tests {
         let agent = Agent::new();
         let pool_key = PoolKey::new(&url, None);
         let stream = NoopStream::stream(PoolReturner::new(agent.clone(), pool_key));
-        let mut limited_read = LimitedRead::new(stream, 500);
+        let mut limited_read = LimitedRead::new(stream, std::num::NonZeroUsize::new(500).unwrap());
 
         limited_read.read_exact(&mut out_buf).unwrap();
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -247,7 +247,7 @@ impl PoolReturner {
 
     pub(crate) fn return_to_pool(&self, stream: Stream) {
         if let Some((agent, pool_key)) = &self.inner {
-            agent.state.pool.add(&pool_key, stream);
+            agent.state.pool.add(pool_key, stream);
         }
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1077,6 +1077,7 @@ mod tests {
         let s = Stream::new(
             ReadOnlyStream::new(v),
             crate::stream::remote_addr_for_test(),
+            PoolReturner::none(),
         );
         let request_url = "https://example.com".parse().unwrap();
         let request_reader = SizedReader {

--- a/src/response.rs
+++ b/src/response.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use std::{fmt, io::BufRead};
 
 use chunked_transfer::Decoder as ChunkDecoder;
-use log::{debug};
+use log::debug;
 use url::Url;
 
 use crate::body::SizedReader;
@@ -353,8 +353,8 @@ impl Response {
                         // when we do that, and since that's a syscall it can fail.
                         stream.return_to_pool().expect("returning stream to pool");
                         Box::new(std::io::empty())
-                    },
-                    Some(len) =>  {
+                    }
+                    Some(len) => {
                         let mut limited_read = LimitedRead::new(stream, len);
 
                         if len.get() <= buffer_len {

--- a/src/response.rs
+++ b/src/response.rs
@@ -328,7 +328,7 @@ impl Response {
         let inner = stream.inner_ref();
         let result = inner.set_read_timeout(unit.agent.config.timeout_read);
         if let Err(e) = result {
-            return Box::new(ErrorReader(e)) as Box<dyn Read + Send + Sync + 'static>;
+            return Box::new(ErrorReader(e));
         }
         let buffer_len = inner.buffer().len();
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -877,7 +877,7 @@ impl Read for ErrorReader {
 
 #[cfg(test)]
 mod tests {
-    use std::{io::Cursor};
+    use std::io::Cursor;
 
     use crate::{body::Payload, pool::PoolKey};
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use crate::pool::PoolReturner;
 use crate::stream::{remote_addr_for_test, ReadOnlyStream, Stream};
 use crate::unit::Unit;
 use crate::ReadWrite;
@@ -55,6 +56,7 @@ pub(crate) fn make_response(
     Ok(Stream::new(
         ReadOnlyStream::new(buf),
         remote_addr_for_test(),
+        PoolReturner::none(),
     ))
 }
 
@@ -103,6 +105,7 @@ impl Recorder {
         Stream::new(
             TestStream::new(cursor, self.clone()),
             remote_addr_for_test(),
+            PoolReturner::none(),
         )
     }
 }


### PR DESCRIPTION
Introduce PoolReturner, a handle on an agent and a PoolKey that is capable of returning a Stream to a Pool. Make Streams keep track of their own PoolReturner, instead of having PoolReturnRead keep track of that information.

For the LimitedRead code path, get rid of PoolReturnRead. Instead, LimitedRead is responsible for returning its Stream to the Pool after its second-to-last read. In other words, LimitedRead will return the stream if the next read is guaranteed to return Ok(0).

Constructing a LimitedRead of size 0 is always wrong, because we could always just return the stream immediately. Change the size argument to NonZeroUsize to enforce that.

Remove the Done trait, which was only used for LimitedRead. It was used to try and make sure we returned the stream to the pool on exact reads, but was not reliable.

This does not yet move the ChunkDecoder code path away from PoolReturnRead. That requires a little more work.

Part 1 of #559.
Fixes #555.