### PR TITLE
Fix Debug format of `RequestBuilder`

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -21,9 +21,11 @@ pub struct RequestBuilder<B> {
     _ph: PhantomData<B>,
 }
 
+#[derive(Debug)]
 pub struct WithoutBody(());
 impl Private for WithoutBody {}
 
+#[derive(Debug)]
 pub struct WithBody(());
 impl Private for WithBody {}
 


### PR DESCRIPTION
With `ureq` 3.x, this example code...
```rust
fn main() {
  println!("{:?}", ureq::get("https://example.com/"));
}
```
... fails to compile in Rust 1.80.1 -
```
error[E0277]: `ureq::request::WithoutBody` doesn't implement `Debug`
 --> src/main.rs:2:20
  |
2 |   println!("{:?}", ureq::get("https://example.com/"));
  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ureq::request::WithoutBody` cannot be formatted using `{:?}` because it doesn't implement `Debug`
  |
  = help: the trait `Debug` is not implemented for `ureq::request::WithoutBody`, which is required by `RequestBuilder<ureq::request::WithoutBody>: Debug`
  = help: the trait `Debug` is implemented for `RequestBuilder<B>`
  = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
```

This PR fixes that error.