### PR TITLE
http_interop: Remove requirement for header values to be UTF-8

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -98,7 +98,7 @@ impl Header {
 
     /// The header value.
     ///
-    /// For non-utf8 headers this returns None (use [`Header::value_raw()`]).
+    /// For non-utf8 headers this returns [`None`] (use [`Header::value_raw()`]).
     pub fn value(&self) -> Option<&str> {
         let bytes = &self.line.as_bytes()[self.index + 1..];
         from_utf8(bytes)
@@ -150,11 +150,20 @@ impl Header {
     }
 }
 
+/// For non-utf8 headers this returns [`None`] (use [`get_header_raw()`]).
 pub fn get_header<'h>(headers: &'h [Header], name: &str) -> Option<&'h str> {
     headers
         .iter()
         .find(|h| h.is_name(name))
         .and_then(|h| h.value())
+}
+
+#[cfg(any(doc, all(test, feature = "http-interop")))]
+pub fn get_header_raw<'h>(headers: &'h [Header], name: &str) -> Option<&'h [u8]> {
+    headers
+        .iter()
+        .find(|h| h.is_name(name))
+        .map(|h| h.value_raw())
 }
 
 pub fn get_all_headers<'h>(headers: &'h [Header], name: &str) -> Vec<&'h str> {


### PR DESCRIPTION
CC @kade-robertson

The current interop implementation forces fallibility around header values when they are not UTF-8, both in conversions from `http` to `ureq` as well as the other way around.

This should not be necessary as both `http` and `ureq` treat these as opaque byte arrays internally, but unfortunately the current open API for `ureq` and `http` make it a bit nasty to deal with.
