### PR TITLE
Auto detect proxy from environments

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -67,6 +67,30 @@ impl Proxy {
         self.user.is_some() && self.password.is_some()
     }
 
+    pub(crate) fn try_from_system() -> Option<Self> {
+        macro_rules! try_env {
+            ($($env:literal),+) => {
+                $(
+                    if let Ok(env) = std::env::var($env) {
+                        if let Ok(proxy) = Self::new(env) {
+                            return Some(proxy);
+                        }
+                    }
+                )+
+            };
+        }
+
+        try_env!(
+            "ALL_PROXY",
+            "all_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "HTTP_PROXY",
+            "http_proxy"
+        );
+        None
+    }
+
     /// Create a proxy from a format string.
     /// # Arguments:
     /// * `proxy` - a str of format `<protocol>://<user>:<password>@<host>:port` . All parts except host are optional.


### PR DESCRIPTION
solve #322 
----
Just like reqwest, auto detect proxy from `ALL_PROXY`/`HTTPS_PROXY`/`HTTP_PROXY` [reqwest::proxy.rs](https://github.com/seanmonstar/reqwest/blob/master/src/proxy.rs#L834)

Add `AgentBuilder::no_proxy` if someone don't want to use system's proxy