### PR TITLE
Bump MSRV 1.61 -> 1.63

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
   build_versions:
     strategy:
       matrix:
-        rust: [stable, beta, 1.61.0]
+        rust: [stable, beta, 1.63.0]
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 
 
 # MSRV
-rust-version = "1.61"
+rust-version = "1.63"
 
 [package.metadata.docs.rs]
 features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy", "gzip", "brotli", "http-interop", "http-crate"]


### PR DESCRIPTION
One of our main upstream deps (rustls) have bumped to 1.63 due to their dependencies. This means we haven't got much choice but to bump as well.

https://github.com/rustls/rustls/pull/1902