### PR TITLE
Proxy: Only use HTTP CONNECT for HTTPS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ to encode the request body using that.
 
 ## Proxying
 
-ureq supports two kinds of proxies,  HTTP [`CONNECT`], [`SOCKS4`] and [`SOCKS5`], the former is
+ureq supports two kinds of proxies,  [`HTTP`], [`SOCKS4`] and [`SOCKS5`], the former is
 always available while the latter must be enabled using the feature
 `ureq = { version = "*", features = ["socks-proxy"] }`.
 
 Proxies settings are configured on an [Agent] (using [AgentBuilder]). All request sent
 through the agent will be proxied.
 
-### Example using HTTP CONNECT
+### Example using HTTP
 
 ```rust
 fn proxy_example_1() -> std::result::Result<(), ureq::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,14 +224,14 @@
 //!
 //! # Proxying
 //!
-//! ureq supports two kinds of proxies,  HTTP [`CONNECT`], [`SOCKS4`] and [`SOCKS5`], the former is
+//! ureq supports two kinds of proxies,  [`HTTP`], [`SOCKS4`] and [`SOCKS5`], the former is
 //! always available while the latter must be enabled using the feature
 //! `ureq = { version = "*", features = ["socks-proxy"] }`.
 //!
 //! Proxies settings are configured on an [Agent] (using [AgentBuilder]). All request sent
 //! through the agent will be proxied.
 //!
-//! ## Example using HTTP CONNECT
+//! ## Example using HTTP
 //!
 //! ```rust
 //! fn proxy_example_1() -> std::result::Result<(), ureq::Error> {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -5,7 +5,7 @@ use crate::error::{Error, ErrorKind};
 /// Proxy protocol
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Proto {
-    HTTPConnect,
+    HTTP,
     SOCKS4,
     SOCKS4A,
     SOCKS5,
@@ -71,7 +71,7 @@ impl Proxy {
     /// # Arguments:
     /// * `proxy` - a str of format `<protocol>://<user>:<password>@<host>:port` . All parts except host are optional.
     /// # Protocols
-    /// * `http`: HTTP Connect
+    /// * `http`: HTTP
     /// * `socks4`: SOCKS4 (requires socks feature)
     /// * `socks4a`: SOCKS4A (requires socks feature)
     /// * `socks5` and `socks`: SOCKS5 (requires socks feature)
@@ -91,7 +91,7 @@ impl Proxy {
 
         let proto = if proxy_parts.len() == 2 {
             match proxy_parts.next() {
-                Some("http") => Proto::HTTPConnect,
+                Some("http") => Proto::HTTP,
                 Some("socks4") => Proto::SOCKS4,
                 Some("socks4a") => Proto::SOCKS4A,
                 Some("socks") => Proto::SOCKS5,
@@ -99,7 +99,7 @@ impl Proxy {
                 _ => return Err(ErrorKind::InvalidProxyUrl.new()),
             }
         } else {
-            Proto::HTTPConnect
+            Proto::HTTP
         };
 
         let remaining_parts = proxy_parts.next();
@@ -140,7 +140,7 @@ impl Proxy {
             ));
 
             match self.proto {
-                Proto::HTTPConnect => format!("Proxy-Authorization: basic {}\r\n", creds),
+                Proto::HTTP => format!("Proxy-Authorization: basic {}\r\n", creds),
                 _ => String::new(),
             }
         } else {
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!(proxy.password, Some(String::from("p@ssw0rd")));
         assert_eq!(proxy.server, String::from("localhost"));
         assert_eq!(proxy.port, 9999);
-        assert_eq!(proxy.proto, Proto::HTTPConnect);
+        assert_eq!(proxy.proto, Proto::HTTP);
     }
 
     #[test]
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(proxy.password, Some(String::from("p@ssw0rd")));
         assert_eq!(proxy.server, String::from("localhost"));
         assert_eq!(proxy.port, 9999);
-        assert_eq!(proxy.proto, Proto::HTTPConnect);
+        assert_eq!(proxy.proto, Proto::HTTP);
     }
 
     #[cfg(feature = "socks-proxy")]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -377,7 +377,7 @@ pub(crate) fn connect_host(
 
         // connect with a configured timeout.
         #[allow(clippy::unnecessary_unwrap)]
-        let stream = if proto.is_some() && Some(Proto::HTTPConnect) != proto {
+        let stream = if proto.is_some() && Some(Proto::HTTP) != proto {
             connect_socks(
                 unit,
                 proxy.clone().unwrap(),
@@ -423,7 +423,7 @@ pub(crate) fn connect_host(
         stream.set_write_timeout(unit.agent.config.timeout_write)?;
     }
 
-    if proto == Some(Proto::HTTPConnect) {
+    if proto == Some(Proto::HTTP) && unit.url.scheme() == "https" {
         if let Some(ref proxy) = proxy {
             write!(
                 stream,


### PR DESCRIPTION
Previously, `ureq` used `HTTP CONNECT` for *all* requests, including plain-text HTTP requests. However, some proxy servers like Squid only allow tunneling via the `HTTP CONNECT` method on port 443 - since it is usually only used to proxy HTTPS requests. As a result, it was not possible to use `ureq` with a Squid server in its default configuration.

With the changes from this commit, ureq will interact with HTTP proxies in a more standard-conforming way, where `CONNECT` is only used for HTTPS requests. HTTP request paths are transformed in such a way that they comply with RFC 7230 [1].

Tested against Squid 4.13 in standard configuration, with and without basic authentication, for HTTP and HTTPS requests.

[1] https://www.rfc-editor.org/rfc/rfc7230#section-5.3.2