### PR TITLE
replace once_cell to std impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,6 @@ dependencies = [
  "http",
  "log",
  "native-tls",
- "once_cell",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 
 
 # MSRV
-rust-version = "1.67"
+rust-version = "1.70"
 
 [package.metadata.docs.rs]
 features = ["rustls", "native-tls", "socks-proxy", "cookies", "gzip", "brotli", "charset", "json", "_test"]
@@ -41,7 +41,6 @@ hoot = "0.2.1"
 http = "1.1.0"
 log = "0.4.22"
 thiserror = "1.0.61"
-once_cell = "1.19.0"
 smallvec = "1.13.2"
 utf-8 = "0.7.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/algesten/ureq"
 readme = "README.md"
 keywords = ["web", "request", "https", "http", "client"]
 categories = ["web-programming::http-client"]
-edition = "2018"
+edition = "2021"
 exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 
 
 # MSRV
-rust-version = "1.70"
+rust-version = "1.80"
 
 [package.metadata.docs.rs]
 features = ["rustls", "native-tls", "socks-proxy", "cookies", "gzip", "brotli", "charset", "json", "_test"]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -216,8 +216,8 @@ impl Agent {
 
                     #[cfg(any(feature = "gzip", feature = "brotli"))]
                     {
-                        use once_cell::sync::Lazy;
-                        static ACCEPTS: Lazy<String> = Lazy::new(|| {
+                        use std::sync::LazyLock;
+                        static ACCEPTS: LazyLock<String> = LazyLock::new(|| {
                             let mut value = String::with_capacity(10);
                             #[cfg(feature = "gzip")]
                             value.push_str("gzip");

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::sync::Arc;
 

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -267,8 +267,6 @@ impl fmt::Display for Cookie<'_> {
 #[cfg(test)]
 mod test {
 
-    use std::convert::TryFrom;
-
     use super::*;
 
     fn uri() -> Uri {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,8 +317,6 @@
 #[macro_use]
 extern crate log;
 
-use std::convert::TryFrom;
-
 /// Re-exported http-crate.
 pub use http;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,12 +398,12 @@ mk_method!(trace, TRACE, WithoutBody);
 #[cfg(test)]
 pub(crate) mod test {
 
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     use super::*;
 
     pub fn init_test_log() {
-        static INIT_LOG: Lazy<()> = Lazy::new(env_logger::init);
+        static INIT_LOG: LazyLock<()> = LazyLock::new(env_logger::init);
         *INIT_LOG
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,7 +1,6 @@
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use hoot::parser::try_parse_response;
-use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::io::Write;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};

--- a/src/tls/native_tls.rs
+++ b/src/tls/native_tls.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::fmt;
 use std::io::{Read, Write};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use crate::tls::{RootCerts, TlsProvider};
 use crate::transport::time::NextTimeout;
@@ -10,7 +10,6 @@ use der::pem::LineEnding;
 use der::Document;
 use native_tls::{Certificate, HandshakeError, Identity, TlsConnector};
 use native_tls::{TlsConnectorBuilder, TlsStream};
-use once_cell::sync::OnceCell;
 
 use super::TlsConfig;
 
@@ -19,7 +18,7 @@ use super::TlsConfig;
 /// Requires feature flag **native-tls**.
 #[derive(Default)]
 pub struct NativeTlsConnector {
-    connector: OnceCell<Arc<TlsConnector>>,
+    connector: OnceLock<Arc<TlsConnector>>,
 }
 
 impl Connector for NativeTlsConnector {

--- a/src/tls/native_tls.rs
+++ b/src/tls/native_tls.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fmt;
 use std::io::{Read, Write};
 use std::sync::{Arc, OnceLock};

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -1,9 +1,8 @@
 use std::convert::TryInto;
 use std::fmt;
 use std::io::{Read, Write};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use once_cell::sync::OnceCell;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned, ALL_VERSIONS};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer};
@@ -23,7 +22,7 @@ use super::TlsConfig;
 /// Requires feature flag **rustls**.
 #[derive(Default)]
 pub struct RustlsConnector {
-    config: OnceCell<Arc<ClientConfig>>,
+    config: OnceLock<Arc<ClientConfig>>,
 }
 
 impl Connector for RustlsConnector {

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::fmt;
 use std::io::{Read, Write};
 use std::sync::{Arc, OnceLock};

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use std::convert::TryFrom;
 use std::io::{self, ErrorKind};
 
 use http::uri::{Authority, Scheme};


### PR DESCRIPTION
I can't guarantee full equivalence of behavior, but at least it's conceptually equivalent. (The `once_cell` crate should write a migration guide!)
This will bump MSRV to `1.80`. `once_cell` only needs `1.70`, while `lazy_cell` needs `1.80`. I originally thought only the former was needed, but then I saw the latter. The latter is a bit of a span, so it depends on you if you can accept it.
Bumped Rust edition to 2021 & removed redundant `use`s by the way.