### PR TITLE
http_interop: Implement `Request` conversion for `http::request::Parts`

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -1,0 +1,2 @@
+- Replace `impl From<http::request::Builder> for Request` with `TryFrom` because the conversion is fallible
+  (implement in terms of `From<http::request::Parts>`: `builder.body(())?.into_parts().0.into()`);


### PR DESCRIPTION
Fixes #656
Closes #501
Closes #520

I found the current conversion for `http::request::Builder` to be rather useless when the `http` crate and various crates providing `http` interfaces like `oauth2` are designed to provide an `http::Request` directly, and there being no way to convert from a `http::Request` back into its `http::request::Builder`.  That, together with strange infallible defaults instead of providing  `TryFrom` make the current implementation cumbersome to use.

Fortunately `http` provides `http::Request::into_parts()` to get back a `Parts` structure (which is wrapped in `Result<>` inside `http::request::Builder` as sole member!) together with the request body (a generic type) which the user can manually pass to `send_string()`, `send_bytes()` or `call()` if there's no data.

Implement a `From<http::request::Parts> for ureq::Request` to support this case, making `ureq` finally capable of sending `http::Request`s.
(Note that, despite exclusively consisting of `Result<Parts>`, `http::request::Builder` has no constructor from `Ok(Parts {..})` which would have also facilitated this use-case somewhat)

### TODO

Some more ideas and things I found while working on this crate:

- [x] Use `doc_cfg` when building for docs.rs: #670;
- [x] Enable all features when building for docs.rs to make the above useful (for discovery);
- [x] Remove unnecessary UTF-8 conversions and their fallibility: #672;
- [x] Wrap intradoc references properly in backticks;
- [ ] Replace `From<http::request::Builder>` with `TryFrom<>` (breaking change!).
- [ ] **Or better: remove this conversion for the `Builder` altogether, see below!** 