### PR TITLE
Turn macros into regular code

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -247,37 +247,97 @@ impl Agent {
     pub(crate) fn new_request_level_config(&self) -> RequestLevelConfig {
         RequestLevelConfig(self.config.as_ref().clone())
     }
-}
 
-macro_rules! mk_method {
-    ($(($f:tt, $m:tt, $b:ty)),*) => {
-        impl Agent {
-            $(
-                #[doc = concat!("Make a ", stringify!($m), " request using this agent.")]
-                #[must_use]
-                pub fn $f<T>(&self, uri: T) -> RequestBuilder<$b>
-                where
-                    Uri: TryFrom<T>,
-                    <Uri as TryFrom<T>>::Error: Into<http::Error>,
-                {
-                    RequestBuilder::<$b>::new(self.clone(), Method::$m, uri)
-                }
-            )*
-        }
-    };
-}
+    /// Make a GET request using this agent.
+    #[must_use]
+    pub fn get<T>(&self, uri: T) -> RequestBuilder<WithoutBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithoutBody>::new(self.clone(), Method::GET, uri)
+    }
 
-mk_method!(
-    (get, GET, WithoutBody),
-    (post, POST, WithBody),
-    (put, PUT, WithBody),
-    (delete, DELETE, WithoutBody),
-    (head, HEAD, WithoutBody),
-    (options, OPTIONS, WithoutBody),
-    (connect, CONNECT, WithoutBody),
-    (patch, PATCH, WithBody),
-    (trace, TRACE, WithoutBody)
-);
+    /// Make a POST request using this agent.
+    #[must_use]
+    pub fn post<T>(&self, uri: T) -> RequestBuilder<WithBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithBody>::new(self.clone(), Method::POST, uri)
+    }
+
+    /// Make a PUT request using this agent.
+    #[must_use]
+    pub fn put<T>(&self, uri: T) -> RequestBuilder<WithBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithBody>::new(self.clone(), Method::PUT, uri)
+    }
+
+    /// Make a DELETE request using this agent.
+    #[must_use]
+    pub fn delete<T>(&self, uri: T) -> RequestBuilder<WithoutBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithoutBody>::new(self.clone(), Method::DELETE, uri)
+    }
+
+    /// Make a HEAD request using this agent.
+    #[must_use]
+    pub fn head<T>(&self, uri: T) -> RequestBuilder<WithoutBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithoutBody>::new(self.clone(), Method::HEAD, uri)
+    }
+
+    /// Make an OPTIONS request using this agent.
+    #[must_use]
+    pub fn options<T>(&self, uri: T) -> RequestBuilder<WithoutBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithoutBody>::new(self.clone(), Method::OPTIONS, uri)
+    }
+
+    /// Make a CONNECT request using this agent.
+    #[must_use]
+    pub fn connect<T>(&self, uri: T) -> RequestBuilder<WithoutBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithoutBody>::new(self.clone(), Method::CONNECT, uri)
+    }
+
+    /// Make a PATCH request using this agent.
+    #[must_use]
+    pub fn patch<T>(&self, uri: T) -> RequestBuilder<WithBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithBody>::new(self.clone(), Method::PATCH, uri)
+    }
+
+    /// Make a TRACE request using this agent.
+    #[must_use]
+    pub fn trace<T>(&self, uri: T) -> RequestBuilder<WithoutBody>
+    where
+        Uri: TryFrom<T>,
+        <Uri as TryFrom<T>>::Error: Into<http::Error>,
+    {
+        RequestBuilder::<WithoutBody>::new(self.clone(), Method::TRACE, uri)
+    }
+}
 
 impl From<Config> for Agent {
     fn from(value: Config) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,29 +584,113 @@ pub fn agent() -> Agent {
     Agent::new_with_defaults()
 }
 
-macro_rules! mk_method {
-    ($f:tt, $m:tt, $b:ty) => {
-        #[doc = concat!("Make a ", stringify!($m), " request.\n\nRun on a use-once [`Agent`].")]
-        #[must_use]
-        pub fn $f<T>(uri: T) -> RequestBuilder<$b>
-        where
-            Uri: TryFrom<T>,
-            <Uri as TryFrom<T>>::Error: Into<http::Error>,
-        {
-            RequestBuilder::<$b>::new(Agent::new_with_defaults(), Method::$m, uri)
-        }
-    };
+/// Make a GET request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn get<T>(uri: T) -> RequestBuilder<WithoutBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithoutBody>::new(Agent::new_with_defaults(), Method::GET, uri)
 }
 
-mk_method!(get, GET, WithoutBody);
-mk_method!(post, POST, WithBody);
-mk_method!(put, PUT, WithBody);
-mk_method!(delete, DELETE, WithoutBody);
-mk_method!(head, HEAD, WithoutBody);
-mk_method!(options, OPTIONS, WithoutBody);
-mk_method!(connect, CONNECT, WithoutBody);
-mk_method!(patch, PATCH, WithBody);
-mk_method!(trace, TRACE, WithoutBody);
+/// Make a POST request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn post<T>(uri: T) -> RequestBuilder<WithBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithBody>::new(Agent::new_with_defaults(), Method::POST, uri)
+}
+
+/// Make a PUT request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn put<T>(uri: T) -> RequestBuilder<WithBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithBody>::new(Agent::new_with_defaults(), Method::PUT, uri)
+}
+
+/// Make a DELETE request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn delete<T>(uri: T) -> RequestBuilder<WithoutBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithoutBody>::new(Agent::new_with_defaults(), Method::DELETE, uri)
+}
+
+/// Make a HEAD request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn head<T>(uri: T) -> RequestBuilder<WithoutBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithoutBody>::new(Agent::new_with_defaults(), Method::HEAD, uri)
+}
+
+/// Make an OPTIONS request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn options<T>(uri: T) -> RequestBuilder<WithoutBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithoutBody>::new(Agent::new_with_defaults(), Method::OPTIONS, uri)
+}
+
+/// Make a CONNECT request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn connect<T>(uri: T) -> RequestBuilder<WithoutBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithoutBody>::new(Agent::new_with_defaults(), Method::CONNECT, uri)
+}
+
+/// Make a PATCH request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn patch<T>(uri: T) -> RequestBuilder<WithBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithBody>::new(Agent::new_with_defaults(), Method::PATCH, uri)
+}
+
+/// Make a TRACE request.
+///
+/// Run on a use-once [`Agent`].
+#[must_use]
+pub fn trace<T>(uri: T) -> RequestBuilder<WithoutBody>
+where
+    Uri: TryFrom<T>,
+    <Uri as TryFrom<T>>::Error: Into<http::Error>,
+{
+    RequestBuilder::<WithoutBody>::new(Agent::new_with_defaults(), Method::TRACE, uri)
+}
 
 #[cfg(test)]
 pub(crate) mod test {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -123,26 +123,41 @@ impl Proxy {
     ///
     /// Returns `None` if no environment variable is set or the URI is invalid.
     pub fn try_from_env() -> Option<Self> {
-        macro_rules! try_env {
-            ($($env:literal),+) => {
-                $(
-                    if let Ok(env) = std::env::var($env) {
-                        if let Ok(proxy) = Self::new_with_flag(&env, true) {
-                            return Some(proxy);
-                        }
-                    }
-                )+
-            };
+        if let Ok(env) = std::env::var("ALL_PROXY") {
+            if let Ok(proxy) = Self::new_with_flag(&env, true) {
+                return Some(proxy);
+            }
         }
 
-        try_env!(
-            "ALL_PROXY",
-            "all_proxy",
-            "HTTPS_PROXY",
-            "https_proxy",
-            "HTTP_PROXY",
-            "http_proxy"
-        );
+        if let Ok(env) = std::env::var("all_proxy") {
+            if let Ok(proxy) = Self::new_with_flag(&env, true) {
+                return Some(proxy);
+            }
+        }
+
+        if let Ok(env) = std::env::var("HTTPS_PROXY") {
+            if let Ok(proxy) = Self::new_with_flag(&env, true) {
+                return Some(proxy);
+            }
+        }
+
+        if let Ok(env) = std::env::var("https_proxy") {
+            if let Ok(proxy) = Self::new_with_flag(&env, true) {
+                return Some(proxy);
+            }
+        }
+
+        if let Ok(env) = std::env::var("HTTP_PROXY") {
+            if let Ok(proxy) = Self::new_with_flag(&env, true) {
+                return Some(proxy);
+            }
+        }
+
+        if let Ok(env) = std::env::var("http_proxy") {
+            if let Ok(proxy) = Self::new_with_flag(&env, true) {
+                return Some(proxy);
+            }
+        }
         None
     }
 

--- a/src/send_body.rs
+++ b/src/send_body.rs
@@ -211,40 +211,82 @@ impl<'a> BodyInner<'a> {
     }
 }
 
-macro_rules! impl_into_body_slice {
-    ($t:ty) => {
-        impl Private for $t {}
-        impl AsSendBody for $t {
-            fn as_body(&mut self) -> SendBody {
-                BodyInner::ByteSlice((*self).as_ref()).into()
-            }
-        }
-    };
+impl Private for &[u8] {}
+impl AsSendBody for &[u8] {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::ByteSlice(self).into()
+    }
 }
 
-impl_into_body_slice!(&[u8]);
-impl_into_body_slice!(&str);
-impl_into_body_slice!(String);
-impl_into_body_slice!(Vec<u8>);
-impl_into_body_slice!(&String);
-impl_into_body_slice!(&Vec<u8>);
-
-macro_rules! impl_into_body {
-    ($t:ty, $s:tt) => {
-        impl Private for $t {}
-        impl AsSendBody for $t {
-            fn as_body(&mut self) -> SendBody {
-                BodyInner::$s(self).into()
-            }
-        }
-    };
+impl Private for &str {}
+impl AsSendBody for &str {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::ByteSlice((*self).as_ref()).into()
+    }
 }
 
-impl_into_body!(&File, Reader);
-impl_into_body!(&TcpStream, Reader);
-impl_into_body!(File, Reader);
-impl_into_body!(TcpStream, Reader);
-impl_into_body!(Stdin, Reader);
+impl Private for String {}
+impl AsSendBody for String {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::ByteSlice((*self).as_ref()).into()
+    }
+}
+
+impl Private for Vec<u8> {}
+impl AsSendBody for Vec<u8> {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::ByteSlice((*self).as_ref()).into()
+    }
+}
+
+impl Private for &String {}
+impl AsSendBody for &String {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::ByteSlice((*self).as_ref()).into()
+    }
+}
+
+impl Private for &Vec<u8> {}
+impl AsSendBody for &Vec<u8> {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::ByteSlice((*self).as_ref()).into()
+    }
+}
+
+impl Private for &File {}
+impl AsSendBody for &File {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::Reader(self).into()
+    }
+}
+
+impl Private for &TcpStream {}
+impl AsSendBody for &TcpStream {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::Reader(self).into()
+    }
+}
+
+impl Private for File {}
+impl AsSendBody for File {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::Reader(self).into()
+    }
+}
+
+impl Private for TcpStream {}
+impl AsSendBody for TcpStream {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::Reader(self).into()
+    }
+}
+
+impl Private for Stdin {}
+impl AsSendBody for Stdin {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::Reader(self).into()
+    }
+}
 
 // MSRV 1.78
 // impl_into_body!(&Stdin, Reader);
@@ -253,7 +295,13 @@ impl_into_body!(Stdin, Reader);
 use std::os::unix::net::UnixStream;
 
 #[cfg(target_family = "unix")]
-impl_into_body!(UnixStream, Reader);
+impl Private for UnixStream {}
+#[cfg(target_family = "unix")]
+impl AsSendBody for UnixStream {
+    fn as_body(&mut self) -> SendBody {
+        BodyInner::Reader(self).into()
+    }
+}
 
 impl<'a> From<BodyInner<'a>> for SendBody<'a> {
     fn from(inner: BodyInner<'a>) -> Self {


### PR DESCRIPTION
Macros are not cached between compilations. Rewrite all macros to regular code.