### PR TITLE
Provide Url getter on Response

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -136,6 +136,12 @@ impl Response {
 
     /// The URL we ended up at. This can differ from the request url when
     /// we have followed redirects.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// The URL we ended up at. This can differ from the request url when
+    /// we have followed redirects.
     pub fn get_url(&self) -> &str {
         &self.url[..]
     }


### PR DESCRIPTION
It would be nice to have access to the `Url` struct itself, so I don't need to reparse the String and use `expect`.