### PR TITLE
Support both http 0.2 and 1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,9 @@ jobs:
           - native-certs
           - gzip
           - brotli
+          - http
           - http-interop
+          - http http-interop
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,17 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
@@ -778,7 +789,8 @@ dependencies = [
  "encoding_rs",
  "env_logger",
  "flate2",
- "http",
+ "http 0.2.11",
+ "http 1.0.0",
  "log",
  "native-tls",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ cookies = ["dep:cookie", "dep:cookie_store"]
 socks-proxy = ["dep:socks"]
 gzip = ["dep:flate2"]
 brotli = ["dep:brotli-decompressor"]
-http-interop = ["dep:http"]
+http-interop = ["dep:http-02"]
+http = ["dep:http"]
 proxy-from-env = []
 
 [dependencies]
@@ -46,6 +47,7 @@ rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }
 brotli-decompressor = { version = "2.3.2", optional = true }
+http-02 = { package = "http", version = "0.2", optional = true }
 http = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/src/header.rs
+++ b/src/header.rs
@@ -158,7 +158,7 @@ pub fn get_header<'h>(headers: &'h [Header], name: &str) -> Option<&'h str> {
         .and_then(|h| h.value())
 }
 
-#[cfg(any(doc, all(test, feature = "http-interop")))]
+#[cfg(any(doc, all(test, any(feature = "http-interop", feature = "http"))))]
 pub fn get_header_raw<'h>(headers: &'h [Header], name: &str) -> Option<&'h [u8]> {
     headers
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,8 @@
 //!   does nothing for `native-tls`.
 //! * `gzip` enables requests of gzip-compressed responses and decompresses them. This is enabled by default.
 //! * `brotli` enables requests brotli-compressed responses and decompresses them.
-//! * `http-interop` enables conversion methods to and from `http::Response` and `http::request::Builder`.
+//! * `http-interop` enables conversion methods to and from `http::Response` and `http::request::Builder` (v0.2).
+//! * `http` enables conversion methods to and from `http::Response` and `http::request::Builder` (v1.0).
 //!
 //! # Plain requests
 //!
@@ -419,6 +420,9 @@ mod testserver;
 
 #[cfg(feature = "http-interop")]
 mod http_interop;
+
+#[cfg(feature = "http")]
+mod http;
 
 pub use crate::agent::Agent;
 pub use crate::agent::AgentBuilder;


### PR DESCRIPTION
This implements the idea I had in #683, supporting both versions of `http` and with the planned breaking change to supporting `TryFrom<http::request::Builder>` instead of `From<http::request::Builder>` since it's non-breaking as a new feature.