### PR TITLE
Enable `http-crate` feature while building docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 rust-version = "1.61"
 
 [package.metadata.docs.rs]
-features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy", "gzip", "brotli", "http-interop"]
+features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy", "gzip", "brotli", "http-interop", "http-crate"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/src/http_crate.rs
+++ b/src/http_crate.rs
@@ -131,6 +131,8 @@ impl From<Response> for http::Response<Vec<u8>> {
 
 /// Converts an [`http::request::Builder`] into a [`Request`].
 ///
+/// For incomplete builders, see the [`http::request::Builder`] documentation for defaults.
+///
 /// ```
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # ureq::is_test(true);
@@ -142,7 +144,6 @@ impl From<Response> for http::Response<Vec<u8>> {
 /// # Ok(())
 /// # }
 /// ```
-///
 ///
 /// # Converting from [`http::Request`]
 ///
@@ -164,7 +165,7 @@ impl From<Response> for http::Response<Vec<u8>> {
 impl core::convert::TryFrom<http::request::Builder> for Request {
     type Error = http::Error;
 
-    fn try_from(value: http::request::Builder) -> Result<Self, http::Error> {
+    fn try_from(value: http::request::Builder) -> Result<Self, Self::Error> {
         let (parts, ()) = value.body(())?.into_parts();
         Ok(parts.into())
     }
@@ -402,7 +403,7 @@ mod tests {
         let request = crate::agent()
             .head("http://some-website.com")
             .set("Some-Key", "some value");
-        let http_request_builder: Builder = request.try_into().unwrap();
+        let http_request_builder: Builder = request.into();
         let http_request = http_request_builder.body(()).unwrap();
 
         assert_eq!(
@@ -446,7 +447,7 @@ mod tests {
                 .unwrap(),
         );
         dbg!(&request);
-        let http_request_builder: Builder = request.try_into().unwrap();
+        let http_request_builder: Builder = request.into();
         let http_request = http_request_builder.body(()).unwrap();
 
         assert_eq!(

--- a/src/http_interop.rs
+++ b/src/http_interop.rs
@@ -164,7 +164,7 @@ impl From<Response> for http::Response<Vec<u8>> {
 /// let request = http_builder.body(()).expect("Builder error"); // Check the error
 /// let (parts, ()) = request.into_parts();
 /// let request: ureq::Request = parts.into();
-//// request.call()?;
+/// request.call()?;
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
`ureq` properly adheres to the additive-only-ness of crate feature flags, allowing interop with the `http 0.2` and `http 1.x` crates concurrently. We should take advantage of this in the docs as well, by generating entries for `http 1.x` `impl`s (with appropriate autogenerated `Available on create feature http-crate only` markers) to make users aware of the bindings they have available.

Also clean up the `http 1` integration a bit following the breaking changes that I proposed (for `http 0.2`) a long time ago, which seem to have been copy-pasted to the new `http 1` interop.
