### PR TITLE
Utilize `HeaderName` for non-sensitive headers

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -2,8 +2,12 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, ErrorKind};
 
+use http::header::{
+    ACCEPT, ACCEPT_CHARSET, ACCEPT_ENCODING, CONNECTION, CONTENT_ENCODING, CONTENT_LENGTH,
+    CONTENT_TYPE, DATE, HOST, LOCATION, SERVER, TRANSFER_ENCODING, USER_AGENT,
+};
 use http::uri::{Authority, Scheme};
-use http::{HeaderMap, HeaderValue, Method, Response, Uri, Version};
+use http::{HeaderMap, HeaderName, HeaderValue, Method, Response, Uri, Version};
 
 use crate::proxy::Proto;
 use crate::Error;
@@ -179,20 +183,20 @@ impl<'a, B> fmt::Debug for DebugResponse<'a, B> {
 
 pub(crate) struct DebugHeaders<'a>(pub &'a HeaderMap);
 
-const NON_SENSITIVE_HEADERS: &[&str] = &[
-    "date",
-    "content-type",
-    "content-length",
-    "transfer-encoding",
-    "connection",
-    "location",
-    "content-encoding",
-    "host",
-    "accept",
-    "accept-encoding",
-    "accept-charset",
-    "server",
-    "user-agent",
+const NON_SENSITIVE_HEADERS: &[HeaderName] = &[
+    DATE,
+    CONTENT_TYPE,
+    CONTENT_LENGTH,
+    TRANSFER_ENCODING,
+    CONNECTION,
+    LOCATION,
+    CONTENT_ENCODING,
+    HOST,
+    ACCEPT,
+    ACCEPT_ENCODING,
+    ACCEPT_CHARSET,
+    SERVER,
+    USER_AGENT,
 ];
 
 impl<'a> fmt::Debug for DebugHeaders<'a> {
@@ -201,7 +205,7 @@ impl<'a> fmt::Debug for DebugHeaders<'a> {
         debug.entries(
             self.0
                 .iter()
-                .filter(|(name, _)| NON_SENSITIVE_HEADERS.contains(&name.as_str())),
+                .filter(|(name, _)| NON_SENSITIVE_HEADERS.contains(name)),
         );
 
         let redact_count = self
@@ -209,7 +213,7 @@ impl<'a> fmt::Debug for DebugHeaders<'a> {
             .iter()
             .filter(|(name, _)| {
                 // println!("{}", name);
-                !NON_SENSITIVE_HEADERS.contains(&name.as_str())
+                !NON_SENSITIVE_HEADERS.contains(name)
             })
             .count();
 


### PR DESCRIPTION
Allows to use the standard headers defined in `http` crate and avoid potential typos.

@algesten I was not 100% certain of what you meant by _const fn_ in [your comment](https://github.com/algesten/ureq/pull/850#issuecomment-2408624293
) on the previous PR and I did not want to ask on a merged PR, so I am submitting what I initially had in mind so we could discuss here.