### PR TITLE
Fix compilation errors

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -682,7 +682,7 @@ impl AgentBuilder {
 
 #[cfg(feature = "tls")]
 #[derive(Clone)]
-pub(crate) struct TLSClientConfig(pub(crate) Arc<rustls::ClientConfig>);
+pub(crate) struct TLSClientConfig(());
 
 #[cfg(feature = "tls")]
 impl fmt::Debug for TLSClientConfig {

--- a/src/http_crate.rs
+++ b/src/http_crate.rs
@@ -125,7 +125,7 @@ impl From<Response> for http::Response<Vec<u8>> {
         let respone_builder = create_builder(&value);
         let mut body_buf: Vec<u8> = vec![];
         value.into_reader().read_to_end(&mut body_buf).unwrap();
-        respone_builder.body(body_buf).unwrap();
+        respone_builder.body(body_buf).unwrap()
     }
 }
 

--- a/src/http_crate.rs
+++ b/src/http_crate.rs
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn convert_to_http_response_bytes() {
         use http::Response;
-        use std::io::{Cursor, Read};
+        use std::io::Cursor;
 
         let mut response = super::Response::new(200, "OK", "tbr").unwrap();
         // b'\xFF' as invalid UTF-8 character

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -107,6 +107,7 @@ impl BufRead for DeadlineStream {
 }
 
 impl Read for DeadlineStream {
+    #[allow(clippy::unused_io_amount)]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // If the stream's BufReader has any buffered bytes, return those first.
         // This avoids calling `fill_buf()` on DeadlineStream unnecessarily,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -120,11 +120,7 @@ impl Write for Recorder {
     }
 }
 
-pub(crate) struct TestStream(
-    Box<dyn Read + Send + Sync>,
-    Box<dyn Write + Send + Sync>,
-    bool,
-);
+pub(crate) struct TestStream(Box<dyn Read + Send + Sync>, Box<dyn Write + Send + Sync>);
 
 impl TestStream {
     #[cfg(test)]
@@ -132,7 +128,7 @@ impl TestStream {
         response: impl Read + Send + Sync + 'static,
         recorder: impl Write + Send + Sync + 'static,
     ) -> Self {
-        Self(Box::new(response), Box::new(recorder), false)
+        Self(Box::new(response), Box::new(recorder))
     }
 }
 


### PR DESCRIPTION
- Fix compilation error introduced in 4602c65
- Fix general clippy errors (introduced in new version of clippy?)
- Fix unused field in struct