### PR TITLE
Rename BodyWithConfig::into_reader -> reader

### DIFF
--- a/examples/cureq.rs
+++ b/examples/cureq.rs
@@ -52,12 +52,7 @@ fn run(opt: &Opt) -> Result<(), ureq::Error> {
 
     const MAX_BODY_SIZE: u64 = 5 * 1024 * 1024;
 
-    let reader = BufReader::new(
-        res.body_mut()
-            .with_config()
-            .limit(MAX_BODY_SIZE)
-            .into_reader(),
-    );
+    let reader = BufReader::new(res.body_mut().with_config().limit(MAX_BODY_SIZE).reader());
     let lines = reader.lines();
 
     for r in lines {


### PR DESCRIPTION
`BodyWithConfig::into_reader` is not a good name, because even though it converts the builder `BodyWithConfig` into a reader, the user is probably considering the ownership of `Body`, not the builder. Whether the `Body` is owned or shared depends on how we got the `BodyWithConfig`, hence it makes sense to just finish with `.reader()` for both owned and shared situation.