### PR TITLE
Remove duplicated header names

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -190,8 +190,6 @@ const NON_SENSITIVE_HEADERS: &[&str] = &[
     "accept",
     "accept-encoding",
     "accept-charset",
-    "date",
-    "connection",
     "server",
     "user-agent",
 ];


### PR DESCRIPTION
`date` and `connection` are currently duplicated.