### PR TITLE
Bumps rust-url to v2.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ socks = { version = "0.3.4", optional = true }
 # cookie_store uses Url, while http-crate has its own Uri.
 # Keep url crate in lockstep with cookie_store.
 cookie_store = { version = "0.21.1", optional = true, default-features = false, features = ["preserve_order"] }
-url = { version = "2.3.1", optional = true, default-features = false }
+url = { version = "2.5.4", optional = true, default-features = false }
 
 flate2 = { version = "1.0.30", optional = true }
 brotli-decompressor = { version = "4.0.1", optional = true }


### PR DESCRIPTION
Hi, @algesten !

Raising this PR because I got a couple of Dependabot Security alerts on [idna](https://crates.io/crates/idna), which `ureq` depends on transitively via [rust-url](https://github.com/servo/rust-url).

Some reference links

- https://github.com/advisories/GHSA-h97m-ww89-6jmq
- https://rustsec.org/advisories/RUSTSEC-2024-0421.html

Since scanners will flag this dependency on projects using `ureq`, I'm following the what the advisories recommend and bumping `rust-url` to 2.5.4.

Apologies for raising the PR directly without an issue, hope that works for you 🙏

Thanks again for `ureq`, looking forward to v3.0.0 🚀