### PR TITLE
Update CHANGELOG for 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.6.0
+
+## Added
+ * Response::remote_addr() (#489)
+ * Request::query_pairs() - make query params from an Iterator of pairs (#519)
+
+## Fixed
+ * Gzip responses with chunked encoding now work with connection pooling (#560)
+ * Don't panic when rustls-native-certs errors (#564)
+ * Responses with zero-length body now work with connection pooling (#565)
+
 # 2.5.0
  * Add tcp no_delay option (#465)
  * Rework public TLS traits

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ureq"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Martin Algesten <martin@algesten.se>", "Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>"]
 description = "Simple, safe HTTP client"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
All aboard the 2.6.0 train!

@algesten I'm choosing not to incorporate #568 into this release; I'd like to do a little more research and thinking about what the right thing is to do here.