### PR TITLE
disable_verification: Signal that all signature schemes are supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,6 +634,35 @@ pub(crate) mod test {
     }
 
     #[test]
+    #[cfg(feature = "rustls")]
+    fn connect_https_google_noverif() {
+        init_test_log();
+        use crate::tls::{TlsConfig, TlsProvider};
+
+        let agent: Agent = Config {
+            tls_config: TlsConfig {
+                provider: TlsProvider::Rustls,
+                disable_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+        .into();
+
+        let res = agent.get("https://www.google.com/").call().unwrap();
+        assert_eq!(
+            "text/html;charset=ISO-8859-1",
+            res.headers()
+                .get("content-type")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .replace("; ", ";")
+        );
+        assert_eq!(res.body().mime_type(), Some("text/html"));
+    }
+
+    #[test]
     fn simple_put_content_len() {
         init_test_log();
         let mut res = put("http://httpbin.org/put").send(&[0_u8; 100]).unwrap();

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -240,7 +240,20 @@ impl ServerCertVerifier for DisabledVerifier {
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        vec![]
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA1,
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::ED448,
+        ]
     }
 }
 


### PR DESCRIPTION
Without this, the server will not accept the connection because it can't use any signature scheme

This adds a test (against google.com) that fails without this change.

Close https://github.com/algesten/ureq/issues/869