### PR TITLE
Remove (unreleased) Body::discard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
 
   * Body::content_length (#927)
-  * Body::discard() (#927)
   * Handle Authorization: Basic from URI (#923)
   * Remove many uses of Box::new() from Connector chain (#919)
 


### PR DESCRIPTION
This function clutters the API and is only partially useful since it
requires an owned Body, i.e. it cannot be used with
Response::body_mut(). It is also not useful if the user has "peeked"
the body via a Reader.
