### PR TITLE
Use std::sync::OnceLock instead of once_cell::sync::Lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,6 @@ dependencies = [
  "flate2",
  "log",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "rustls",
  "rustls-pemfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ base64 = "0.22.1"
 ureq-proto = "0.2.5"
 # ureq-proto = { path = "../ureq-proto" }
 log = "0.4.22"
-once_cell = "1.19.0"
 utf-8 = "0.7.6"
 percent-encoding = "2.3.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,11 +596,10 @@ mk_method!(trace, TRACE, WithoutBody);
 
 #[cfg(test)]
 pub(crate) mod test {
-    use std::io;
+    use std::{io, sync::OnceLock};
 
     use assert_no_alloc::AllocDisabler;
     use config::{Config, ConfigBuilder};
-    use once_cell::sync::Lazy;
     use typestate::AgentScope;
 
     use super::*;
@@ -610,8 +609,8 @@ pub(crate) mod test {
     static A: AllocDisabler = AllocDisabler;
 
     pub fn init_test_log() {
-        static INIT_LOG: Lazy<()> = Lazy::new(env_logger::init);
-        *INIT_LOG
+        static INIT_LOG: OnceLock<()> = OnceLock::new();
+        INIT_LOG.get_or_init(|| env_logger::init());
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::{io, mem};
 
 use http::uri::Scheme;
 use http::{header, HeaderValue, Request, Response, Uri};
-use once_cell::sync::Lazy;
 use ureq_proto::client::flow::state::{Await100, RecvBody, RecvResponse, Redirect, SendRequest};
 use ureq_proto::client::flow::state::{Prepare, SendBody as SendBodyState};
 use ureq_proto::client::flow::{Await100Result, RecvBodyResult};
@@ -267,7 +266,9 @@ fn add_headers(
     }
 
     {
-        static ACCEPTS: Lazy<String> = Lazy::new(|| {
+        static ACCEPTS: OnceLock<String> = OnceLock::new();
+
+        let accepts = ACCEPTS.get_or_init(|| {
             #[allow(unused_mut)]
             let mut value = String::with_capacity(10);
             #[cfg(feature = "gzip")]
@@ -278,8 +279,9 @@ fn add_headers(
             value.push_str("br");
             value
         });
+
         if !has_header_accept_enc {
-            if let Some(v) = config.accept_encoding().as_str(&ACCEPTS) {
+            if let Some(v) = config.accept_encoding().as_str(accepts) {
                 // unwrap is ok because above ACCEPTS will produce a valid value,
                 // or the value is user provided in which case it must be valid.
                 let value = HeaderValue::from_str(v).unwrap();

--- a/src/tls/native_tls.rs
+++ b/src/tls/native_tls.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::fmt;
 use std::io::{Read, Write};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use crate::tls::{RootCerts, TlsProvider};
 use crate::{transport::*, Error};
@@ -9,7 +9,6 @@ use der::pem::LineEnding;
 use der::Document;
 use native_tls::{Certificate, HandshakeError, Identity, TlsConnector};
 use native_tls::{TlsConnectorBuilder, TlsStream};
-use once_cell::sync::OnceCell;
 
 use super::TlsConfig;
 
@@ -18,7 +17,7 @@ use super::TlsConfig;
 /// Requires feature flag **native-tls**.
 #[derive(Default)]
 pub struct NativeTlsConnector {
-    connector: OnceCell<Arc<TlsConnector>>,
+    connector: OnceLock<Arc<TlsConnector>>,
 }
 
 impl<In: Transport> Connector<In> for NativeTlsConnector {

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -1,9 +1,8 @@
 use std::convert::TryInto;
 use std::fmt;
 use std::io::{Read, Write};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use once_cell::sync::OnceCell;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::crypto::CryptoProvider;
 use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned, ALL_VERSIONS};
@@ -23,7 +22,7 @@ use super::TlsConfig;
 /// Requires feature flag **rustls**.
 #[derive(Default)]
 pub struct RustlsConnector {
-    config: OnceCell<Arc<ClientConfig>>,
+    config: OnceLock<Arc<ClientConfig>>,
 }
 
 impl<In: Transport> Connector<In> for RustlsConnector {


### PR DESCRIPTION
This is a revival of #725 but for ureq 3.0 adhering to the "lightweight" spirit of this library.
MSRV is 1.71.1 and `OnceLock` was added in 1.70.0 therefore no bump is required.

I'm not exactly sure if the changes to public structs in `tls/` are OK.