### PR TITLE
feat: expose `local_addr` from `Response`

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -78,7 +78,6 @@ pub(crate) struct AgentConfig {
     pub redirect_auth_headers: RedirectAuthHeaders,
     pub user_agent: String,
     pub tls_config: TlsConfig,
-    pub get_local_addr: bool,
 }
 
 /// Agents keep state between requests.
@@ -263,7 +262,6 @@ impl AgentBuilder {
                 redirect_auth_headers: RedirectAuthHeaders::Never,
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
                 tls_config: TlsConfig(crate::default_tls_config()),
-                get_local_addr: false,
             },
             max_idle_connections: DEFAULT_MAX_IDLE_CONNECTIONS,
             max_idle_connections_per_host: DEFAULT_MAX_IDLE_CONNECTIONS_PER_HOST,
@@ -619,30 +617,6 @@ impl AgentBuilder {
     /// ```
     pub fn tls_connector<T: TlsConnector + 'static>(mut self, tls_config: Arc<T>) -> Self {
         self.config.tls_config = TlsConfig(tls_config);
-        self
-    }
-
-    /// Whether local_addr will be read from the tcp socket.
-    ///
-    /// local_addr is the address from which the client sends the request.
-    /// Reading it invokes a syscall, therefore it is disabled by default.
-    ///
-    /// Defaults to false.
-    ///
-    /// ```
-    /// # fn main() -> Result<(), ureq::Error> {
-    /// # use std::net::SocketAddr;
-    /// # ureq::is_test(true);
-    /// let agent = ureq::builder()
-    ///     .get_local_addr(true)
-    ///     .build();
-    /// let response = agent.get("http://httpbin.org/get").call()?;
-    /// assert!(response.local_addr().is_some());
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn get_local_addr(mut self, get_local_addr: bool) -> Self {
-        self.config.get_local_addr = get_local_addr;
         self
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -78,6 +78,7 @@ pub(crate) struct AgentConfig {
     pub redirect_auth_headers: RedirectAuthHeaders,
     pub user_agent: String,
     pub tls_config: TlsConfig,
+    pub get_local_addr: bool,
 }
 
 /// Agents keep state between requests.
@@ -262,6 +263,7 @@ impl AgentBuilder {
                 redirect_auth_headers: RedirectAuthHeaders::Never,
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
                 tls_config: TlsConfig(crate::default_tls_config()),
+                get_local_addr: false,
             },
             max_idle_connections: DEFAULT_MAX_IDLE_CONNECTIONS,
             max_idle_connections_per_host: DEFAULT_MAX_IDLE_CONNECTIONS_PER_HOST,
@@ -617,6 +619,30 @@ impl AgentBuilder {
     /// ```
     pub fn tls_connector<T: TlsConnector + 'static>(mut self, tls_config: Arc<T>) -> Self {
         self.config.tls_config = TlsConfig(tls_config);
+        self
+    }
+
+    /// Whether local_addr will be read from the tcp socket.
+    ///
+    /// local_addr is the address from which the client sends the request.
+    /// Reading it invokes a syscall, therefore it is disabled by default.
+    ///
+    /// Defaults to false.
+    ///
+    /// ```
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # use std::net::SocketAddr;
+    /// # ureq::is_test(true);
+    /// let agent = ureq::builder()
+    ///     .get_local_addr(true)
+    ///     .build();
+    /// let response = agent.get("http://httpbin.org/get").call()?;
+    /// assert!(response.local_addr().is_some());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_local_addr(mut self, get_local_addr: bool) -> Self {
+        self.config.get_local_addr = get_local_addr;
         self
     }
 

--- a/src/http_interop.rs
+++ b/src/http_interop.rs
@@ -48,7 +48,7 @@ impl<T: AsRef<[u8]> + Send + Sync + 'static> From<http::Response<T>> for Respons
                 .collect::<Vec<_>>(),
             reader: Box::new(Cursor::new(value.into_body())),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80),
-            local_addr: None,
+            local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
             history: vec![],
         }
     }

--- a/src/http_interop.rs
+++ b/src/http_interop.rs
@@ -48,6 +48,7 @@ impl<T: AsRef<[u8]> + Send + Sync + 'static> From<http::Response<T>> for Respons
                 .collect::<Vec<_>>(),
             reader: Box::new(Cursor::new(value.into_body())),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80),
+            local_addr: None,
             history: vec![],
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,8 +568,8 @@ mod tests {
 
         let resp = agent.get("http://www.google.com/").call().unwrap();
         assert_eq!(
-            "text/html; charset=ISO-8859-1",
-            resp.header("content-type").unwrap()
+            "text/html;charset=ISO-8859-1",
+            resp.header("content-type").unwrap().replace("; ", ";")
         );
         assert_eq!("text/html", resp.content_type());
     }
@@ -581,8 +581,8 @@ mod tests {
 
         let resp = agent.get("https://www.google.com/").call().unwrap();
         assert_eq!(
-            "text/html; charset=ISO-8859-1",
-            resp.header("content-type").unwrap()
+            "text/html;charset=ISO-8859-1",
+            resp.header("content-type").unwrap().replace("; ", ";")
         );
         assert_eq!("text/html", resp.content_type());
     }
@@ -597,8 +597,8 @@ mod tests {
 
         let resp = agent.get("https://www.google.com/").call().unwrap();
         assert_eq!(
-            "text/html; charset=ISO-8859-1",
-            resp.header("content-type").unwrap()
+            "text/html;charset=ISO-8859-1",
+            resp.header("content-type").unwrap().replace("; ", ";")
         );
         assert_eq!("text/html", resp.content_type());
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -542,7 +542,7 @@ impl Response {
         let remote_addr = stream.remote_addr;
 
         let local_addr = match stream.socket() {
-            Some(sock) => sock.local_addr().map_err(|e| Error::from(e))?,
+            Some(sock) => sock.local_addr().map_err(Error::from)?,
             None => std::net::SocketAddrV4::new(std::net::Ipv4Addr::new(127, 0, 0, 1), 0).into(),
         };
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -79,7 +79,7 @@ pub struct Response {
     /// The socket address of the server that sent the response.
     pub(crate) remote_addr: SocketAddr,
     /// The socket address of the client that sent the request.
-    pub(crate) local_addr: Option<SocketAddr>,
+    pub(crate) local_addr: SocketAddr,
     /// The redirect history of this response, if any. The history starts with
     /// the first response received and ends with the response immediately
     /// previous to this one.
@@ -235,7 +235,7 @@ impl Response {
     }
 
     /// The local address the request was made from.
-    pub fn local_addr(&self) -> Option<SocketAddr> {
+    pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
     }
 
@@ -541,7 +541,10 @@ impl Response {
     pub(crate) fn do_from_stream(stream: Stream, unit: Unit) -> Result<Response, Error> {
         let remote_addr = stream.remote_addr;
 
-        let local_addr = stream.socket().map(|s| s.local_addr().unwrap());
+        let local_addr = match stream.socket() {
+            Some(sock) => sock.local_addr().map_err(|e| Error::from(e))?,
+            None => std::net::SocketAddrV4::new(std::net::Ipv4Addr::new(127, 0, 0, 1), 0).into(),
+        };
 
         //
         // HTTP/1.1 200 OK\r\n


### PR DESCRIPTION
Expanding on #591 which adds `remote_addr` to `Stream` and `Response`; this PR also exposes the local address through the `Response`.

Retrieving `local_addr` this way can be helpful when the user needs to know the client port which is selected arbitrarily from the ephemeral port range. Similarly, if the client is running on a device with multiple NICs that can route to the remote address; one might want to know from which local IP address the request was sent. (In [our](https://github.com/picussecurity) case, we'd like to to record the local IP and port to track them in WAF logs).

(This is my first contribution to the repo; and I couldn't see a contribution guideline. If there is a process that I missed I'd be happy to follow it)