### PR TITLE
fix: cannot use http_proxy connect non-standard http ports

### DIFF
--- a/src/unit.rs
+++ b/src/unit.rs
@@ -409,12 +409,21 @@ fn send_prelude(unit: &Unit, stream: &mut Stream) -> io::Result<()> {
         // HTTP proxies require the path to be in absolute URI form
         // https://www.rfc-editor.org/rfc/rfc7230#section-5.3.2
         match proxy.proto {
-            Proto::HTTP => format!(
-                "{}://{}{}",
-                unit.url.scheme(),
-                unit.url.host().unwrap(),
-                unit.url.path()
-            ),
+            Proto::HTTP => match unit.url.port() {
+                Some(port) => format!(
+                    "{}://{}:{}{}",
+                    unit.url.scheme(),
+                    unit.url.host().unwrap(),
+                    port,
+                    unit.url.path()
+                ),
+                None => format!(
+                    "{}://{}{}",
+                    unit.url.scheme(),
+                    unit.url.host().unwrap(),
+                    unit.url.path()
+                ),
+            },
             _ => unit.url.path().into(),
         }
     } else {


### PR DESCRIPTION
Previously, when making http proxy plain-text HTTP requests, the port was omitted from the proxy request target, which prevented connecting to non-standard http ports.

if the request url contains a port, This PR add this port to the proxy request target.