### PR TITLE
Allow setting custom agent when converting from `http` crate types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,7 @@ mod testserver;
 
 #[cfg(feature = "http-interop")]
 // 0.2 version dependency (deprecated)
-mod http_interop;
+pub mod http_interop;
 
 #[cfg(feature = "http-crate")]
 // 1.0 version dependency.


### PR DESCRIPTION
I encountered a case where we needed to support custom ssl certificates as well as convert between the http crate as ureq. Because the conversion routines call into `crate::agent` directly this isn't possible. This PR adds helpers so I can do that, however, I'm not sure they're up to the standard of how `ureq` would do these things, so I'd love some pointers to help clean up this PR.