### PR TITLE
Add `vendored` cargo feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.0+3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a709e02f2b4aca747929cca5ed248880847c650233cf8b8cdc48f40aaf4898a6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +545,7 @@ checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ gzip = ["dep:flate2"]
 brotli = ["dep:brotli-decompressor"]
 charset = ["dep:encoding_rs"]
 json = ["dep:serde", "dep:serde_json"]
+vendored = ["native-tls?/vendored"]
 
 # Underscore prefixed features are internal
 _url = ["dep:url"]

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ The default enabled features are: **rustls**, **gzip** and **json**.
    (e.g.  `Content-Type: text/plain; charset=iso-8859-1`). Without this, the
    library defaults to Rust's built in `utf-8`
 * **json** enables JSON sending and receiving via serde_json
-* **vendored** compiles and statically links to a copy of non-Rust vendors (e.g. OpenSSL from `native-tls`)
 
 ## TLS (https)
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The default enabled features are: **rustls**, **gzip** and **json**.
    (e.g.  `Content-Type: text/plain; charset=iso-8859-1`). Without this, the
    library defaults to Rust's built in `utf-8`
 * **json** enables JSON sending and receiving via serde_json
+* **vendored** compiles and statically links to a copy of non-Rust vendors (e.g. OpenSSL from `native-tls`)
 
 ## TLS (https)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@
 //!    (e.g.  `Content-Type: text/plain; charset=iso-8859-1`). Without this, the
 //!    library defaults to Rust's built in `utf-8`
 //! * **json** enables JSON sending and receiving via serde_json
+//! * **vendored** compiles and statically links to a copy of non-Rust vendors (e.g. OpenSSL from `native-tls`)
 //!
 //! # TLS (https)
 //!


### PR DESCRIPTION
This PR forwards the `vendored` cargo features to `native-tls`. Useful when users want to statically link OpenSSL.