### PR TITLE
testdeps feature to pull in hootbin when needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features "${{ matrix.tls }} ${{ matrix.feature }}"
+          args: --no-default-features --features "testdeps ${{ matrix.tls }} ${{ matrix.feature }}"
 
 
   cargo-deny:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "hoot"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df22a4d90f1b0e65fe3e0d6ee6a4608cc4d81f4b2eb3e670f44bb6bde711e452"
+checksum = "fceae3b65325d8086333faa87d165c595464b57a50963911a5a2c1ee87cd4e56"
 dependencies = [
  "httparse",
  "log",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "hootbin"
-version = "0.1.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "354e60868e49ea1a39c44b9562ad207c4259dc6eabf9863bf3b0f058c55cfdb2"
+checksum = "ebcf9e17911ae109a3abe00cd094ff6a5d36e36a10694b7db827fdf30d36c1b8"
 dependencies = [
  "fastrand",
  "hoot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ http-02 = { package = "http", version = "0.2", optional = true }
 http = { version = "1.0", optional = true }
 
 # This can't be in dev-dependencies due to doc tests.
-hootbin = { version = "0.1.1", optional = true }
+hootbin = { version = "0.1.5", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ http-interop = ["dep:http-02"]
 # http-crate is for http crate version 1.0 (full release)
 http-crate = ["dep:http"]
 proxy-from-env = []
+# Doc tests require hootbin.
+testdeps = ["dep:hootbin"]
 
 [dependencies]
 base64 = "0.21"
@@ -60,7 +62,7 @@ http-02 = { package = "http", version = "0.2", optional = true }
 http = { version = "1.0", optional = true }
 
 # This can't be in dev-dependencies due to doc tests.
-hootbin = { version = "0.1.1" }
+hootbin = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/response.rs
+++ b/src/response.rs
@@ -435,7 +435,7 @@ impl Response {
     /// ```
     /// # fn main() -> Result<(), ureq::Error> {
     /// # ureq::is_test(true);
-    /// let text = ureq::get("http://httpbin.org/get/success")
+    /// let text = ureq::get("http://httpbin.org/get?success")
     ///     .call()?
     ///     .into_string()?;
     ///

--- a/test.sh
+++ b/test.sh
@@ -5,8 +5,8 @@ export RUST_BACKTRACE=1
 export RUSTFLAGS="-D dead_code -D unused-variables -D unused"
 
 for feature in "" tls json charset cookies socks-proxy "tls native-certs" native-tls gzip brotli http-interop http-crate; do
-  if ! cargo test --no-default-features --features "${feature}" ; then
-    echo Command failed: cargo test --no-default-features --features \"${feature}\"
+  if ! cargo test --no-default-features --features "testdeps ${feature}" ; then
+    echo Command failed: cargo test --no-default-features --features \"testdeps ${feature}\"
     exit 1
   fi
 done


### PR DESCRIPTION
This PR makes it so tests must run using the `testdeps`
feature. That means hootbin can be an optional dependency
and thus not being a forced dependency on our users.

Close #724 
Relates to #703 