### PR TITLE
Headers from iterator type

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -312,6 +312,43 @@ impl Request {
         self
     }
 
+    /// Set multiple header fields.
+    ///
+    /// ```
+    /// # fn main() -> Result<(), ureq::Error> {
+    /// # ureq::is_test(true);
+    /// let headers = [
+    ///     ("Accept", "text/plain"),
+    ///     ("Range", "bytes=500-999")
+    /// ];
+    /// let resp = ureq::get("http://httpbin.org/bytes/1000")
+    ///     .set_headers(&headers)
+    ///     .call()?;
+    ///
+    /// let headers_vec = vec![
+    ///     ("Accept", "text/plain"),
+    ///     ("Range", "bytes=500-999")
+    /// ];
+    /// let resp = ureq::get("http://httpbin.org/bytes/1000")
+    ///     .set_headers(&headers_vec)
+    ///     .call()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn set_headers<I, T>(mut self, headers: I) -> Self
+    where
+        I: IntoIterator<Item = (T, T)>,
+        T: AsRef<str>,
+    {
+        for (name, value) in headers {
+            header::add_header(
+                &mut self.headers,
+                Header::new(name.as_ref(), value.as_ref()),
+            );
+        }
+        self
+    }
+
     /// Returns the value for a set header.
     ///
     /// ```


### PR DESCRIPTION
This added method is intended to make it easier to add multiple headers.

The name of the function is put in dicusion if you see it convenient.

## Motivation
I recently came across some code similar to this online and realized that ureq did not have an easy way to do this and that it resulted in code that was not very performant or readable (even acceptable).

```rs
for header in headers.iter(){
  req = req.set(&header.name, &header.value)
}
```

> [!NOTE]
> It would be ideal to explore a way to implement more From<T> for converting headers from a variety of other types.

I understand that this is probably only applicable to very particular cases, in that case and if you do not see your integration in `ureq` as convenient, feel free to comment and/or reject the PR.