### PR TITLE
Set default proxy ports to spec

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -153,7 +153,10 @@ impl Proxy {
             server,
             user,
             password,
-            port: port.unwrap_or(8080),
+            port: port.unwrap_or(match proto {
+                Proto::HTTP => 80,
+                Proto::SOCKS4 | Proto::SOCKS4A | Proto::SOCKS5 => 1080,
+            }),
             proto,
         })
     }


### PR DESCRIPTION
"If the port number is not specified, 80 is always assumed for HTTP."
See: https://www.w3.org/Protocols/HTTP/AsImplemented.html

It was strange behavior to me to default to 8080