### PR TITLE
Redirect history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # 3.0.0-rc5
 
+  * Feature `Config::save_redirect_history` (#939)
   * `TlsConfig::unversioned_rustls_crypto_provider()` (#931)
   * Feature `rustls-no-provider` to compile without ring (#931)
   * Fix CONNECT proxy Host header (#936)

--- a/src/body/lossy.rs
+++ b/src/body/lossy.rs
@@ -58,7 +58,7 @@ impl<R: io::Read> io::Read for LossyUtf8Reader<R> {
                     invalid_sequence,
                     ..
                 } => {
-                    let valid_len = valid_prefix.as_bytes().len();
+                    let valid_len = valid_prefix.len();
                     let invalid_len = invalid_sequence.len();
 
                     // Switch out the problem input chars

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,6 +145,7 @@ pub struct Config {
     max_redirects: u32,
     max_redirects_will_error: bool,
     redirect_auth_headers: RedirectAuthHeaders,
+    save_redirect_history: bool,
     user_agent: AutoHeaderValue,
     accept: AutoHeaderValue,
     accept_encoding: AutoHeaderValue,
@@ -275,6 +276,17 @@ impl Config {
     /// Defaults to `None`.
     pub fn redirect_auth_headers(&self) -> RedirectAuthHeaders {
         self.redirect_auth_headers
+    }
+
+    /// If we should record a history of every redirect location,
+    /// including the request and final locations.
+    ///
+    /// Comes at the cost of allocating/retaining the Uri for
+    /// every redirect loop.
+    ///
+    /// Defaults to false
+    pub fn save_redirect_history(&self) -> bool {
+        self.save_redirect_history
     }
 
     /// Value to use for the `User-Agent` header.
@@ -479,6 +491,18 @@ impl<Scope: private::ConfigScope> ConfigBuilder<Scope> {
     /// Defaults to `None`.
     pub fn redirect_auth_headers(mut self, v: RedirectAuthHeaders) -> Self {
         self.config().redirect_auth_headers = v;
+        self
+    }
+
+    /// If we should record a history of every redirect location,
+    /// including the request and final locations.
+    ///
+    /// Comes at the cost of allocating/retaining the Uri for
+    /// every redirect loop.
+    ///
+    /// Defaults to false
+    pub fn save_redirect_history(mut self, v: bool) -> Self {
+        self.config().save_redirect_history = v;
         self
     }
 
@@ -809,6 +833,7 @@ impl Default for Config {
             max_redirects: 10,
             max_redirects_will_error: true,
             redirect_auth_headers: RedirectAuthHeaders::Never,
+            save_redirect_history: false,
             user_agent: AutoHeaderValue::default(),
             accept: AutoHeaderValue::default(),
             accept_encoding: AutoHeaderValue::default(),
@@ -884,6 +909,7 @@ impl fmt::Debug for Config {
             .field("no_delay", &self.no_delay)
             .field("max_redirects", &self.max_redirects)
             .field("redirect_auth_headers", &self.redirect_auth_headers)
+            .field("save_redirect_history", &self.save_redirect_history)
             .field("user_agent", &self.user_agent)
             .field("timeouts", &self.timeouts)
             .field("max_response_header_size", &self.max_response_header_size)

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,10 +281,12 @@ impl Config {
     /// If we should record a history of every redirect location,
     /// including the request and final locations.
     ///
-    /// Comes at the cost of allocating/retaining the Uri for
+    /// Comes at the cost of allocating/retaining the `Uri` for
     /// every redirect loop.
     ///
-    /// Defaults to false
+    /// See [`ResponseExt::get_redirect_history()`][crate::ResponseExt::get_redirect_history].
+    ///
+    /// Defaults to `false`.
     pub fn save_redirect_history(&self) -> bool {
         self.save_redirect_history
     }
@@ -497,10 +499,12 @@ impl<Scope: private::ConfigScope> ConfigBuilder<Scope> {
     /// If we should record a history of every redirect location,
     /// including the request and final locations.
     ///
-    /// Comes at the cost of allocating/retaining the Uri for
+    /// Comes at the cost of allocating/retaining the `Uri` for
     /// every redirect loop.
     ///
-    /// Defaults to false
+    /// See [`ResponseExt::get_redirect_history()`][crate::ResponseExt::get_redirect_history].
+    ///
+    /// Defaults to `false`.
     pub fn save_redirect_history(mut self, v: bool) -> Self {
         self.config().save_redirect_history = v;
         self

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,12 +6,20 @@ use crate::http;
 #[derive(Debug, Clone)]
 pub(crate) struct ResponseUri(pub http::Uri);
 
+#[derive(Debug, Clone)]
+pub(crate) struct RedirectHistory(pub Vec<Uri>);
+
 /// Extension trait for `http::Response<Body>` objects
 ///
 /// Allows the user to access the `Uri` in http::Response
 pub trait ResponseExt {
     /// The Uri we ended up at. This can differ from the request uri when we have followed redirects.
     fn get_uri(&self) -> &Uri;
+
+    /// The full history of uris, including the request and final uri.
+    ///
+    /// Returns None when `save_redirect_history` is false.
+    fn get_redirect_history(&self) -> Option<&[Uri]>;
 }
 
 impl ResponseExt for http::Response<Body> {
@@ -21,5 +29,11 @@ impl ResponseExt for http::Response<Body> {
             .get::<ResponseUri>()
             .expect("uri to have been set")
             .0
+    }
+
+    fn get_redirect_history(&self) -> Option<&[Uri]> {
+        self.extensions()
+            .get::<RedirectHistory>()
+            .map(|r| r.0.as_ref())
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -9,16 +9,48 @@ pub(crate) struct ResponseUri(pub http::Uri);
 #[derive(Debug, Clone)]
 pub(crate) struct RedirectHistory(pub Vec<Uri>);
 
-/// Extension trait for `http::Response<Body>` objects
+/// Extension trait for [`http::Response<Body>`].
 ///
-/// Allows the user to access the `Uri` in http::Response
+/// Adds additional convenience methods to the `Response` that are not available
+/// in the plain http API.
 pub trait ResponseExt {
-    /// The Uri we ended up at. This can differ from the request uri when we have followed redirects.
+    /// The Uri that ultimately this Response is about.
+    ///
+    /// This can differ from the request uri when we have followed redirects.
+    ///
+    /// ```
+    /// use ureq::ResponseExt;
+    ///
+    /// let res = ureq::get("https://httpbin.org/redirect-to?url=%2Fget")
+    ///     .call().unwrap();
+    ///
+    /// assert_eq!(res.get_uri(), "https://httpbin.org/get");
+    /// ```
     fn get_uri(&self) -> &Uri;
 
     /// The full history of uris, including the request and final uri.
     ///
-    /// Returns None when `save_redirect_history` is false.
+    /// Returns `None` when [`Config::save_redirect_history`][crate::config::Config::save_redirect_history]
+    /// is `false`.
+    ///
+    ///
+    /// ```
+    /// # use ureq::http::Uri;
+    /// use ureq::ResponseExt;
+    ///
+    /// let uri1: Uri = "https://httpbin.org/redirect-to?url=%2Fget".parse().unwrap();
+    /// let uri2: Uri = "https://httpbin.org/get".parse::<Uri>().unwrap();
+    ///
+    /// let res = ureq::get(&uri1)
+    ///     .config()
+    ///     .save_redirect_history(true)
+    ///     .build()
+    ///     .call().unwrap();
+    ///
+    /// let history = res.get_redirect_history().unwrap();
+    ///
+    /// assert_eq!(history, &[uri1, uri2]);
+    /// ```
     fn get_redirect_history(&self) -> Option<&[Uri]>;
 }
 


### PR DESCRIPTION
#731
Adds the option `.save_redirect_history(bool)` to the config.
When true the function `get_redirect_history()` on the `ResponseExt` trait returns a `Some(&[Uri])` which will contain the request, any redirects, and the final uris.
When false `get_redirect_history()` returns `None`.