### PR TITLE
Exclude unnecessary files from being packaged

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["web", "request", "https", "http", "client"]
 categories = ["web-programming::http-client"]
 edition = "2018"
+exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 
 
 # MSRV


### PR DESCRIPTION
These files are unnecessary, and some cause issues (e.g. when packaged in Fedora, having shell scripts creates a package dependency on Bash)