### PR TITLE
Body::discard and content_length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Body::content_length (#927)
+  * Body::discard() (#927)
   * Handle Authorization: Basic from URI (#923)
   * Remove many uses of Box::new() from Connector chain (#919)
 

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::sync::Arc;
 
 pub use build::BodyBuilder;
+use ureq_proto::http::header;
 use ureq_proto::BodyMode;
 
 use crate::http;
@@ -428,13 +429,13 @@ enum ContentEncoding {
 impl ResponseInfo {
     pub fn new(headers: &http::HeaderMap, body_mode: BodyMode) -> Self {
         let content_encoding = headers
-            .get("content-encoding")
+            .get(header::CONTENT_ENCODING)
             .and_then(|v| v.to_str().ok())
             .map(ContentEncoding::from)
             .unwrap_or(ContentEncoding::None);
 
         let (mime_type, charset) = headers
-            .get("content-type")
+            .get(header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
             .map(split_content_type)
             .unwrap_or((None, None));

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -315,6 +315,20 @@ impl Body {
         let handler = self.source.into();
         BodyWithConfig::new(handler, self.info.clone())
     }
+
+    /// Discards the body up to `max` bytes.
+    ///
+    /// This is useful if you want to discard the body without reading it. The connection
+    /// will be returned to the pool (if applicable) and ureq will be able to reuse it.
+    ///
+    /// If the body is bigger than `max`, the connection can't be reused and will be closed.
+    ///
+    /// Before calling this you can check the body size using [`Body::content_length()`]. However
+    /// if the body is chunked or close delimited, the size is unknown.
+    pub fn discard(mut self, max: u64) -> Result<(), Error> {
+        self.as_reader().discard(max)?;
+        Ok(())
+    }
 }
 
 /// Configuration of how to read the body.
@@ -596,6 +610,19 @@ impl<'a> BodyReader<'a> {
     pub(crate) fn body_mode(&self) -> BodyMode {
         self.outgoing_body_mode
     }
+
+    fn discard(&mut self, max: u64) -> Result<(), Error> {
+        let mut buf = [0; 10 * 1024];
+        let mut n = 0;
+        while n < max {
+            let read = self.reader.read(&mut buf)?;
+            if read == 0 {
+                break;
+            }
+            n += read as u64;
+        }
+        Ok(())
+    }
 }
 
 #[allow(unused)]
@@ -712,6 +739,7 @@ impl<'a> From<&'a mut BodyDataSource> for BodySourceRef<'a> {
         }
     }
 }
+
 impl From<BodyDataSource> for BodySourceRef<'static> {
     fn from(value: BodyDataSource) -> Self {
         match value {


### PR DESCRIPTION
- **Replace some header names with constants**
- **Body::content_length() for known sizes**
- **Body::discard() to discard and re-pool connection**
