### PR TITLE
Bumps rustls to 0.22.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ cookie_store = { version = "0.21", optional = true, default-features = false, fe
 log = "0.4"
 webpki = { package = "rustls-webpki", version = "0.102", optional = true }
 webpki-roots = { version = "0.26", optional = true }
-rustls = { version = "0.22.0", optional = true }
+rustls = { version = "0.22.4", optional = true }
 rustls-pki-types = { version = "1", optional = true }
 rustls-native-certs = { version = "0.7", optional = true }
 native-tls = { version = "0.2", optional = true }


### PR DESCRIPTION
Hello!  👋

First of all, thanks for `ureq`, I've been using it in a couple of projects and I love it ❤️

Raising this PR since I got a couple of Dependabot Security Alerts on a critical issue found on `rustls`, which `ureq` depends on.

For the sake of reference

- https://github.com/advisories/GHSA-6g7w-8wpp-frhj
- https://nvd.nist.gov/vuln/detail/CVE-2024-32650

This PR bumps `rustls` to a proper [patch version](https://github.com/rustls/rustls/releases/tag/v%2F0.22.4) which address the aforementioned issue. 

I've ran a couple of test locally, eg running

```bash
$> cargo test --no-default-features --features "testdeps tls http-crate http-interop"
```

and found no issues so far. Happy to address any finding from a complete CI run. 🙂