### PR TITLE
Allow accessing last redirected Uri from Response<Body>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,6 +431,7 @@ use http::{Request, Response, Uri};
 pub use proxy::Proxy;
 pub use request::RequestBuilder;
 use request::{WithBody, WithoutBody};
+pub use response::ResponseExt;
 pub use send_body::AsSendBody;
 
 mod agent;
@@ -441,6 +442,7 @@ mod pool;
 mod proxy;
 mod query;
 mod request;
+mod response;
 mod run;
 mod send_body;
 mod timings;
@@ -711,6 +713,15 @@ pub(crate) mod test {
         assert_eq!(txt, "You've been redirected");
         #[cfg(not(feature = "_test"))]
         assert_eq!(txt, "");
+    }
+
+    #[test]
+    fn redirect_follow() {
+        let res = get("http://httpbin.org/redirect-to?url=%2Fget")
+            .call()
+            .unwrap();
+        let response_uri = res.get_uri();
+        assert_eq!(response_uri.path(), "/get")
     }
 
     #[test]

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,25 @@
+use http::Uri;
+
+use crate::body::Body;
+use crate::http;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResponseUri(pub http::Uri);
+
+/// Extension trait for `http::Response<Body>` objects
+///
+/// Allows the user to access the `Uri` in http::Response
+pub trait ResponseExt {
+    /// The Uri we ended up at. This can differ from the request uri when we have followed redirects.
+    fn get_uri(&self) -> &Uri;
+}
+
+impl ResponseExt for http::Response<Body> {
+    fn get_uri(&self) -> &Uri {
+        &self
+            .extensions()
+            .get::<ResponseUri>()
+            .expect("uri to have been set")
+            .0
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -14,6 +14,7 @@ use crate::body::ResponseInfo;
 use crate::config::{Config, RequestLevelConfig, DEFAULT_USER_AGENT};
 use crate::http;
 use crate::pool::Connection;
+use crate::response::ResponseUri;
 use crate::timings::{CallTimings, CurrentTime};
 use crate::transport::time::{Duration, Instant};
 use crate::transport::ConnectionDetails;
@@ -147,7 +148,7 @@ fn flow_run(
         SendRequestResult::RecvResponse(flow) => flow,
     };
 
-    let (response, response_result) = recv_response(flow, &mut connection, config, timings)?;
+    let (mut response, response_result) = recv_response(flow, &mut connection, config, timings)?;
 
     info!("{:?}", DebugResponse(&response));
 
@@ -164,6 +165,8 @@ fn flow_run(
 
         jar.store_response_cookies(iter, &uri);
     }
+
+    response.extensions_mut().insert(ResponseUri(uri));
 
     let ret = match response_result {
         RecvResponseResult::RecvBody(flow) => {

--- a/src/unversioned/transport/test.rs
+++ b/src/unversioned/transport/test.rs
@@ -290,13 +290,22 @@ fn setup_default_handlers(handlers: &mut Vec<TestHandler>) {
         TestHandler::new("/redirect-to", |_uri, _req, w| {
             write!(
                 w,
-                "HTTP/1.1 302 OK\r\n\
+                "HTTP/1.1 302 FOUND\r\n\
                 Location: /get\r\n\
                 Content-Length: 22\r\n\
                 \r\n\
                 You've been redirected\
                 ",
-            )
+            )?;
+            write!(
+                w,
+                "HTTP/1.1 200 OK\r\n\
+                Content-Type: application/json\r\n\
+                Content-Length: {}\r\n\
+                \r\n",
+                HTTPBIN_GET.as_bytes().len()
+            )?;
+            w.write_all(HTTPBIN_GET.as_bytes())
         }),
         handlers,
     );


### PR DESCRIPTION
Not sure where to put the documentation associated.

Related to https://github.com/algesten/ureq/issues/883