### PR TITLE
proxy: use the same data for CONNECT and Host header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Use the same data in CONNECT and Host header for proxied requests (#967)
   * Set default scheme in proxy uri (#966)
   * Redact URI and Location header on debug level (#964)
   * Downgrade all logging to debug and below (#964)

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -244,7 +244,7 @@ impl<In: Transport> Connector<In> for ConnectProxyConnector {
             .unwrap_or(proxied.scheme().unwrap().default_port().unwrap());
 
         write!(w, "CONNECT {}:{} HTTP/1.1\r\n", proxied_host, proxied_port)?;
-        write!(w, "Host: {}:{}\r\n", proxy.host(), proxy.port())?;
+        write!(w, "Host: {}:{}\r\n", proxied_host, proxied_port)?;
         if let Some(v) = details.config.user_agent().as_str(DEFAULT_USER_AGENT) {
             write!(w, "User-Agent: {}\r\n", v)?;
         }


### PR DESCRIPTION
The CONNECT and Host header should both point to the proxied host that we want to eventually reach, not to the proxy itself.

I'm no expert on proxies but MDN suggest that these headers should use the same data: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT

Also I used to be able to send proxied requests via `socat` to an Nginx with ureq < 3.0.0 and now it doesn't work anymore. `socat` now forwards the HTTP request as is to Nginx (telling me it doesn't recognize it as a valid proxy request) and Nginx replies with a 400. In previous ureq versions the CONNECT and Host headers used the same data: https://github.com/algesten/ureq/blob/2.12.1/src/proxy.rs#L187