### PR TITLE
Fix overall_timeout_reading_json test failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ once_cell = "1"
 url = "2"
 socks = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
-serde_json = { version = ">=1,<1.0.94", optional = true }
+serde_json = { version = ">=1.0.97", optional = true }
 encoding_rs = { version = "0.8", optional = true }
 cookie_store = { version = "0.19", optional = true, default-features = false, features = ["preserve_order"] }
 log = "0.4"


### PR DESCRIPTION
Fixes #602

`serde_json` [introduced a new API](https://github.com/serde-rs/json/pull/1026) to properly support our use case of extracting the underlying `std::io::ErrorKind`, this PR updates the dependency to match the requisite `serde_json` version and switches to it.
