### PR TITLE
Don't export Header struct

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -65,7 +65,7 @@ impl fmt::Display for HeaderLine {
 #[derive(Clone, PartialEq, Eq)]
 /// Wrapper type for a header field.
 /// <https://tools.ietf.org/html/rfc7230#section-3.2>
-pub struct Header {
+pub(crate) struct Header {
     // Line contains the unmodified bytes of single header field.
     // It does not contain the final CRLF.
     line: HeaderLine,
@@ -115,6 +115,7 @@ impl Header {
     ///
     /// ureq can't know what encoding the header is in, but this function provides
     /// an escape hatch for users that need to handle such headers.
+    #[cfg(any(feature = "http-interop", feature = "charset"))]
     pub fn value_raw(&self) -> &[u8] {
         let mut bytes = &self.line.as_bytes()[self.index + 1..];
 

--- a/src/http_interop.rs
+++ b/src/http_interop.rs
@@ -8,8 +8,8 @@ use crate::{header::HeaderLine, response::ResponseStatusIndex, Request, Response
 /// Converts an [`http::Response`] into a [`Response`].
 ///
 /// As an [`http::Response`] does not contain a URL, `"https://example.com/"` is used as a
-/// placeholder. Additionally, if the response has a header which cannot be converted into a valid
-/// [`Header`](crate::Header), it will be skipped rather than having the conversion fail. The remote
+/// placeholder. Additionally, if the response has a header which cannot be converted into
+/// the ureq equivalent, it will be skipped rather than having the conversion fail. The remote
 /// address property will also always be `127.0.0.1:80` for similar reasons to the URL.
 ///
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,6 @@ pub use crate::agent::Agent;
 pub use crate::agent::AgentBuilder;
 pub use crate::agent::RedirectAuthHeaders;
 pub use crate::error::{Error, ErrorKind, OrAnyStatus, Transport};
-pub use crate::header::Header;
 pub use crate::middleware::{Middleware, MiddlewareNext};
 pub use crate::proxy::Proxy;
 pub use crate::request::{Request, RequestUrl};


### PR DESCRIPTION
This struct does not need to be exported from the crate because it
is not used in any public fn - it's internal.

This is technically a breaking change, but in practice, not too bad
since the struct is not used by the API.
