### PR TITLE
fix: Determine the URL to connect to after middleware finishes

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -115,7 +115,6 @@ impl Request {
         for h in &self.headers {
             h.validate()?;
         }
-        let url = self.parse_url()?;
 
         #[cfg(any(feature = "gzip", feature = "brotli"))]
         self.add_accept_encoding();
@@ -138,6 +137,7 @@ impl Request {
 
         let request_fn = |req: Request| {
             let reader = payload.into_read();
+            let url = req.parse_url()?;
             let unit = Unit::new(
                 &req.agent,
                 &req.method,
@@ -147,7 +147,7 @@ impl Request {
                 deadline,
             );
 
-            unit::connect(unit, true, reader).map_err(|e| e.url(url.clone()))
+            unit::connect(unit, true, reader).map_err(|e| e.url(url))
         };
 
         let response = if !self.agent.state.middleware.is_empty() {


### PR DESCRIPTION
Make sure that the URL that's used to establish the transport connection is parsed after middleware runs, in case the middleware made any changes to the URL itself (added query string params, changed the URL itself, etc.)

Fixes: #741