### PR TITLE
temporarily add no_run to middleware doctests

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -535,7 +535,7 @@ impl AgentBuilder {
     /// Defaults to `ureq/[VERSION]`. You can override the user-agent on an individual request by
     /// setting the `User-Agent` header when constructing the request.
     ///
-    /// ```
+    /// ```no_run
     /// # #[cfg(feature = "json")]
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -498,7 +498,7 @@ impl AgentBuilder {
     /// WARNING: for 307 and 308 redirects, this value is ignored for methods that have a body.
     /// You must handle 307 redirects yourself when sending a PUT, POST, PATCH, or DELETE request.
     ///
-    /// ```
+    /// ```no_run
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
     /// let result = ureq::builder()

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -24,7 +24,7 @@ use crate::{Error, Request, Response};
 ///
 /// A common use case is to add headers to the outgoing request. Here an example of how.
 ///
-/// ```
+/// ```no_run
 /// # #[cfg(feature = "json")]
 /// # fn main() -> Result<(), ureq::Error> {
 /// # use ureq::{Request, Response, MiddlewareNext, Error};
@@ -58,7 +58,7 @@ use crate::{Error, Request, Response};
 /// In the `examples` directory there is an additional example `count-bytes.rs` which uses
 /// a mutex lock like shown below.
 ///
-/// ```
+/// ```no_run
 /// # use ureq::{Request, Response, Middleware, MiddlewareNext, Error};
 /// # use std::sync::{Arc, Mutex};
 /// struct MyState {
@@ -89,7 +89,7 @@ use crate::{Error, Request, Response};
 /// This example shows how we can increase a counter for each request going
 /// through the agent.
 ///
-/// ```
+/// ```no_run
 /// # fn main() -> Result<(), ureq::Error> {
 /// # ureq::is_test(true);
 /// use ureq::{Request, Response, Middleware, MiddlewareNext, Error};

--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -1,5 +1,6 @@
 #[cfg(all(feature = "json", any(feature = "tls", feature = "tls-native")))]
-#[test]
+// #[test] test temporarily disabled because httpbin is down / we need to figure out
+// how to eliminate the external dependency.
 fn agent_set_header() {
     use serde::Deserialize;
     use std::collections::HashMap;

--- a/tests/https-agent.rs
+++ b/tests/https-agent.rs
@@ -1,28 +1,28 @@
 #[cfg(all(feature = "json", any(feature = "tls", feature = "tls-native")))]
-// #[test] test temporarily disabled because httpbin is down / we need to figure out
+// test temporarily disabled because httpbin is down / we need to figure out
 // how to eliminate the external dependency.
-fn agent_set_header() {
-    use serde::Deserialize;
-    use std::collections::HashMap;
+// #[test]
+// fn agent_set_header() {
+//     use serde::Deserialize;
+//     use std::collections::HashMap;
 
-    #[derive(Deserialize, Debug)]
-    struct HttpBin {
-        headers: HashMap<String, String>,
-    }
+//     #[derive(Deserialize, Debug)]
+//     struct HttpBin {
+//         headers: HashMap<String, String>,
+//     }
 
-    let agent = ureq::Agent::new();
-    let resp = agent
-        .get("https://httpbin.org/get")
-        .set("header", "value")
-        .set("Connection", "close")
-        .call()
-        .unwrap();
-    assert_eq!(resp.status(), 200);
-    let json: HttpBin = resp.into_json().unwrap();
-    // println!("{:?}", json);
-    assert_eq!("value", json.headers.get("Header").unwrap());
-}
-
+//     let agent = ureq::Agent::new();
+//     let resp = agent
+//         .get("https://httpbin.org/get")
+//         .set("header", "value")
+//         .set("Connection", "close")
+//         .call()
+//         .unwrap();
+//     assert_eq!(resp.status(), 200);
+//     let json: HttpBin = resp.into_json().unwrap();
+//     // println!("{:?}", json);
+//     assert_eq!("value", json.headers.get("Header").unwrap());
+// }
 #[test]
 #[cfg(any(feature = "tls", feature = "tls-native"))]
 // From here https://badssl.com/download/


### PR DESCRIPTION
These test were failing because they made live requests to httpbin.org, which is serving intermittent 500s.

In general we strive to make our test and doctests interact with a local test server rather than a live website. For doctests we do this with some sleight of hand in a hidden `ureq::is_test(true)`, which swaps out the default agent returned by ureq::agent. However, since the middleware doctests rely on constructing a custom agent with the middleware, they can't rely on this.

I suspect we can get around this problem but it may take some thinking.

Similarly disable the AgentBuilder::user_agent and redirects doctests and the agent_set_header unittest.