### PR TITLE
ureq 2.10 tweaks for Rustls 0.23 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,22 @@
   * Bump MSRV 1.61 -> 1.63 due to rustls (#764)
   * Update deps (only patch versions in Cargo.lock) (#763)
   * Refork frewsxcv/rust-chunked-transfer to fix MIT/Apache2.0 license (#761)
-  * Fix doc Rustls does now support IP address certificates (#759)
   * Enable http-crate feature for docs (#755)
-  * Rustls dep to default to ring backend (#753)
+  * Update Rustls from 0.22 to 0.23 - this may be a breaking change if your
+    application depends on Rustls 0.22 (e.g. to provide a custom 
+    `rustls::ClientConfig` to `ureq`). See the [Rustls 0.23.0][rustls-0.23.0]
+    changelog for a list of breaking API changes (#753)
+  * Rustls dep to default to ring backend. If your project uses the
+    default `ureq` TLS config, or constructs its own `rustls::ClientConfig`
+    with `rustls::ClientConfig::builder()` you must ensure the Rustls 
+    `aws-lc-rs` feature is not activated, or set the process default 
+    cryptography provider before constructing any configs. See the Rustls
+    [CryptoProvider][CryptoProvider] docs for more information (#753)
   * Remove direct dep rustls-webpki (#752)
+  * Fix doc Rustls does now support IP address certificates (#759)(#753)
+
+[rustls-0.23.0]: https://github.com/rustls/rustls/releases/tag/v%2F0.23.0
+[CryptoProvider]: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider
 
 # 2.9.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+  * default `ureq` Rustls tls config updated to avoid panic for applications
+    that activate the default Rustls `aws-lc-rs` feature without setting
+    a process-wide crypto provider. `ureq` will now use `*ring*` in this
+    circumstance instead of panicing.
 
 # 2.10.0
   * Bump MSRV 1.61 -> 1.63 due to rustls (#764)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
:wave: here are a few changes pulled out of our discussion in https://github.com/algesten/ureq/issues/765

### docs: add more Rustls detail to 2.10.0 CHANGELOG

Two main goals here:
1. Explicitly call out that the Rustls update from 0.22 to 0.23 occurred, and is a breaking change for consumers that were using their own Rustls 0.22 dep to construct configs given to `ureq`. The Rustls 0.23 changelog is linked to discuss the upstream changes in detail. This explicitly addresses [the original issue](https://github.com/algesten/ureq/issues/765#issue-2395808883) flagged in #765.
2. Expand on the implications of `ureq` activating the `ring` feature by default. In particular you must either ensure Rustls features are unambiguous or install a process-wide default provider before building configs, or having `ureq` build you a config. This covers the reports in #765 of [an unexpected panic](https://github.com/algesten/ureq/issues/765#issuecomment-2217950386). This becomes slightly less painful with the subsequent change to update `default_tls_config()`'s builder choice.

### rtls: default_tls_config() explicit `*ring*` choice

This change is [informed by my comment](https://github.com/algesten/ureq/issues/765#issuecomment-2223080932) describing a place for improvement with `ureq`'s preference to use `*ring*` by default. We can avoid a risk of a panic building the `ureq` default TLS config and make the default provider intention clearer by using [`rustls::ClientConfig::builder_with_provider()`](https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html#method.builder_with_provider) instead of [`rustls::ClientConfig::builder()`](https://docs.rs/rustls/latest/rustls/client/struct.ClientConfig.html#method.builder) (which requires a clear process wide default is available, or panics).

###  Cargo: bytes v1.6.0 -> v1.6.1

<details>
<summary>Small add-on that fixes a `cargo-deny` error:</summary>

```
error[yanked]: detected yanked crate (try `cargo update -p bytes`)
   ┌─ /github/workspace/Cargo.lock:10:1
   │
10 │ bytes 1.6.0 registry+https://github.com/rust-lang/crates.io-index
   │ ----------------------------------------------------------------- yanked version
   │
   = bytes v1.6.0
     └── http v0.2.12
         └── ureq v2.10.0

advisories FAILED, bans ok, licenses ok, sources ok
```
</details>