### PR TITLE
Making sure we error correctly when an invalid uri is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Fix panic when parsing malformed proxy URI (#990)
   * ureq::Error wrapped as io::Error should pass through body chain (#984)
   * send_json should set content-length header (#983)
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -481,5 +481,4 @@ mod test {
         let result = Proxy::new_with_flag("r32/?//52:**", false);
         assert!(result.is_err());
     }
-
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -84,7 +84,7 @@ impl Proxy {
     }
 
     fn new_with_flag(proxy: &str, from_env: bool) -> Result<Self, Error> {
-        let mut uri = proxy.parse::<Uri>().unwrap();
+        let mut uri = proxy.parse::<Uri>().or(Err(Error::InvalidProxyUrl))?;
 
         // The uri must have an authority part (with the host), or
         // it is invalid.
@@ -469,4 +469,17 @@ mod test {
         assert_eq!(c.proto(), Proto::Http);
         assert_eq!(c.uri(), "http://localhost:1234");
     }
+
+    #[test]
+    fn proxy_empty_env_url() {
+        let result = Proxy::new_with_flag("", false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn proxy_invalid_env_url() {
+        let result = Proxy::new_with_flag("r32/?//52:**", false);
+        assert!(result.is_err());
+    }
+
 }


### PR DESCRIPTION
Fixes issue #989 

When the URI is either empty or invalid, the unwrap() will fail so we will catch this and return a correct error result.