### PR TITLE
Use std::sync::OnceLock instead of once_cell::sync::Lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,6 @@ dependencies = [
  "http 1.0.0",
  "log",
  "native-tls",
- "once_cell",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ proxy-from-env = []
 [dependencies]
 base64 = "0.21"
 cookie = { version = "0.18", default-features = false, optional = true }
-once_cell = "1"
 url = "2"
 socks = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,8 +460,7 @@ pub fn serde_to_value<T: serde::Serialize>(
     serde_json::to_value(value)
 }
 
-use once_cell::sync::Lazy;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
 
 /// Creates an [AgentBuilder].
 pub fn builder() -> AgentBuilder {
@@ -477,11 +476,11 @@ pub fn builder() -> AgentBuilder {
 // when collecting doctests, not when building the crate.
 #[doc(hidden)]
 pub fn is_test(is: bool) -> bool {
-    static IS_TEST: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
+    static IS_TEST: OnceLock<bool> = OnceLock::new();
     if is {
-        IS_TEST.store(true, Ordering::SeqCst);
+        let _ = IS_TEST.set(true);
     }
-    IS_TEST.load(Ordering::SeqCst)
+    *IS_TEST.get_or_init(|| false)
 }
 
 /// Agents are used to hold configuration and keep state between requests.


### PR DESCRIPTION
This PR removes the `once_cell` dependency and uses the std struct instead.
MSRV would go up to 1.70


See:
- https://doc.rust-lang.org/std/sync/struct.OnceLock.html
- https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#oncecell-and-oncelock