### PR TITLE
Fix cookie leak on redirect

### DIFF
--- a/src/unit.rs
+++ b/src/unit.rs
@@ -217,9 +217,11 @@ pub(crate) fn connect(
         let mut headers = unit.headers;
 
         // on redirects we don't want to keep "content-length". we also might want to
-        // strip away "authorization" to ensure credentials are not leaked.
+        // strip away "authorization" and "cookie" to ensure credentials are not leaked.
         headers.retain(|h| {
-            !h.is_name("content-length") && (!h.is_name("authorization") || keep_auth_header)
+            !h.is_name("content-length")
+                && !h.is_name("cookie")
+                && (!h.is_name("authorization") || keep_auth_header)
         });
 
         // recreate the unit to get a new hostname and cookies for the new host.


### PR DESCRIPTION
This removes the cookie header on redirect, otherwise if there are multiple redirects, a new cookie header gets appended each time, while the existing one remains. This could result in the cookies being leaked to a third party.