### PR TITLE
Add support for "Expect: 100-continue" header

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -501,3 +501,13 @@ mod tests {
         assert!(size < 500); // 344 on Macbook M1
     }
 }
+
+pub(crate) fn error_get_root_source<'a>(
+    err: &'a (dyn std::error::Error + 'static),
+) -> &'a (dyn std::error::Error + 'static) {
+    if let Some(err) = err.source() {
+        error_get_root_source(err) as &(dyn std::error::Error + 'static)
+    } else {
+        err as &(dyn std::error::Error + 'static)
+    }
+}

--- a/src/http_interop.rs
+++ b/src/http_interop.rs
@@ -5,7 +5,9 @@ use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 
-use crate::{header::HeaderLine, response::ResponseStatusIndex, Request, Response};
+use crate::{
+    header::HeaderLine, response::PendingReader, response::ResponseStatusIndex, Request, Response,
+};
 
 /// Converts an [`http::Response`] into a [`Response`].
 ///
@@ -47,7 +49,7 @@ impl<T: AsRef<[u8]> + Send + Sync + 'static> From<http::Response<T>> for Respons
                     HeaderLine::from(raw_header).into_header().unwrap()
                 })
                 .collect::<Vec<_>>(),
-            reader: Box::new(Cursor::new(value.into_body())),
+            reader: PendingReader::Reader(Box::new(Cursor::new(value.into_body()))),
             remote_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80),
             local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
             history: vec![],
@@ -280,6 +282,7 @@ impl From<Request> for http::request::Builder {
 mod tests {
     use crate::header::{add_header, get_header_raw, HeaderLine};
     use http_02 as http;
+    use std::io::Read;
 
     #[test]
     fn convert_http_response() {
@@ -376,7 +379,9 @@ mod tests {
 
         let mut response = super::Response::new(200, "OK", "tbr").unwrap();
         // b'\xFF' as invalid UTF-8 character
-        response.reader = Box::new(Cursor::new(vec![b'\xFF', 0xde, 0xad, 0xbe, 0xef]));
+        response.reader = super::PendingReader::Reader(Box::new(Cursor::new(vec![
+            b'\xFF', 0xde, 0xad, 0xbe, 0xef,
+        ])));
         let http_response: Response<Vec<u8>> = response.into();
 
         assert_eq!(

--- a/src/response.rs
+++ b/src/response.rs
@@ -561,7 +561,7 @@ impl Response {
     /// let resp = ureq::Response::do_from_read(read);
     ///
     /// assert_eq!(resp.status(), 401);
-    pub(crate) fn do_from_stream(stream: Stream, unit: Unit) -> Result<Response, Error> {
+    pub(crate) fn do_from_stream(stream: Stream, unit: &Unit) -> Result<Response, Error> {
         let remote_addr = stream.remote_addr;
 
         let local_addr = match stream.socket() {
@@ -609,7 +609,7 @@ impl Response {
         }
 
         let reader =
-            Self::stream_to_reader(stream, &unit, body_type, compression, connection_option);
+            Self::stream_to_reader(stream, unit, body_type, compression, connection_option);
 
         let url = unit.url.clone();
 
@@ -766,7 +766,7 @@ impl FromStr for Response {
             &request_reader,
             None,
         );
-        Self::do_from_stream(stream, unit)
+        Self::do_from_stream(stream, &unit)
     }
 }
 
@@ -1150,7 +1150,7 @@ mod tests {
             &request_reader,
             None,
         );
-        let resp = Response::do_from_stream(s.into(), unit).unwrap();
+        let resp = Response::do_from_stream(s.into(), &unit).unwrap();
         assert_eq!(resp.status(), 200);
         assert_eq!(resp.header("x-geo-header"), None);
     }
@@ -1206,7 +1206,7 @@ mod tests {
         );
         Response::do_from_stream(
             stream,
-            Unit::new(
+            &Unit::new(
                 &agent,
                 "GET",
                 &"https://example.com/".parse().unwrap(),
@@ -1238,7 +1238,7 @@ mod tests {
         );
         let resp = Response::do_from_stream(
             stream,
-            Unit::new(
+            &Unit::new(
                 &agent,
                 "GET",
                 &"https://example.com/".parse().unwrap(),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -72,6 +72,10 @@ impl DeadlineStream {
     pub(crate) fn inner_mut(&mut self) -> &mut Stream {
         &mut self.stream
     }
+
+    pub(crate) fn into_inner(self) -> Stream {
+        self.stream
+    }
 }
 
 impl From<DeadlineStream> for Stream {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -456,7 +456,7 @@ pub(crate) fn connect_host(
             let pool_key = PoolKey::from_parts(unit.url.scheme(), hostname, port);
             let pool_returner = PoolReturner::new(&unit.agent, pool_key);
             let s = Stream::new(s, remote_addr, pool_returner);
-            let response = Response::do_from_stream(s, unit.clone())?;
+            let response = Response::do_from_stream(s, unit)?;
             Proxy::verify_response(&response)?;
         }
     }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -455,8 +455,9 @@ pub(crate) fn connect_host(
             let s = stream.try_clone()?;
             let pool_key = PoolKey::from_parts(unit.url.scheme(), hostname, port);
             let pool_returner = PoolReturner::new(&unit.agent, pool_key);
-            let s = Stream::new(s, remote_addr, pool_returner);
-            let response = Response::do_from_stream(s, unit)?;
+            let stream = Stream::new(s, remote_addr, pool_returner);
+            let stream = DeadlineStream::new(stream, unit.deadline);
+            let response = Response::do_from_stream(stream, unit)?;
             Proxy::verify_response(&response)?;
         }
     }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -281,10 +281,7 @@ fn connect_inner(
     body::send_body(body, unit.is_chunked, &mut stream)?;
 
     // start reading the response to process cookies and redirects.
-    // TODO: this unit.clone() bothers me. At this stage, we're not
-    // going to use the unit (much) anymore, and it should be possible
-    // to have ownership of it and pass it into the Response.
-    let result = Response::do_from_stream(stream, unit.clone());
+    let result = Response::do_from_stream(stream, unit);
 
     // https://tools.ietf.org/html/rfc7230#section-6.3.1
     // When an inbound connection is closed prematurely, a client MAY


### PR DESCRIPTION
Works well, very easy to use by just setting the expect header like this

```rust
let huge_string = "abcde ".repeat(500);
let req = ureq::post("http://127.0.0.1:5000")
    .set("Expect", "100-continue");
 let res = req.send_string(&huge_string).unwrap();
println!("res: {:?}", res);
let body = res.into_string().unwrap();
println!("body: {}", body);
```

## To-do

- [x] A timeout to send body even if server does not understand "Expect: 100-continue"
    - [x] If the client timed out waiting for the HTTP/1.1 100 Continue, then proceed with sending the body without waiting for an "100 Continue" response.
    - [ ] (optional) Make the timeout configurable (1000ms default)
- [x] Follow the spec and on 417 resend the whole request but without the expect-100 header.
- [ ] (optional) Set "Expect: 100-continue" by default
    - Only set 100-continue if there is a body, if the body has a known size over X MB or always if the size is not known
