### PR TITLE
Mitigate version mismatch of public rustls dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,18 @@
 //! [actix-web](https://crates.io/crates/actix-web), and [hyper](https://crates.io/crates/hyper).
 //!
 
+/// Re-exported rustls crate
+///
+/// Use this re-export to always get a compatible version of `ClientConfig`.
+#[cfg(feature = "rustls")]
+pub use rustls;
+
+/// Re-exported native-tls crate
+///
+/// Use this re-export to always get a compatible version of `TlsConnector`.
+#[cfg(feature = "native-tls")]
+pub use native_tls;
+
 mod agent;
 mod body;
 mod chunked;


### PR DESCRIPTION
Technically [2.10.0, 2.9.2, etc.](https://lib.rs/crates/ureq/versions#version-2.10.0) were breaking releases, because they upgraded rustls, which has its type exposed in the public API. This [has broken `maturin`](https://github.com/PyO3/maturin/issues/1671).

Instead of requiring users to add a matching version of `rustls` dependency themselves, an easier and more robust option is to re-export the version that `ureq` requires.
