### PR TITLE
add `rustls-aws-lc-rs` feature for alternative to `ring`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+dependencies = [
+ "aws-lc-sys",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "paste",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +149,29 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2 1.0.92",
+ "quote 1.0.38",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.94",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -159,6 +207,8 @@ version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -169,10 +219,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -284,6 +363,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,10 +486,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -573,6 +685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,10 +720,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -635,6 +787,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +816,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -755,6 +923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +954,16 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2 1.0.92",
+ "syn 2.0.94",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -862,6 +1046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +1070,7 @@ version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -950,6 +1141,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1324,6 +1516,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "ureq"
 version = "3.0.0-rc4"
-authors = ["Martin Algesten <martin@algesten.se>", "Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>"]
+authors = [
+	"Martin Algesten <martin@algesten.se>",
+	"Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>",
+]
 description = "Simple, safe HTTP client"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/algesten/ureq"
@@ -16,11 +19,24 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 rust-version = "1.71.1"
 
 [package.metadata.docs.rs]
-features = ["rustls", "platform-verifier", "native-tls", "socks-proxy", "cookies", "gzip", "brotli", "charset", "json", "_test"]
+features = [
+	"rustls",
+	"platform-verifier",
+	"native-tls",
+	"socks-proxy",
+	"cookies",
+	"gzip",
+	"brotli",
+	"charset",
+	"json",
+	"_test",
+]
 
 [features]
-default = ["rustls", "gzip", "json"]
+default = ["rustls-aws-lc-rs", "gzip", "json"]
 rustls = ["dep:rustls", "_tls", "dep:webpki-roots"]
+rustls-ring = ["rustls", "rustls/ring"]
+rustls-aws-lc-rs = ["rustls", "rustls/aws-lc-rs"]
 platform-verifier = ["dep:rustls-platform-verifier"]
 native-tls = ["dep:native-tls", "dep:der", "_tls", "dep:webpki-root-certs"]
 socks-proxy = ["dep:socks"]
@@ -46,32 +62,50 @@ utf-8 = "0.7.6"
 percent-encoding = "2.3.1"
 
 # These are used regardless of TLS implementation.
-rustls-pemfile = { version = "2.1.2", optional = true, default-features = false, features = ["std"] }
-rustls-pki-types = { version = "1.7.0", optional = true, default-features = false, features = ["std"] }
+rustls-pemfile = { version = "2.1.2", optional = true, default-features = false, features = [
+	"std",
+] }
+rustls-pki-types = { version = "1.7.0", optional = true, default-features = false, features = [
+	"std",
+] }
 # rustls-platform-verifier held back due to 0.4.0 causing a double
 # depedendency on windows-sys (0.59.0, 0.52.0) and security-framework (2.11.1, 3.1.0)
 rustls-platform-verifier = { version = "0.3.4", optional = true, default-features = false }
 webpki-roots = { version = "0.26.3", optional = true, default-features = false }
 webpki-root-certs = { version = "0.26.4", optional = true, default-features = false }
 
-# ring has a higher chance of compiling cleanly without additional developer environment
-rustls = { version = "0.23.18", optional = true, default-features = false, features = ["ring", "logging", "std", "tls12"] }
+
+rustls = { version = "0.23.18", optional = true, default-features = false, features = [
+	# backend enabled by feature
+	"logging",
+	"std",
+	"tls12",
+] }
 native-tls = { version = "0.2.12", optional = true, default-features = false }
-der = { version = "0.7.9", optional = true, default-features = false, features = ["pem", "std"] }
+der = { version = "0.7.9", optional = true, default-features = false, features = [
+	"pem",
+	"std",
+] }
 
 socks = { version = "0.3.4", optional = true }
 
 # cookie_store uses Url, while http-crate has its own Uri.
 # Keep url crate in lockstep with cookie_store.
-cookie_store = { version = "0.21.1", optional = true, default-features = false, features = ["preserve_order"] }
+cookie_store = { version = "0.21.1", optional = true, default-features = false, features = [
+	"preserve_order",
+] }
 url = { version = "2.3.1", optional = true, default-features = false }
 
 flate2 = { version = "1.0.30", optional = true }
 brotli-decompressor = { version = "4.0.1", optional = true }
 encoding_rs = { version = "0.8.34", optional = true }
 
-serde = { version = "1.0.204", optional = true, default-features = false, features = ["std"] }
-serde_json = { version = "1.0.120", optional = true, default-features = false, features = ["std"] }
+serde = { version = "1.0.204", optional = true, default-features = false, features = [
+	"std",
+] }
+serde_json = { version = "1.0.120", optional = true, default-features = false, features = [
+	"std",
+] }
 
 [build-dependencies]
 cc = "1.0.106"
@@ -85,4 +119,12 @@ assert_no_alloc = "1.1.2"
 
 [[example]]
 name = "cureq"
-required-features = ["rustls", "native-tls", "socks-proxy", "cookies", "gzip", "brotli", "charset"]
+required-features = [
+	"rustls",
+	"native-tls",
+	"socks-proxy",
+	"cookies",
+	"gzip",
+	"brotli",
+	"charset",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ features = [
 ]
 
 [features]
-default = ["rustls-aws-lc-rs", "gzip", "json"]
-rustls = ["dep:rustls", "_tls", "dep:webpki-roots"]
+default = ["rustls-ring", "gzip", "json"]
 rustls-ring = ["rustls", "rustls/ring"]
 rustls-aws-lc-rs = ["rustls", "rustls/aws-lc-rs"]
+rustls = ["dep:rustls", "_tls", "dep:webpki-roots"]
 platform-verifier = ["dep:rustls-platform-verifier"]
 native-tls = ["dep:native-tls", "dep:der", "_tls", "dep:webpki-root-certs"]
 socks-proxy = ["dep:socks"]

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use once_cell::sync::OnceCell;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-use rustls::crypto::CryptoProvider;
 use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned, ALL_VERSIONS};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer};
 use rustls_pki_types::{PrivateSec1KeyDer, ServerName};


### PR DESCRIPTION
I hope you dont mind me opening a pr without prior discussion, feel free to close for whatever reason.

We're working on adding ureq as a bevy dependency, its lightweight nature is perfect for a game engine, but we're unable to use ring due to its license requiring us to make acknowledgements in all advertising material.

This pr adds two features, each of which enables the `rustls` feature:
- `rustls-ring` (default)
- `rustls-aws-lc-rs`

More info for context:

- [bevy ureq pr](https://github.com/bevyengine/bevy/pull/16366)
- [ring licencing issues](https://github.com/briansmith/ring/issues/1827)
- [ureq aws-lc-rs discussion 1](https://github.com/algesten/ureq/issues/751)
- [ureq aws-lc-rs discussion 2](https://github.com/algesten/ureq/issues/765)
  - > You can certainly still use aws_lc_rs with ureq by taking your own rustls dep, activating that feature, and using AgentBuilder::tls_config to provide your own config.
    
    I'm not sure this solution would be accepted in bevy, both as a licensing grey area and the dependency bloat from having two crypto providers