### PR TITLE
Fix license declaration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "ureq"
 version = "2.9.5"
 authors = ["Martin Algesten <martin@algesten.se>", "Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>"]
 description = "Simple, safe HTTP client"
-license = "MIT OR Apache-2.0"
+# src/chunked is forked from chunked_transfer, licensed  under Apache-2.0
+license = "(MIT OR Apache-2.0) AND Apache-2.0"
 repository = "https://github.com/algesten/ureq"
 readme = "README.md"
 keywords = ["web", "request", "https", "http", "client"]


### PR DESCRIPTION
`src/chunked` was forked from `chunked_transfer` on Nov 26 2022, back when it was Apache-2.0 licensed:

fe3f1d550b097aa580ed02a18b48106d27d74911

`chunked_transfer` has since been relicensed on Dec 25 2022:

https://github.com/frewsxcv/rust-chunked-transfer/commit/e949e94cc61ec97a7bc7884e2426fc9e79b42dcd

So if all the commits to `src/chunked` can be rebased on top of all the changes between the time it was forked and that commit, `ureq` can be purely MIT OR Apache-2.0 dual licensed, otherwise it has to be `(MIT OR Apache-2.0) AND Apache-2.0`