### PR TITLE
Added support for storing default headers in an `Agent`.

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -593,8 +593,32 @@ impl AgentBuilder {
     /// List of default headers to use when making a request.
     ///
     /// This can be overriden on a per-request basis
-    pub fn headers(mut self, headers: Vec<Header>) -> Self {
-        self.config.headers = headers;
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "json")]
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # ureq::is_test(true);
+    /// let agent = ureq::builder()
+    ///     .headers(vec![("Foo", "Bar")])
+    ///     .build();
+    ///
+    /// // Uses agent's header
+    /// let result: serde_json::Value =
+    ///     agent.get("http://httpbin.org/headers").call()?.into_json()?;
+    /// assert_eq!(&result["headers"]["Foo"], "Bar");
+    ///
+    /// // Overrides user-agent set on the agent
+    /// let result: serde_json::Value = agent.get("http://httpbin.org/headers")
+    ///     .set("Foo", "Baz")
+    ///     .call()?.into_json()?;
+    /// assert_eq!(&result["headers"]["Foo"], "Baz");
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(feature = "json"))]
+    /// # fn main() {}
+    /// ```
+    pub fn headers(mut self, headers: Vec<(&str, &str)>) -> Self {
+        self.config.headers = headers.iter().map(|(name, value)| Header::new(name, value)).collect();
         self
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,6 +16,7 @@ use {
     crate::cookies::{CookieStoreGuard, CookieTin},
     cookie_store::CookieStore,
 };
+use crate::header::Header;
 
 /// Strategy for keeping `authorization` headers during redirects.
 ///
@@ -78,6 +79,7 @@ pub(crate) struct AgentConfig {
     pub redirects: u32,
     pub redirect_auth_headers: RedirectAuthHeaders,
     pub user_agent: String,
+    pub headers: Vec<Header>,
     pub tls_config: TlsConfig,
 }
 
@@ -262,6 +264,7 @@ impl AgentBuilder {
                 redirects: 5,
                 redirect_auth_headers: RedirectAuthHeaders::Never,
                 user_agent: format!("ureq/{}", env!("CARGO_PKG_VERSION")),
+                headers: Vec::new(),
                 tls_config: TlsConfig(crate::default_tls_config()),
             },
             #[cfg(feature = "proxy-from-env")]
@@ -584,6 +587,14 @@ impl AgentBuilder {
     /// ```
     pub fn user_agent(mut self, user_agent: &str) -> Self {
         self.config.user_agent = user_agent.into();
+        self
+    }
+
+    /// List of default headers to use when making a request.
+    ///
+    /// This can be overriden on a per-request basis
+    pub fn headers(mut self, headers: Vec<Header>) -> Self {
+        self.config.headers = headers;
         self
     }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -464,14 +464,14 @@ fn send_prelude(unit: &Unit, stream: &mut Stream) -> io::Result<()> {
     }
 
     // config headers
-    for header in &unit.agent.config.headers {
+    for config_header in &unit.agent.config.headers {
         // specified headers have precedence
-        if !header.has_header(&unit.headers, header.name()) {
-            if let Some(v) = header.value() {
-                if is_header_sensitive(header) {
-                    prelude.write_sensitive_header(header.name(), v)?;
+        if !header::has_header(&unit.headers, config_header.name()) {
+            if let Some(v) = config_header.value() {
+                if is_header_sensitive(config_header) {
+                    prelude.write_sensitive_header(config_header.name(), v)?;
                 } else {
-                    prelude.write_header(header.name(), v)?;
+                    prelude.write_header(config_header.name(), v)?;
                 }
             }
         }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -463,6 +463,20 @@ fn send_prelude(unit: &Unit, stream: &mut Stream) -> io::Result<()> {
         prelude.write_header("Accept", "*/*")?;
     }
 
+    // config headers
+    for header in &unit.agent.config.headers {
+        // specified headers have precedence
+        if !header.has_header(&unit.headers, header.name()) {
+            if let Some(v) = header.value() {
+                if is_header_sensitive(header) {
+                    prelude.write_sensitive_header(header.name(), v)?;
+                } else {
+                    prelude.write_header(header.name(), v)?;
+                }
+            }
+        }
+    }
+
     // other headers
     for header in &unit.headers {
         if let Some(v) = header.value() {


### PR DESCRIPTION
Use the `.headers` function in the AgentBuilder to set the default headers. These can be overwritten by per-request headers. Note that there currently isn’t a way to remove them from an already built agent.

Resolves #732