### PR TITLE
Allow http/1.0 responses to have content-length

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -66,6 +66,10 @@ impl DeadlineStream {
     pub(crate) fn inner_ref(&self) -> &Stream {
         &self.stream
     }
+
+    pub(crate) fn inner_mut(&mut self) -> &mut Stream {
+        &mut self.stream
+    }
 }
 
 impl From<DeadlineStream> for Stream {
@@ -238,6 +242,10 @@ impl Stream {
             Some(socket) => Stream::serverclosed_stream(socket),
             None => Ok(false),
         }
+    }
+
+    pub(crate) fn set_unpoolable(&mut self) {
+        self.pool_returner = PoolReturner::none();
     }
 
     pub(crate) fn return_to_pool(mut self) -> io::Result<()> {


### PR DESCRIPTION
Previously, we treated HTTP/1.0 responses as always being close-delimited. However, that's not quite right. HTTP/1.0 responses _default_ to Connection: close, but the server may send Connection: keep-alive, along with a Content-Length header. Update body_type to understand this.

Also, slightly reorganize body_type. has_no_body was being checked redundantly when we could just early-return when has_no_body is true. And regardless of whether we see Connection: close (on any HTTP version), we must honor Transfer-Encoding or Content-Length if they are present.

Fixes #600