### PR TITLE
new feature flag to control whether or not to detect proxy settings from environment by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ socks-proxy = ["dep:socks"]
 gzip = ["dep:flate2"]
 brotli = ["dep:brotli-decompressor"]
 http-interop = ["dep:http"]
+proxy-from-env = []
 
 [dependencies]
 base64 = "0.21"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -325,8 +325,9 @@ impl AgentBuilder {
 
     /// Attempt to detect proxy settings from the environment, i.e. HTTP_PROXY
     ///
-    /// The default is `false`, i.e. not detecting proxy from env since this is
-    /// a potential security risk.
+    /// The default is `false` without the `proxy-from-env` feature flag, i.e.
+    /// not detecting proxy from env, due to the potential security risk and to
+    /// maintain backward compatibility.
     ///
     /// If the `proxy` is set on the builder, this setting has no effect.
     pub fn try_proxy_from_env(mut self, do_try: bool) -> Self {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -264,6 +264,9 @@ impl AgentBuilder {
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
                 tls_config: TlsConfig(crate::default_tls_config()),
             },
+            #[cfg(feature = "proxy-from-env")]
+            try_proxy_from_env: true,
+            #[cfg(not(feature = "proxy-from-env"))]
             try_proxy_from_env: false,
             max_idle_connections: DEFAULT_MAX_IDLE_CONNECTIONS,
             max_idle_connections_per_host: DEFAULT_MAX_IDLE_CONNECTIONS_PER_HOST,


### PR DESCRIPTION
The default behavior of many libs and tools is to pick up proxy environment variables.  Being able to config `ureq` to behave the same way makes implementing this behavior in other software easier.

If the default is `false` and we have no ways to make it default to `true`, implementing this behavior in other software would mean one of the following:
- no qol methods like `ureq::get(..)`, because we need to construct an `AgentBuilder` and call `try_proxy_from_env`, then `build`, every time.
- construct and config a shared or global `Agent`, use that throughout the code.