### PR TITLE
gzip: examine Content-Length header before removing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.6.1
+
+## Fixed
+ * gzip: examine Content-Length header before removing (#578)
+
 # 2.6.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ureq"
-version = "2.6.0"
+version = "2.6.1"
 authors = ["Martin Algesten <martin@algesten.se>", "Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>"]
 description = "Simple, safe HTTP client"
 license = "MIT/Apache-2.0"

--- a/src/response.rs
+++ b/src/response.rs
@@ -1186,15 +1186,16 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "gzip")]
     fn gzip_content_length() {
         use std::io::Cursor;
-        let response_bytes = b"HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 23\r\n\r\n\
+        let response_bytes =
+            b"HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 23\r\n\r\n\
 \x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\xc8\xe4\x02\x00\x7a\x7a\x6f\xed\x03\x00\x00\x00";
         // Follow the response with an infinite stream of 0 bytes, so the content-length
         // is important.
         let reader = Cursor::new(response_bytes).chain(std::io::repeat(0u8));
-        let test_stream =
-            crate::test::TestStream::new(reader, std::io::sink());
+        let test_stream = crate::test::TestStream::new(reader, std::io::sink());
         let agent = Agent::new();
         let stream = Stream::new(
             test_stream,

--- a/src/response.rs
+++ b/src/response.rs
@@ -566,12 +566,13 @@ impl Response {
         let compression =
             get_header(&headers, "content-encoding").and_then(Compression::from_header_value);
 
+        let body_type = Self::body_type(&unit.method, status, http_version, &headers);
+
         // remove Content-Encoding and length due to automatic decompression
         if compression.is_some() {
             headers.retain(|h| !h.is_name("content-encoding") && !h.is_name("content-length"));
         }
 
-        let body_type = Self::body_type(&unit.method, status, http_version, &headers);
         let reader = Self::stream_to_reader(stream, &unit, body_type, compression);
 
         let url = unit.url.clone();

--- a/src/response.rs
+++ b/src/response.rs
@@ -1190,8 +1190,11 @@ mod tests {
         use std::io::Cursor;
         let response_bytes = b"HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 23\r\n\r\n\
 \x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\xc8\xe4\x02\x00\x7a\x7a\x6f\xed\x03\x00\x00\x00";
+        // Follow the response with an infinite stream of 0 bytes, so the content-length
+        // is important.
+        let reader = Cursor::new(response_bytes).chain(std::io::repeat(0u8));
         let test_stream =
-            crate::test::TestStream::new(Cursor::new(response_bytes), std::io::sink());
+            crate::test::TestStream::new(reader, std::io::sink());
         let agent = Agent::new();
         let stream = Stream::new(
             test_stream,


### PR DESCRIPTION
Fixes #575.