### PR TITLE
feat: support interop between ureq and http

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
           - native-certs
           - gzip
           - brotli
+          - http
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           - native-certs
           - gzip
           - brotli
-          - http
+          - http-interop
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
 gzip = ["flate2"]
 brotli = ["brotli-decompressor"]
+http = ["dep:http"]
 
 [dependencies]
 base64 = "0.21"
@@ -43,6 +44,7 @@ rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }
 brotli-decompressor = { version = "2.3.2", optional = true }
+http = { version = "0.2", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
 gzip = ["flate2"]
 brotli = ["brotli-decompressor"]
-http = ["dep:http"]
+http-interop = ["dep:http"]
 
 [dependencies]
 base64 = "0.21"

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ A simple, safe HTTP client.
 Ureq's first priority is being easy for you to use. It's great for
 anyone who wants a low-overhead HTTP client that just gets the job done. Works
 very well with HTTP APIs. Its features include cookies, JSON, HTTP proxies,
-HTTPS, and charset decoding.
+HTTPS, interoperability with the `http` crate, and charset decoding.
 
 Ureq is in pure Rust for safety and ease of understanding. It avoids using
 `unsafe` directly. It [uses blocking I/O][blocking] instead of async I/O, because that keeps
 the API simple and keeps dependencies to a minimum. For TLS, ureq uses
 [rustls or native-tls](#https--tls--ssl).
 
-Version 2.0.0 was released recently and changed some APIs. See the [changelog] for details.
+See the [changelog] for details of recent releases.
 
 [blocking]: #blocking-io-for-simplicity
-[changelog]: https://github.com/algesten/ureq/blob/master/CHANGELOG.md
+[changelog]: https://github.com/algesten/ureq/blob/main/CHANGELOG.md
 
 
 ### Usage
@@ -134,6 +134,7 @@ You can control them when including ureq as a dependency.
   does nothing for `native-tls`.
 * `gzip` enables requests of gzip-compressed responses and decompresses them. This is enabled by default.
 * `brotli` enables requests brotli-compressed responses and decompresses them.
+* `http-interop` enables conversion methods to and from `http::Response` and `http::request::Builder`.
 
 ## Plain requests
 

--- a/src/http_interop.rs
+++ b/src/http_interop.rs
@@ -1,0 +1,190 @@
+use std::{
+    io::{Cursor, Read},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+use crate::{header::HeaderLine, response::ResponseStatusIndex, Request, Response};
+
+impl<T: AsRef<[u8]> + Send + Sync + 'static> From<http::Response<T>> for Response {
+    fn from(value: http::Response<T>) -> Self {
+        let version_str = format!("{:?}", value.version());
+        let status_line = format!("{} {}", version_str, value.status());
+        let status_num = u16::from(value.status());
+        Response {
+            url: "https://example.com/".parse().unwrap(),
+            status_line,
+            index: ResponseStatusIndex {
+                http_version: version_str.len(),
+                response_code: version_str.len() + status_num.to_string().len(),
+            },
+            status: status_num,
+            headers: value
+                .headers()
+                .iter()
+                .filter_map(|(name, value)| {
+                    let mut raw_header: Vec<u8> = name.to_string().into_bytes();
+                    raw_header.extend([0x3a, 0x20]); // ": "
+                    raw_header.extend(value.as_bytes());
+
+                    HeaderLine::from(raw_header).into_header().ok()
+                })
+                .collect::<Vec<_>>(),
+            reader: Box::new(Cursor::new(value.into_body())),
+            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80),
+            history: vec![],
+        }
+    }
+}
+
+fn create_builder(response: &Response) -> http::response::Builder {
+    let http_version = match response.http_version() {
+        "HTTP/0.9" => http::Version::HTTP_09,
+        "HTTP/1.0" => http::Version::HTTP_10,
+        "HTTP/1.1" => http::Version::HTTP_11,
+        "HTTP/2.0" => http::Version::HTTP_2,
+        "HTTP/3.0" => http::Version::HTTP_3,
+        _ => unreachable!(),
+    };
+
+    let response_builder = response
+        .headers
+        .iter()
+        .filter_map(|header| {
+            header
+                .value()
+                .map(|safe_value| (header.name().to_owned(), safe_value.to_owned()))
+        })
+        .fold(http::Response::builder(), |builder, header| {
+            builder.header(header.0, header.1)
+        })
+        .status(response.status())
+        .version(http_version);
+
+    response_builder
+}
+
+impl From<Response> for http::Response<Box<dyn Read + Send + Sync + 'static>> {
+    fn from(value: Response) -> Self {
+        create_builder(&value).body(value.into_reader()).unwrap()
+    }
+}
+
+impl From<Response> for http::Response<String> {
+    fn from(value: Response) -> Self {
+        create_builder(&value)
+            .body(value.into_string().unwrap())
+            .unwrap()
+    }
+}
+
+impl From<http::request::Builder> for Request {
+    fn from(value: http::request::Builder) -> Self {
+        let mut new_request = crate::agent().request(
+            value.method_ref().map_or("GET", |m| m.as_str()),
+            &value
+                .uri_ref()
+                .map_or("https://example.com".to_string(), |u| u.to_string()),
+        );
+
+        if let Some(headers) = value.headers_ref() {
+            new_request = headers
+                .iter()
+                .filter_map(|header| {
+                    header
+                        .1
+                        .to_str()
+                        .ok()
+                        .map(|str_value| (header.0.as_str(), str_value))
+                })
+                .fold(new_request, |request, header| {
+                    request.set(header.0, header.1)
+                });
+        }
+
+        new_request
+    }
+}
+
+impl From<Request> for http::request::Builder {
+    fn from(value: Request) -> Self {
+        value
+            .headers
+            .iter()
+            .filter_map(|header| {
+                header
+                    .value()
+                    .map(|safe_value| (header.name().to_owned(), safe_value.to_owned()))
+            })
+            .fold(http::Request::builder(), |builder, header| {
+                builder.header(header.0, header.1)
+            })
+            .method(value.method())
+            .version(http::Version::HTTP_11)
+            .uri(value.url())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn convert_http_response() {
+        use http::{Response, StatusCode, Version};
+
+        let http_response_body = (0..10240).into_iter().map(|_| 0xaa).collect::<Vec<u8>>();
+        let http_response = Response::builder()
+            .version(Version::HTTP_2)
+            .header("Custom-Header", "custom value")
+            .header("Content-Type", "application/octet-stream")
+            .status(StatusCode::IM_A_TEAPOT)
+            .body(http_response_body.clone())
+            .unwrap();
+
+        let response: super::Response = http_response.into();
+        assert_eq!(response.get_url(), "https://example.com/");
+        assert_eq!(response.http_version(), "HTTP/2.0");
+        assert_eq!(response.status(), u16::from(StatusCode::IM_A_TEAPOT));
+        assert_eq!(response.status_text(), "I'm a teapot");
+        assert_eq!(response.remote_addr().to_string().as_str(), "127.0.0.1:80");
+        assert_eq!(response.header("Custom-Header"), Some("custom value"));
+        assert_eq!(response.content_type(), "application/octet-stream");
+
+        let mut body_buf: Vec<u8> = vec![];
+        response.into_reader().read_to_end(&mut body_buf).unwrap();
+        assert_eq!(body_buf, http_response_body);
+    }
+
+    #[test]
+    fn convert_http_response_string() {
+        use http::{Response, StatusCode, Version};
+
+        let http_response_body = "Some body string".to_string();
+        let http_response = Response::builder()
+            .version(Version::HTTP_11)
+            .status(StatusCode::OK)
+            .body(http_response_body.clone())
+            .unwrap();
+
+        let response: super::Response = http_response.into();
+        assert_eq!(response.get_url(), "https://example.com/");
+        assert_eq!(response.content_type(), "text/plain");
+        assert_eq!(response.into_string().unwrap(), http_response_body);
+    }
+
+    #[test]
+    fn convert_http_response_bad_header() {
+        use http::{Response, StatusCode, Version};
+
+        let http_response = Response::builder()
+            .version(Version::HTTP_11)
+            .status(StatusCode::OK)
+            .header("Some-Invalid-Header", vec![0xde, 0xad, 0xbe, 0xef])
+            .header("Some-Valid-Header", vec![0x48, 0x45, 0x4c, 0x4c, 0x4f])
+            .body(vec![])
+            .unwrap();
+
+        let response: super::Response = http_response.into();
+        assert_eq!(response.header("Some-Invalid-Header"), None);
+        assert_eq!(response.header("Some-Valid-Header"), Some("HELLO"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! Ureq's first priority is being easy for you to use. It's great for
 //! anyone who wants a low-overhead HTTP client that just gets the job done. Works
 //! very well with HTTP APIs. Its features include cookies, JSON, HTTP proxies,
-//! HTTPS, and charset decoding.
+//! HTTPS, interoperability with the `http` crate, and charset decoding.
 //!
 //! Ureq is in pure Rust for safety and ease of understanding. It avoids using
 //! `unsafe` directly. It [uses blocking I/O][blocking] instead of async I/O, because that keeps
@@ -160,6 +160,7 @@
 //!   does nothing for `native-tls`.
 //! * `gzip` enables requests of gzip-compressed responses and decompresses them. This is enabled by default.
 //! * `brotli` enables requests brotli-compressed responses and decompresses them.
+//! * `http-interop` enables conversion methods to and from `http::Response` and `http::request::Builder`.
 //!
 //! # Plain requests
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,9 @@ mod test;
 #[doc(hidden)]
 mod testserver;
 
+#[cfg(feature = "http-interop")]
+mod http_interop;
+
 pub use crate::agent::Agent;
 pub use crate::agent::AgentBuilder;
 pub use crate::agent::RedirectAuthHeaders;

--- a/src/request.rs
+++ b/src/request.rs
@@ -500,7 +500,7 @@ impl Request {
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(feature = "http-interop")]
 impl From<http::request::Builder> for Request {
     fn from(value: http::request::Builder) -> Self {
         let mut new_request = crate::agent().request(
@@ -529,7 +529,7 @@ impl From<http::request::Builder> for Request {
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(feature = "http-interop")]
 impl From<Request> for http::request::Builder {
     fn from(value: Request) -> Self {
         value

--- a/src/request.rs
+++ b/src/request.rs
@@ -30,7 +30,7 @@ pub struct Request {
     agent: Agent,
     method: String,
     url: String,
-    headers: Vec<Header>,
+    pub(crate) headers: Vec<Header>,
     timeout: Option<time::Duration>,
 }
 
@@ -497,55 +497,6 @@ impl Request {
     /// ```
     pub fn request_url(&self) -> Result<RequestUrl> {
         Ok(RequestUrl::new(self.parse_url()?))
-    }
-}
-
-#[cfg(feature = "http-interop")]
-impl From<http::request::Builder> for Request {
-    fn from(value: http::request::Builder) -> Self {
-        let mut new_request = crate::agent().request(
-            value.method_ref().map_or("GET", |m| m.as_str()),
-            &value
-                .uri_ref()
-                .map_or("https://example.com".to_string(), |u| u.to_string()),
-        );
-
-        if let Some(headers) = value.headers_ref() {
-            new_request = headers
-                .iter()
-                .filter_map(|header| {
-                    header
-                        .1
-                        .to_str()
-                        .ok()
-                        .map(|str_value| (header.0.as_str(), str_value))
-                })
-                .fold(new_request, |request, header| {
-                    request.set(header.0, header.1)
-                });
-        }
-
-        new_request
-    }
-}
-
-#[cfg(feature = "http-interop")]
-impl From<Request> for http::request::Builder {
-    fn from(value: Request) -> Self {
-        value
-            .headers
-            .iter()
-            .filter_map(|header| {
-                header
-                    .value()
-                    .map(|safe_value| (header.name().to_owned(), safe_value.to_owned()))
-            })
-            .fold(http::Request::builder(), |builder, header| {
-                builder.header(header.0, header.1)
-            })
-            .method(value.method())
-            .version(http::Version::HTTP_11)
-            .uri(value.url())
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -28,7 +28,7 @@ use flate2::read::MultiGzDecoder;
 #[cfg(feature = "brotli")]
 use brotli_decompressor::Decompressor as BrotliDecoder;
 
-#[cfg(feature = "http")]
+#[cfg(feature = "http-interop")]
 use std::net::{IpAddr, Ipv4Addr};
 
 pub const DEFAULT_CONTENT_TYPE: &str = "text/plain";
@@ -875,7 +875,7 @@ impl Read for ErrorReader {
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(feature = "http-interop")]
 impl<T: AsRef<[u8]> + Send + Sync + 'static> From<http::Response<T>> for Response {
     fn from(value: http::Response<T>) -> Self {
         let version_str = format!("{:?}", value.version());
@@ -907,7 +907,7 @@ impl<T: AsRef<[u8]> + Send + Sync + 'static> From<http::Response<T>> for Respons
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(feature = "http-interop")]
 fn create_builder(response: &Response) -> http::response::Builder {
     let http_version = match response.http_version() {
         "HTTP/0.9" => http::Version::HTTP_09,
@@ -935,14 +935,14 @@ fn create_builder(response: &Response) -> http::response::Builder {
     response_builder
 }
 
-#[cfg(feature = "http")]
+#[cfg(feature = "http-interop")]
 impl From<Response> for http::Response<Box<dyn Read + Send + Sync + 'static>> {
     fn from(value: Response) -> Self {
         create_builder(&value).body(value.into_reader()).unwrap()
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(feature = "http-interop")]
 impl From<Response> for http::Response<String> {
     fn from(value: Response) -> Self {
         create_builder(&value)
@@ -1291,7 +1291,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "http")]
+    #[cfg(feature = "http-interop")]
     fn convert_http_response() {
         use http::{Response, StatusCode, Version};
 
@@ -1319,7 +1319,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "http")]
+    #[cfg(feature = "http-interop")]
     fn convert_http_response_string() {
         use http::{Response, StatusCode, Version};
 
@@ -1337,7 +1337,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "http")]
+    #[cfg(feature = "http-interop")]
     fn convert_http_response_bad_header() {
         use http::{Response, StatusCode, Version};
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -28,9 +28,6 @@ use flate2::read::MultiGzDecoder;
 #[cfg(feature = "brotli")]
 use brotli_decompressor::Decompressor as BrotliDecoder;
 
-#[cfg(feature = "http-interop")]
-use std::net::{IpAddr, Ipv4Addr};
-
 pub const DEFAULT_CONTENT_TYPE: &str = "text/plain";
 pub const DEFAULT_CHARACTER_SET: &str = "utf-8";
 const INTO_STRING_LIMIT: usize = 10 * 1_024 * 1_024;
@@ -74,13 +71,13 @@ enum BodyType {
 /// ```
 pub struct Response {
     pub(crate) url: Url,
-    status_line: String,
-    index: ResponseStatusIndex,
-    status: u16,
-    headers: Vec<Header>,
-    reader: Box<dyn Read + Send + Sync + 'static>,
+    pub(crate) status_line: String,
+    pub(crate) index: ResponseStatusIndex,
+    pub(crate) status: u16,
+    pub(crate) headers: Vec<Header>,
+    pub(crate) reader: Box<dyn Read + Send + Sync + 'static>,
     /// The socket address of the server that sent the response.
-    remote_addr: SocketAddr,
+    pub(crate) remote_addr: SocketAddr,
     /// The redirect history of this response, if any. The history starts with
     /// the first response received and ends with the response immediately
     /// previous to this one.
@@ -91,9 +88,9 @@ pub struct Response {
 
 /// index into status_line where we split: HTTP/1.1 200 OK
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-struct ResponseStatusIndex {
-    http_version: usize,
-    response_code: usize,
+pub(crate) struct ResponseStatusIndex {
+    pub(crate) http_version: usize,
+    pub(crate) response_code: usize,
 }
 
 impl fmt::Debug for Response {
@@ -875,82 +872,6 @@ impl Read for ErrorReader {
     }
 }
 
-#[cfg(feature = "http-interop")]
-impl<T: AsRef<[u8]> + Send + Sync + 'static> From<http::Response<T>> for Response {
-    fn from(value: http::Response<T>) -> Self {
-        let version_str = format!("{:?}", value.version());
-        let status_line = format!("{} {}", version_str, value.status());
-        let status_num = u16::from(value.status());
-        Response {
-            url: "https://example.com/".parse().unwrap(),
-            status_line,
-            index: ResponseStatusIndex {
-                http_version: version_str.len(),
-                response_code: version_str.len() + status_num.to_string().len(),
-            },
-            status: status_num,
-            headers: value
-                .headers()
-                .iter()
-                .filter_map(|(name, value)| {
-                    let mut raw_header: Vec<u8> = name.to_string().into_bytes();
-                    raw_header.extend([0x3a, 0x20]); // ": "
-                    raw_header.extend(value.as_bytes());
-
-                    HeaderLine::from(raw_header).into_header().ok()
-                })
-                .collect::<Vec<_>>(),
-            reader: Box::new(std::io::Cursor::new(value.into_body())),
-            remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80),
-            history: vec![],
-        }
-    }
-}
-
-#[cfg(feature = "http-interop")]
-fn create_builder(response: &Response) -> http::response::Builder {
-    let http_version = match response.http_version() {
-        "HTTP/0.9" => http::Version::HTTP_09,
-        "HTTP/1.0" => http::Version::HTTP_10,
-        "HTTP/1.1" => http::Version::HTTP_11,
-        "HTTP/2.0" => http::Version::HTTP_2,
-        "HTTP/3.0" => http::Version::HTTP_3,
-        _ => unreachable!(),
-    };
-
-    let response_builder = response
-        .headers
-        .iter()
-        .filter_map(|header| {
-            header
-                .value()
-                .map(|safe_value| (header.name().to_owned(), safe_value.to_owned()))
-        })
-        .fold(http::Response::builder(), |builder, header| {
-            builder.header(header.0, header.1)
-        })
-        .status(response.status())
-        .version(http_version);
-
-    response_builder
-}
-
-#[cfg(feature = "http-interop")]
-impl From<Response> for http::Response<Box<dyn Read + Send + Sync + 'static>> {
-    fn from(value: Response) -> Self {
-        create_builder(&value).body(value.into_reader()).unwrap()
-    }
-}
-
-#[cfg(feature = "http-interop")]
-impl From<Response> for http::Response<String> {
-    fn from(value: Response) -> Self {
-        create_builder(&value)
-            .body(value.into_string().unwrap())
-            .unwrap()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
@@ -1288,69 +1209,5 @@ mod tests {
         .unwrap();
         let body = resp.into_string().unwrap();
         assert_eq!(body, "hi\n");
-    }
-
-    #[test]
-    #[cfg(feature = "http-interop")]
-    fn convert_http_response() {
-        use http::{Response, StatusCode, Version};
-
-        let http_response_body = (0..10240).into_iter().map(|_| 0xaa).collect::<Vec<u8>>();
-        let http_response = Response::builder()
-            .version(Version::HTTP_2)
-            .header("Custom-Header", "custom value")
-            .header("Content-Type", "application/octet-stream")
-            .status(StatusCode::IM_A_TEAPOT)
-            .body(http_response_body.clone())
-            .unwrap();
-
-        let response: super::Response = http_response.into();
-        assert_eq!(response.get_url(), "https://example.com/");
-        assert_eq!(response.http_version(), "HTTP/2.0");
-        assert_eq!(response.status(), u16::from(StatusCode::IM_A_TEAPOT));
-        assert_eq!(response.status_text(), "I'm a teapot");
-        assert_eq!(response.remote_addr().to_string().as_str(), "127.0.0.1:80");
-        assert_eq!(response.header("Custom-Header"), Some("custom value"));
-        assert_eq!(response.content_type(), "application/octet-stream");
-
-        let mut body_buf: Vec<u8> = vec![];
-        response.into_reader().read_to_end(&mut body_buf).unwrap();
-        assert_eq!(body_buf, http_response_body);
-    }
-
-    #[test]
-    #[cfg(feature = "http-interop")]
-    fn convert_http_response_string() {
-        use http::{Response, StatusCode, Version};
-
-        let http_response_body = "Some body string".to_string();
-        let http_response = Response::builder()
-            .version(Version::HTTP_11)
-            .status(StatusCode::OK)
-            .body(http_response_body.clone())
-            .unwrap();
-
-        let response: super::Response = http_response.into();
-        assert_eq!(response.get_url(), "https://example.com/");
-        assert_eq!(response.content_type(), "text/plain");
-        assert_eq!(response.into_string().unwrap(), http_response_body);
-    }
-
-    #[test]
-    #[cfg(feature = "http-interop")]
-    fn convert_http_response_bad_header() {
-        use http::{Response, StatusCode, Version};
-
-        let http_response = Response::builder()
-            .version(Version::HTTP_11)
-            .status(StatusCode::OK)
-            .header("Some-Invalid-Header", vec![0xde, 0xad, 0xbe, 0xef])
-            .header("Some-Valid-Header", vec![0x48, 0x45, 0x4c, 0x4c, 0x4f])
-            .body(vec![])
-            .unwrap();
-
-        let response: super::Response = http_response.into();
-        assert_eq!(response.header("Some-Invalid-Header"), None);
-        assert_eq!(response.header("Some-Valid-Header"), Some("HELLO"));
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ set -eu
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D dead_code -D unused-variables -D unused"
 
-for feature in "" tls json charset cookies socks-proxy "tls native-certs" native-tls gzip brotli http; do
+for feature in "" tls json charset cookies socks-proxy "tls native-certs" native-tls gzip brotli http-interop; do
   if ! cargo test --no-default-features --features "${feature}" ; then
     echo Command failed: cargo test --no-default-features --features \"${feature}\"
     exit 1

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ set -eu
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D dead_code -D unused-variables -D unused"
 
-for feature in "" tls json charset cookies socks-proxy "tls native-certs" native-tls gzip brotli; do
+for feature in "" tls json charset cookies socks-proxy "tls native-certs" native-tls gzip brotli http; do
   if ! cargo test --no-default-features --features "${feature}" ; then
     echo Command failed: cargo test --no-default-features --features \"${feature}\"
     exit 1


### PR DESCRIPTION
Preliminary look at some of the ideas discussed in https://github.com/algesten/ureq/issues/589. Took some inspiration from the layout of https://github.com/algesten/ureq/pull/520 since that covered a similar thing.

## General issues

`http::Response` has no `Content-Type` or `Content-Length` validation.

Nearly everything here calls some fallible method. In these instances, they are either `.unwrap()`ed, or replaced with a sane default (or skipped, if applicable). There's a decent argument to be made that we should fail if any of these instances occur, meaning we'd want to implement `TryFrom` instead. 

## Response

This works _relatively_ well. I chose `AsRef<[u8]> + Send + Sync + 'static` as this works automatically for `Vec<u8>` and `Strings`, and most body types can be relatively easily converted into one of those two. It also makes it fairly easy to package into the type `Response.reader` is expected to be. In the other direction, a `Response` can be converted into an `http:Response` with a body that is either directly from `.into_reader()` or `into_string()`. Maybe worth considering one for `Vec<u8>`?

Notably, pretty much all of the `Response` properties are now `pub(crate)`. We don't really have a builder syntax here so without fleshing out something like a `ResponseBuilder`, this is the change that touches the least of the project and doesn't expose anything to the outside world.

## Request

This ends up being a bit awkward. It isn't really possible to convert a `Request` to `http::Request` in either direction, because `Request` does have a builder pattern _and_ doesn't know its body until a `.send_` method is called, which is returning a `Result<Response>`. The closest analog ends up being `http::request::Builder` -- I'd argue this isn't even a valuable implementation to have.