### PR TITLE
Add link to `AgentBuilder` in README

### DIFF
--- a/README.tpl
+++ b/README.tpl
@@ -8,6 +8,7 @@
 [std::sync::Arc]: https://doc.rust-lang.org/stable/alloc/sync/struct.Arc.html
 [std::io::Read]: https://doc.rust-lang.org/stable/std/io/trait.Read.html
 [Agent]: https://docs.rs/ureq/latest/ureq/struct.Agent.html
+[AgentBuilder]: https://docs.rs/ureq/latest/ureq/struct.AgentBuilder.html
 [get()]: https://docs.rs/ureq/latest/ureq/fn.get.html
 [post()]: https://docs.rs/ureq/latest/ureq/fn.post.html
 [put()]: https://docs.rs/ureq/latest/ureq/fn.put.html


### PR DESCRIPTION
Used here: https://github.com/algesten/ureq/blob/71be54297aa34cb976b352f69dbdd93a1a045af8/README.md?plain=1#L207