### PR TITLE
fix: set up path to ureq

### DIFF
--- a/examples/mbedtls/Cargo.toml
+++ b/examples/mbedtls/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 
 [dependencies]
 mbedtls = { version = "0.8.1" }
+ureq = { path = "../.." }


### PR DESCRIPTION
We need this one line fix to be able to "cargo run" for this example.
Probably this should be turned into a proper example that can be run from the top of ureq.
I would appreciate some other people testing this.  On an ubuntu 20.04 laptop, it fails to connect, yet on an Devuan desktop, it works just fine.  Same network. Same IPv4 and IPv6 connectivity.  Still reviewing cargo tree.