### PR TITLE
Fix docs for serde_derive

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -465,10 +465,6 @@ impl Response {
     /// // Put this in Cargo.toml: serde = { version = "1", features = ["derive"] }
     /// use serde::{Deserialize};
     ///
-    /// // An alternative way to is to use the `serde_derive` crate.
-    /// // Put this in Cargo.toml: serde_derive = "1"
-    /// // use serde_derive::{Deserialize};
-    ///
     /// #[derive(Deserialize)]
     /// struct Message {
     ///     hello: String,


### PR DESCRIPTION
If only using `serde_derive` and not `serde` this is required for each
use of `#[derive(Deserialize)]`.

Fixes https://github.com/algesten/ureq/issues/579

See also:
- https://github.com/serde-rs/serde/issues/856
- https://github.com/serde-rs/serde/issues/1465
