### PR TITLE
Prepare 2.12.0 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,49 +3,10 @@ on: [push, pull_request]
 name: CI
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -D warnings
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: Run Rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
-    - name: Run Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-  doc:
-    name: Docs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Docs
-        uses: actions-rs/cargo@v1
-        env:
-          RUSTDOCFLAGS: -Dwarnings
-        with:
-          command: doc
-          args: --no-deps --all-features --document-private-items
-
   build_versions:
     strategy:
       matrix:
-        rust: [stable, beta, 1.67.0]
+        rust: [1.71]
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
@@ -91,7 +52,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.71
           override: true
       - name: Test
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# 2.12.0
+
+  * Bump MSRV 1.67 -> 1.71 because rustls will soon adopt it (#883)
+  * Unpin rustls dep (>=0.23.19) (#883)
+
 # 2.11.0
 
  * Fixes for changes to cargo-deny (#882)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
  "base64",
  "brotli-decompressor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,6 @@ dependencies = [
  "hootbin",
  "http 0.2.12",
  "http 1.1.0",
- "litemap",
  "log",
  "native-tls",
  "once_cell",
@@ -947,8 +946,6 @@ dependencies = [
  "socks",
  "url",
  "webpki-roots",
- "yoke",
- "zerofrom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ureq"
-version = "2.11.0"
+version = "2.12.0"
 authors = ["Martin Algesten <martin@algesten.se>", "Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>"]
 description = "Simple, safe HTTP client"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 
 
 # MSRV
-rust-version = "1.67"
+rust-version = "1.71"
 
 [package.metadata.docs.rs]
 features = ["tls", "native-tls", "json", "charset", "cookies", "socks-proxy", "gzip", "brotli", "http-interop", "http-crate"]
@@ -58,12 +58,7 @@ brotli-decompressor = { version = "4.0.0", optional = true }
 http-02 = { package = "http", version = "0.2", optional = true }
 http = { version = "1.1", optional = true }
 url = "2.5.0"
-
-# These are locked down for MSRV 1.67
-rustls = { version = "=0.23.19", optional = true, default-features = false, features = ["ring", "logging", "std", "tls12"] }
-yoke = "=0.7.4"
-litemap = "=0.7.3"
-zerofrom = "=0.1.4"
+rustls = { version = ">=0.23.19", optional = true, default-features = false, features = ["ring", "logging", "std", "tls12"] }
 
 # This can't be in dev-dependencies due to doc tests.
 hootbin = { version = "0.1.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -23,13 +23,16 @@
 A simple, safe HTTP client.
 
 > [!NOTE]
+> * 2.12.x is MSRV 1.71, and we might bump it further (in minor versions).
+> * 2.11.x will remain MSRV 1.67 and we will release version with pinned dependencies
+> for as long as it's possible/wanted (please open issue/PR when needed).
+
+> [!NOTE]
 > ureq version 2.11.0 was forced to bump MSRV from 1.63 -> 1.67. The problem is that the
 > `time` crate 0.3.20, the last 1.63 compatible version, stopped compiling with Rust
 > [1.80 and above](https://github.com/algesten/ureq/pull/878#issuecomment-2503176155).
 > To release a 2.x version that is possible to compile on the latest Rust we were
 > forced to bump MSRV.
-
-
 
 Ureq's first priority is being easy for you to use. It's great for
 anyone who wants a low-overhead HTTP client that just gets the job done. Works

--- a/src/http_interop.rs
+++ b/src/http_interop.rs
@@ -279,11 +279,10 @@ impl From<Request> for http::request::Builder {
 #[cfg(test)]
 mod tests {
     use crate::header::{add_header, get_header_raw, HeaderLine};
-    use http_02 as http;
 
     #[test]
     fn convert_http_response() {
-        use http::{Response, StatusCode, Version};
+        use http_02::{Response, StatusCode, Version};
 
         let http_response_body = vec![0xaa; 10240];
         let http_response = Response::builder()
@@ -310,7 +309,7 @@ mod tests {
 
     #[test]
     fn convert_http_response_string() {
-        use http::{Response, StatusCode, Version};
+        use http_02::{Response, StatusCode, Version};
 
         let http_response_body = "Some body string".to_string();
         let http_response = Response::builder()
@@ -327,7 +326,7 @@ mod tests {
 
     #[test]
     fn convert_http_response_bad_header() {
-        use http::{Response, StatusCode, Version};
+        use http_02::{Response, StatusCode, Version};
 
         let http_response = Response::builder()
             .version(Version::HTTP_11)
@@ -344,7 +343,7 @@ mod tests {
 
     #[test]
     fn convert_to_http_response_string() {
-        use http::Response;
+        use http_02::Response;
 
         let mut response = super::Response::new(418, "I'm a teapot", "some body text").unwrap();
         response.headers.push(
@@ -371,7 +370,7 @@ mod tests {
 
     #[test]
     fn convert_to_http_response_bytes() {
-        use http::Response;
+        use http_02::Response;
         use std::io::Cursor;
 
         let mut response = super::Response::new(200, "OK", "tbr").unwrap();
@@ -388,7 +387,7 @@ mod tests {
 
     #[test]
     fn convert_http_response_builder_with_invalid_utf8_header() {
-        use http::Response;
+        use http_02::Response;
 
         let http_response = Response::builder()
             .header("Some-Key", b"some\xff\xffvalue".as_slice())
@@ -412,7 +411,7 @@ mod tests {
                 .unwrap(),
         );
         dbg!(&response);
-        let http_response: http::Response<Vec<u8>> = response.into();
+        let http_response: http_02::Response<Vec<u8>> = response.into();
 
         assert_eq!(
             http_response
@@ -425,7 +424,7 @@ mod tests {
 
     #[test]
     fn convert_http_request_builder() {
-        use http::Request;
+        use http_02::Request;
 
         let http_request = Request::builder()
             .method("PUT")
@@ -440,7 +439,7 @@ mod tests {
 
     #[test]
     fn convert_to_http_request_builder() {
-        use http::request::Builder;
+        use http_02::request::Builder;
 
         let request = crate::agent()
             .head("http://some-website.com")
@@ -456,12 +455,12 @@ mod tests {
             Some("some value")
         );
         assert_eq!(http_request.uri(), "http://some-website.com");
-        assert_eq!(http_request.version(), http::Version::HTTP_11);
+        assert_eq!(http_request.version(), http_02::Version::HTTP_11);
     }
 
     #[test]
     fn convert_http_request_builder_with_invalid_utf8_header() {
-        use http::Request;
+        use http_02::Request;
 
         let http_request = Request::builder()
             .method("PUT")
@@ -479,7 +478,7 @@ mod tests {
 
     #[test]
     fn convert_to_http_request_builder_with_invalid_utf8_header() {
-        use http::request::Builder;
+        use http_02::request::Builder;
 
         let mut request = crate::agent().head("http://some-website.com");
         add_header(
@@ -497,6 +496,6 @@ mod tests {
             Some(b"some\xff\xffvalue".as_slice())
         );
         assert_eq!(http_request.uri(), "http://some-website.com");
-        assert_eq!(http_request.version(), http::Version::HTTP_11);
+        assert_eq!(http_request.version(), http_02::Version::HTTP_11);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,16 @@
 //! A simple, safe HTTP client.
 //!
 //! > [!NOTE]
+//! > * 2.12.x is MSRV 1.71, and we might bump it further (in minor versions).
+//! > * 2.11.x will remain MSRV 1.67 and we will release version with pinned dependencies
+//! > for as long as it's possible/wanted (please open issue/PR when needed).
+//!
+//! > [!NOTE]
 //! > ureq version 2.11.0 was forced to bump MSRV from 1.63 -> 1.67. The problem is that the
 //! > `time` crate 0.3.20, the last 1.63 compatible version, stopped compiling with Rust
 //! > [1.80 and above](https://github.com/algesten/ureq/pull/878#issuecomment-2503176155).
 //! > To release a 2.x version that is possible to compile on the latest Rust we were
 //! > forced to bump MSRV.
-//!
-//!
 //!
 //! Ureq's first priority is being easy for you to use. It's great for
 //! anyone who wants a low-overhead HTTP client that just gets the job done. Works


### PR DESCRIPTION
2.12.0 is unpinning the rustls dep and bumps MSRV to 1.71.

The idea is that 2.12.x will be MSRV 1.71 and 2.11.x will be MSRV 1.67.