### PR TITLE
response: Remove error wrapper in read_next_line

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -788,15 +788,9 @@ fn read_next_line(reader: &mut impl BufRead, context: &str) -> io::Result<Header
         Ok(_) => Ok(()),
         Err(e) => {
             // Provide context to errors encountered while reading the line.
-            let reason = format!("Error encountered in {}", context);
-
+            let reason = format!("Error encountered in {}: {}", context, e);
             let kind = e.kind();
-
-            // Use an intermediate wrapper type which carries the error message
-            // as well as a .source() reference to the original error.
-            let wrapper = Error::new(ErrorKind::Io, Some(reason)).src(e);
-
-            Err(io::Error::new(kind, wrapper))
+            Err(io::Error::new(kind, reason))
         }
     }?;
 


### PR DESCRIPTION
I'm not sure why this wrapper is here. It can result in read_next_line could return ureq::Error->std::io::Error->ureq::Error->std::io::Error where "->" refers to the source.
This makes it messy to try and find out if there was an Transport error and you want to know the Io error kind (e.g. connection reset by peer), as then you had to match both err.source() for the "ureq::Error->std::io::Error" case as well as
err.source().source().source() for the
"ureq::Error->std::io::Error->ureq::Error->std::io::Error" case. Thus, we removed the wrapper between the std::io::Error's and bundled them together into a single std::io::Error. This will make read_next_line() return an Error which always looks like this: ureq::Error -> std::io::Error.