### PR TITLE
Add support for tcp keepalive through socket2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "socks"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1426,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "socket2",
  "socks",
  "ureq-proto",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ gzip = ["dep:flate2"]
 brotli = ["dep:brotli-decompressor"]
 charset = ["dep:encoding_rs"]
 json = ["dep:serde", "dep:serde_json", "cookie_store?/serde_json"]
+keepalive = ["dep:socket2", "socket2/all"]
 
 ######## UNSTABLE FEATURES.
 # Might be removed or changed in a minor version.
@@ -90,6 +91,7 @@ encoding_rs = { version = "0.8.34", optional = true }
 
 serde = { version = "1.0.138", optional = true, default-features = false, features = ["std"] }
 serde_json = { version = "1.0.120", optional = true, default-features = false, features = ["std"] }
+socket2 = { version = "0.5.8", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11.6"


### PR DESCRIPTION
Not fully implemented, probably should be using a custom structure for `TcpKeepalive` to avoid exposing `socket2` publicly.

In that case, should we have the same feature flag as the `socket2` library? Or should we allow each setting and just warn when one is not available for the given platform ?

Fixes https://github.com/algesten/ureq/issues/547