### PR TITLE
Drop redundant or wrong `Requires feature` documentation

### DIFF
--- a/src/http_interop.rs
+++ b/src/http_interop.rs
@@ -12,7 +12,6 @@ use crate::{header::HeaderLine, response::ResponseStatusIndex, Request, Response
 /// [`Header`](crate::Header), it will be skipped rather than having the conversion fail. The remote
 /// address property will also always be `127.0.0.1:80` for similar reasons to the URL.
 ///
-/// Requires feature `ureq = { version = "*", features = ["http"] }`
 /// ```
 /// # fn main() -> Result<(), http::Error> {
 /// # ureq::is_test(true);
@@ -86,7 +85,6 @@ fn create_builder(response: &Response) -> http::response::Builder {
 /// Due to slight differences in how headers are handled, this means if a header from a [`Response`]
 /// is not valid UTF-8, it will not be included in the resulting [`http::Response`].
 ///
-/// Requires feature `ureq = { version = "*", features = ["http"] }`
 /// ```
 /// # fn main() -> Result<(), ureq::Error> {
 /// # ureq::is_test(true);
@@ -107,7 +105,6 @@ impl From<Response> for http::Response<Box<dyn Read + Send + Sync + 'static>> {
 /// Due to slight differences in how headers are handled, this means if a header from a [`Response`]
 /// is not valid UTF-8, it will not be included in the resulting [`http::Response`].
 ///
-/// Requires feature `ureq = { version = "*", features = ["http"] }`
 /// ```
 /// # fn main() -> Result<(), ureq::Error> {
 /// # ureq::is_test(true);
@@ -129,7 +126,6 @@ impl From<Response> for http::Response<String> {
 /// Due to slight differences in how headers are handled, this means if a header from a [`Response`]
 /// is not valid UTF-8, it will not be included in the resulting [`http::Response`].
 ///
-/// Requires feature `ureq = { version = "*", features = ["http"] }`
 /// ```
 /// # fn main() -> Result<(), ureq::Error> {
 /// # ureq::is_test(true);
@@ -153,7 +149,6 @@ impl From<Response> for http::Response<Vec<u8>> {
 /// to being a `GET` request to `"https://example.com"`. Additionally, any non-UTF8 headers will
 /// be skipped.
 ///
-/// Requires feature `ureq = { version = "*", features = ["http"] }`
 /// ```
 /// # fn main() -> Result<(), ureq::Error> {
 /// # ureq::is_test(true);
@@ -196,7 +191,6 @@ impl From<http::request::Builder> for Request {
 /// This will only convert valid UTF-8 header values into headers on the resulting builder. The
 /// method and URI are preserved. The HTTP version will always be set to `HTTP/1.1`.
 ///
-/// Requires feature `ureq = { version = "*", features = ["http"] }`
 /// ```
 /// # fn main() -> Result<(), http::Error> {
 /// # ureq::is_test(true);

--- a/src/request.rs
+++ b/src/request.rs
@@ -175,8 +175,6 @@ impl Request {
 
     /// Send data a json value.
     ///
-    /// Requires feature `ureq = { version = "*", features = ["json"] }`
-    ///
     /// The `Content-Length` header is implicitly set to the length of the serialized value.
     ///
     /// ```

--- a/src/response.rs
+++ b/src/response.rs
@@ -489,8 +489,6 @@ impl Response {
     ///
     /// [turbofish operator]: https://matematikaadit.github.io/posts/rust-turbofish.html
     ///
-    /// Requires feature `ureq = { version = "*", features = ["json"] }`
-    ///
     /// Example:
     ///
     /// ```


### PR DESCRIPTION
As mentioned in https://github.com/algesten/ureq/pull/670#issuecomment-1756381424 this sort of documentation is superfluous now that `doc_cfg`/ `doc_auto_cfg` **automatically** generates colored blocks in the documentation denoting what `cfg`s (including features) need to be met in order to enable a symbol.

In addition the `http` feature only exists to turn on the `http` crate, while the type conversions in the `http_interop.rs` module are only provided behind the `http-interop` feature.

The `charset` feature documentation is left in place, because that affects additional functionality deeper down inside the `send_string()` function.
