### PR TITLE
Do not expose crate-private Header struct in public interface

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -152,7 +152,7 @@ impl Header {
 }
 
 /// For non-utf8 headers this returns [`None`] (use [`get_header_raw()`]).
-pub fn get_header<'h>(headers: &'h [Header], name: &str) -> Option<&'h str> {
+pub(crate) fn get_header<'h>(headers: &'h [Header], name: &str) -> Option<&'h str> {
     headers
         .iter()
         .find(|h| h.is_name(name))
@@ -160,14 +160,14 @@ pub fn get_header<'h>(headers: &'h [Header], name: &str) -> Option<&'h str> {
 }
 
 #[cfg(any(doc, all(test, any(feature = "http-interop", feature = "http-crate"))))]
-pub fn get_header_raw<'h>(headers: &'h [Header], name: &str) -> Option<&'h [u8]> {
+pub(crate) fn get_header_raw<'h>(headers: &'h [Header], name: &str) -> Option<&'h [u8]> {
     headers
         .iter()
         .find(|h| h.is_name(name))
         .map(|h| h.value_raw())
 }
 
-pub fn get_all_headers<'h>(headers: &'h [Header], name: &str) -> Vec<&'h str> {
+pub(crate) fn get_all_headers<'h>(headers: &'h [Header], name: &str) -> Vec<&'h str> {
     headers
         .iter()
         .filter(|h| h.is_name(name))
@@ -175,11 +175,11 @@ pub fn get_all_headers<'h>(headers: &'h [Header], name: &str) -> Vec<&'h str> {
         .collect()
 }
 
-pub fn has_header(headers: &[Header], name: &str) -> bool {
+pub(crate) fn has_header(headers: &[Header], name: &str) -> bool {
     get_header(headers, name).is_some()
 }
 
-pub fn add_header(headers: &mut Vec<Header>, header: Header) {
+pub(crate) fn add_header(headers: &mut Vec<Header>, header: Header) {
     let name = header.name();
     if !name.starts_with("x-") && !name.starts_with("X-") {
         headers.retain(|h| h.name() != name);


### PR DESCRIPTION
Commit https://github.com/algesten/ureq/commit/4ddcc3a27a6c8cb88041dc713010455f776fa753 made `Header` struct internal (crate-private), but is was used in some non-exported functions maked as public. This raises an error while compiling the library.
Marking the functions as crate-private (as the `Header` struct) fixes the compilation.