### PR TITLE
Fix missing add_trust_anchors method due to lax rustls versioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ cookie_store = { version = "0.20", optional = true, default-features = false, fe
 log = "0.4"
 webpki = { package = "rustls-webpki", version = "0.101", optional = true }
 webpki-roots = { version = "0.25", optional = true }
-rustls = { version = "0.21", optional = true }
+rustls = { version = ">=0.21.6, <0.22", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }
@@ -50,7 +50,7 @@ http = { version = "0.2", optional = true }
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 env_logger = "0.10"
-rustls = { version = "0.21", features = ["dangerous_configuration"] }
+rustls = { version = ">=0.21.6, <0.22", features = ["dangerous_configuration"] }
 rustls-pemfile = { version = "1.0" }
 
 [[example]]


### PR DESCRIPTION
Upon upgrading to 2.8.0, I got the following compile error from inside `ureq`:

    error[E0599]: no method named `add_trust_anchors` found for struct `RootCertStore` in the current scope
       --> /home/cdown/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ureq-2.8.0/src/rtls.rs:102:16
        |
    102 |     root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
        |     -----------^^^^^^^^^^^^^^^^^ help: there is a method with a similar name: `add_server_trust_anchors`

The reason is because `add_trust_anchors` was only added in rustls 0.21.6, but ureq only specifies that any 0.21 is required. As such, if you are already using a compliant, earlier version, the method does not exist and the compile fails.

Pin to >=0.21.6 to make sure this method exists.

Originally introduced in 50fd1fe14e9a ("Update deps").