### PR TITLE
Release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.9.0
+
+## Fixed
+  * Broken rustls dep (introduced new function in patch version) (#677)
+  * Doc and test fixes (#670, #673, #674)
+
+## Added
+  * Upgraded http dep to 1.0
+  * http_interop to not require utf-8 headers (#672)
+  * http_interop implement conversion for `http::request::Parts` (#669)
+
 # 2.8.0
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "base64",
  "brotli-decompressor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }
 brotli-decompressor = { version = "2.3.2", optional = true }
-http = { version = "0.2", optional = true }
+http = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ureq"
-version = "2.8.0"
+version = "2.9.0"
 authors = ["Martin Algesten <martin@algesten.se>", "Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>"]
 description = "Simple, safe HTTP client"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ cookie_store = { version = "0.20", optional = true, default-features = false, fe
 log = "0.4"
 webpki = { package = "rustls-webpki", version = "0.101", optional = true }
 webpki-roots = { version = "0.25", optional = true }
-rustls = { version = ">=0.21.6, <0.22", optional = true }
+rustls = { version = "0.21.6", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }


### PR DESCRIPTION
- http 1.0
- Simpler version expression for rustls dep
- Update changelog
- 2.9.0
