### PR TITLE
feat: set headers on agent level.

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -47,10 +47,10 @@ impl fmt::Debug for Request {
 impl Request {
     pub(crate) fn new(agent: Agent, method: String, url: String) -> Request {
         Request {
-            agent,
+            agent: agent.clone(),
             method,
             url,
-            headers: vec![],
+            headers: agent.state.headers.clone(),
             timeout: None,
         }
     }


### PR DESCRIPTION
This PR enables setting `Request` headers on an agent level so that they will be used on all requests made by that agent. Its a small utility function that saves some boilerplate in case all requests need a custom header (like a `Bearer <TOKEN>` for authentication).

```rust
use ureq::{Agent, AgentBuilder};

let agent: Agent = AgentBuilder::new()
    .set("Accept", "text/plain")
    .build();

let body: String = agent.get("http://example.com/page").call()?.into_string()?;

```

I don't know if this is something that you would like to have on `ureq` but it is useful in my use-case.