### PR TITLE
[ureq 3.x] Use process-wide default rustls backend if set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,7 +488,7 @@ pub(crate) mod test {
 
         let agent: Agent = AgentConfig {
             tls_config: TlsConfig {
-                provider: TlsProvider::RustlsWithRing,
+                provider: TlsProvider::Rustls,
                 root_certs: RootCerts::WebPki,
                 ..Default::default()
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ pub(crate) mod test {
 
         let agent: Agent = AgentConfig {
             tls_config: TlsConfig {
-                provider: TlsProvider::RustlsWithRing,
+                provider: TlsProvider::Rustls,
                 ..Default::default()
             },
             ..Default::default()

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -17,19 +17,20 @@ pub use self::native_tls::NativeTlsConnector;
 
 /// Setting for which TLS provider to use.
 ///
-/// Defaults to [`RustlsWithRing`][Self::RustlsWithRing] because this has the highest chance
+/// Defaults to [`Rustls`][Self::Rustls] because this has the highest chance
 /// to compile and "just work" straight out of the box without installing additional
 /// development dependencies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TlsProvider {
-    /// [Rustls](https://crates.io/crates/rustls) with [Ring](https://crates.io/crates/ring) as
-    /// cryptographic backend.
+    /// [Rustls](https://crates.io/crates/rustls) with the
+    /// [process-wide default cryptographic backend](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default),
+    /// or [Ring](https://crates.io/crates/ring) if no process-wide default is set.
     ///
     /// Requires the feature flag **rustls**.
     ///
     /// This is the default.
-    RustlsWithRing,
+    Rustls,
 
     /// [Native-TLS](https://crates.io/crates/native-tls) for cases where it's important to
     /// use the TLS libraries installed on the host running ureq.
@@ -44,7 +45,7 @@ pub enum TlsProvider {
 impl TlsProvider {
     pub(crate) fn is_feature_enabled(&self) -> bool {
         match self {
-            TlsProvider::RustlsWithRing => {
+            TlsProvider::Rustls => {
                 cfg!(feature = "rustls")
             }
             TlsProvider::NativeTls => {
@@ -55,7 +56,7 @@ impl TlsProvider {
 
     pub(crate) fn feature_name(&self) -> &'static str {
         match self {
-            TlsProvider::RustlsWithRing => "rustls",
+            TlsProvider::Rustls => "rustls",
             TlsProvider::NativeTls => "native-tls",
         }
     }
@@ -69,7 +70,7 @@ impl TlsProvider {
 pub struct TlsConfig {
     /// The provider to use.
     ///
-    /// Defaults to [`TlsProvider::RustlsWithRing`].
+    /// Defaults to [`TlsProvider::Rustls`].
     pub provider: TlsProvider,
 
     /// Client certificate chains with corresponding private keys.
@@ -131,6 +132,6 @@ impl Default for TlsConfig {
 
 impl Default for TlsProvider {
     fn default() -> Self {
-        Self::RustlsWithRing
+        Self::Rustls
     }
 }

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -47,7 +47,7 @@ impl Connector for RustlsConnector {
             return Ok(Some(transport));
         }
 
-        if details.config.tls_config.provider != TlsProvider::RustlsWithRing {
+        if details.config.tls_config.provider != TlsProvider::Rustls {
             debug!("Skip because config is not set to Rustls");
             return Ok(Some(transport));
         }
@@ -95,7 +95,8 @@ impl Connector for RustlsConnector {
 fn build_config(tls_config: &TlsConfig) -> Arc<ClientConfig> {
     // Improve chances of ureq working out-of-the-box by not requiring the user
     // to select a default crypto provider.
-    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let provider = rustls::crypto::CryptoProvider::get_default().cloned()
+        .unwrap_or(Arc::new(rustls::crypto::ring::default_provider()));
 
     let builder = ClientConfig::builder_with_provider(provider)
         .with_protocol_versions(ALL_VERSIONS)

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -95,7 +95,8 @@ impl Connector for RustlsConnector {
 fn build_config(tls_config: &TlsConfig) -> Arc<ClientConfig> {
     // Improve chances of ureq working out-of-the-box by not requiring the user
     // to select a default crypto provider.
-    let provider = rustls::crypto::CryptoProvider::get_default().cloned()
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .cloned()
         .unwrap_or(Arc::new(rustls::crypto::ring::default_provider()));
 
     let builder = ClientConfig::builder_with_provider(provider)

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -231,7 +231,7 @@ impl Default for DefaultConnector {
             // Panic if the config calls for rustls, the uri scheme is https and that
             // TLS provider is not enabled by feature flags.
             #[cfg(feature = "_tls")]
-            no_tls::WarnOnMissingTlsProvider(crate::tls::TlsProvider::RustlsWithRing).boxed(),
+            no_tls::WarnOnMissingTlsProvider(crate::tls::TlsProvider::Rustls).boxed(),
             //
             // As a fallback if rustls isn't enabled, use native-tls
             #[cfg(feature = "native-tls")]


### PR DESCRIPTION
This PR is the idea in https://github.com/algesten/ureq/issues/765#issuecomment-2282921492 : Keep `ring` as default and simplify opting into other `rustls` backend.

Also renames `RustlsWithRing` to `Rustls` since user can easily opt into an alternative backend.