### PR TITLE
Create RequestExtension trait that allows for attaching agents directly to `http::Request`.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use http::Uri;
 
-use crate::{http, Body, Error};
 use crate::middleware::{Middleware, MiddlewareChain};
+use crate::{http, Body, Error};
 use crate::{Agent, AsSendBody, Proxy, RequestBuilder};
 
 #[cfg(feature = "_tls")]
@@ -25,8 +25,8 @@ mod private {
 }
 
 pub(crate) mod typestate {
-    use crate::request_ext::WithAgent;
     use super::*;
+    use crate::request_ext::WithAgent;
 
     /// Typestate for [`Config`] when configured for an [`Agent`].
     pub struct AgentScope(pub(crate) Config);
@@ -65,12 +65,12 @@ pub(crate) mod typestate {
     }
 }
 
-use typestate::AgentScope;
-use typestate::HttpCrateScope;
-use typestate::RequestScope;
 use crate::config::typestate::RequestExtScope;
 use crate::http::Response;
 use crate::request_ext::WithAgent;
+use typestate::AgentScope;
+use typestate::HttpCrateScope;
+use typestate::RequestScope;
 
 /// Config primarily for the [`Agent`], but also per-request.
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,7 @@ pub(crate) mod typestate {
     pub struct RequestScope<Any>(pub(crate) RequestBuilder<Any>);
     /// Typestate for for [`Config`] when configured via [`Agent::configure_request`].
     pub struct HttpCrateScope<S: AsSendBody>(pub(crate) http::Request<S>);
-    /// Typestate for for [`Config`] when configured via [`request::with_agent`].
+    /// Typestate for for [`Config`] when configured via [`crate::RequestExt::with_agent`].
     pub struct RequestExtScope<'a, S: AsSendBody>(pub(crate) WithAgent<'a, S>);
 
     impl private::ConfigScope for AgentScope {

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,7 @@ pub(crate) mod typestate {
     pub struct RequestScope<Any>(pub(crate) RequestBuilder<Any>);
     /// Typestate for for [`Config`] when configured via [`Agent::configure_request`].
     pub struct HttpCrateScope<S: AsSendBody>(pub(crate) http::Request<S>);
-    // TODO
+    /// Typestate for for [`Config`] when configured via [`request::with_agent`].
     pub struct RequestExtScope<'a, S: AsSendBody>(pub(crate) WithAgent<'a, S>);
 
     impl private::ConfigScope for AgentScope {
@@ -794,12 +794,12 @@ impl<S: AsSendBody> ConfigBuilder<HttpCrateScope<S>> {
 }
 
 impl<'a, S: AsSendBody> ConfigBuilder<RequestExtScope<'a, S>> {
-    /// TODO
+    /// Finalize the config
     pub fn build(self) -> WithAgent<'a, S> {
         self.0 .0
     }
 
-    /// TODO
+    /// Run the request with the agent in the ConfigBuilder
     pub fn run(self) -> Result<Response<Body>, Error> {
         self.0 .0.run()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,6 +525,7 @@ use http::{Request, Response, Uri};
 pub use proxy::Proxy;
 pub use request::RequestBuilder;
 use request::{WithBody, WithoutBody};
+pub use request_ext::RequestExt;
 pub use response::ResponseExt;
 pub use send_body::AsSendBody;
 
@@ -553,6 +554,8 @@ pub mod tls;
 
 #[cfg(feature = "cookies")]
 mod cookies;
+mod request_ext;
+
 #[cfg(feature = "cookies")]
 pub use cookies::{Cookie, CookieJar};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1144,7 +1144,7 @@ pub(crate) mod test {
             .build()
             .call()
             .unwrap_err();
-        assert!(matches!(err, Error::LargeResponseHeader(65, 5)));
+        assert!(matches!(err, Error::LargeResponseHeader(516, 5)));
     }
 
     // This doesn't need to run, just compile.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1144,7 +1144,7 @@ pub(crate) mod test {
             .build()
             .call()
             .unwrap_err();
-        assert!(matches!(err, Error::LargeResponseHeader(516, 5)));
+        assert!(matches!(err, Error::LargeResponseHeader(65, 5)));
     }
 
     // This doesn't need to run, just compile.

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -214,7 +214,7 @@ mod tests {
             .unwrap()
             .with_default_agent()
             .configure()
-            .https_only(true)
+            .https_only(false)
             .build();
 
         // Assert that the request-level configuration has been set
@@ -225,7 +225,7 @@ mod tests {
             .cloned()
             .unwrap();
 
-        assert_eq!(request_config.0.https_only(), true);
+        assert_eq!(request_config.0.https_only(), false);
     }
 
     #[test]

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -1,6 +1,9 @@
-use crate::config::ConfigBuilder;
-use crate::typestate::HttpCrateScope;
-use crate::{http, Agent, AsSendBody};
+use std::ops::{Deref, DerefMut};
+use ureq_proto::http::{Request, Response};
+use crate::config::{Config, ConfigBuilder, RequestLevelConfig};
+use crate::typestate::{HttpCrateScope, RequestScope};
+use crate::{http, Agent, AsSendBody, Body, Error};
+use crate::config::typestate::RequestExtScope;
 
 /// Extension trait for [`http::Request<impl AsSendBody>`].
 ///
@@ -10,38 +13,144 @@ pub trait RequestExt<S>
 where
     S: AsSendBody,
 {
-    /// Allows ureq-specific configuration for this request.
+    /// TODO
     ///
-    /// This function will return a `ConfigBuilder` that can be used to set ureq-specific options.
-    /// The resulting method can be used with `ureq::run` or with an existing agent.
-    /// Configuration values set on the request takes precedence over configuration values set on the agent.
+    /// # Example
     ///
-    /// # Examples
     /// ```
-    /// use ureq::http;
-    /// use ureq::RequestExt;
+    /// use ureq::{http, RequestExt};
     ///
-    /// // Acquire an `http::Request` somehow
+    /// http::Request::builder()
+    ///     .method(http::Method::POST)
+    ///     .uri("http://httpbin.org/post")
+    ///     .body(())
+    ///     .unwrap()
+    ///     .with_default_agent()
+    ///     .run();
+    /// ```
+    fn with_default_agent(self) -> WithAgent<'static, S> where Self: Sized {
+        let agent = Agent::new_with_defaults();
+        Self::with_agent(self, agent)
+    }
+
+    /// Use this [`Request`] with a ureq [`Agent`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ureq::{http, Agent, RequestExt};
+    /// use std::time::Duration;
+    ///
     /// let request: http::Request<()> = http::Request::builder()
-    ///             .method(http::Method::GET)
-    ///             .uri("http://foo.bar")
-    ///             .body(())
-    ///             .unwrap();
+    ///     .method(http::Method::GET)
+    ///     .uri("http://httpbin.org/get")
+    ///     .body(())
+    ///     .unwrap();
     ///
-    /// // Use the `configure()` method to set ureq-specific options
-    /// // and call `build()` to get the request back.
-    /// let request: http::Request<()> = request
+    /// let mut agent = Agent::config_builder()
+    ///     .timeout_global(Some(Duration::from_secs(30)))
+    ///     .build()
+    ///     .new_agent();
+    ///
+    /// let response = request
+    ///     .with_agent(&mut agent)
     ///     .configure()
-    ///     .https_only(false)
-    ///     .build();
+    ///     .https_only(true)
+    ///     .run()
+    ///     .unwrap();
     /// ```
-    fn configure(self) -> ConfigBuilder<HttpCrateScope<S>>;
+    fn with_agent<'a>(self, agent: impl Into<AgentRef<'a>>) -> WithAgent<'a, S>;
 }
 
+pub struct WithAgent<'a, S: AsSendBody> {
+    pub(crate) agent: AgentRef<'a>,
+    pub(crate) request: Request<S>,
+}
+
+impl<'a, S: AsSendBody> WithAgent<'a, S> {
+    /// TODO
+    pub fn configure(mut self) -> ConfigBuilder<RequestExtScope<'a, S>> {
+        let exts = self.request.extensions_mut();
+
+        if exts.get::<RequestLevelConfig>().is_none() {
+            exts.insert(self.agent.new_request_level_config());
+        }
+
+        ConfigBuilder(RequestExtScope(self))
+    }
+
+    /// TODO
+    pub fn run(self) -> Result<Response<Body>, Error> {
+        self.agent.run(self.request)
+    }
+}
+
+impl<'a, S: AsSendBody> WithAgent<'a, S> {
+    pub(crate) fn request_level_config(&mut self) -> &mut Config {
+        let request_level_config = self.request
+            .extensions_mut()
+            .get_mut::<RequestLevelConfig>();
+
+
+        if request_level_config.is_none() {
+            self.request.extensions_mut().insert(self.agent.new_request_level_config());
+        }
+
+        // Unwrap is OK because of above check
+        let req_level: &mut RequestLevelConfig = self.request.extensions_mut().get_mut::<RequestLevelConfig>().unwrap();
+
+        &mut req_level.0
+    }
+}
+
+/// Glue type to hold an owned or &mut Agent.
+pub enum AgentRef<'a> {
+    /// TODO
+    Owned(Agent),
+    /// TODO
+    Borrowed(&'a mut Agent),
+}
+
+
 impl<S: AsSendBody> RequestExt<S> for http::Request<S> {
-    fn configure(self) -> ConfigBuilder<HttpCrateScope<S>> {
-        let agent = Agent::new_with_defaults();
-        agent.configure_request(self)
+    fn with_agent<'a>(self, agent: impl Into<AgentRef<'a>>) -> WithAgent<'a, S> {
+        WithAgent {
+            agent: agent.into(),
+            request: self,
+        }
+    }
+}
+
+
+impl From<Agent> for AgentRef<'static> {
+    fn from(value: Agent) -> Self {
+        AgentRef::Owned(value)
+    }
+}
+
+impl<'a> From<&'a mut Agent> for AgentRef<'a> {
+    fn from(value: &'a mut Agent) -> Self {
+        AgentRef::Borrowed(value)
+    }
+}
+
+impl Deref for AgentRef<'_> {
+    type Target = Agent;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            AgentRef::Owned(agent) => agent,
+            AgentRef::Borrowed(agent) => &*agent,
+        }
+    }
+}
+
+impl DerefMut for AgentRef<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            AgentRef::Owned(agent) => agent,
+            AgentRef::Borrowed(agent) => agent,
+        }
     }
 }
 
@@ -57,80 +166,89 @@ mod tests {
             .method(http::Method::GET)
             .uri("http://foo.bar")
             .body(())
-            .unwrap();
+            .unwrap()
+            .with_default_agent()
+            .configure()
+            .http_status_as_error(true)
+            .build();
 
         // Configure with the trait
-        let request = request.configure().https_only(true).build();
+        // let request = request.configure().https_only(true).build();
 
-        let request_config = request
-            .extensions()
-            .get::<RequestLevelConfig>()
-            .cloned()
-            .unwrap();
+        dbg!(&request.request.extensions().get::<RequestLevelConfig>());
+        dbg!(&request.agent.deref());
 
-        assert_eq!(request_config.0.https_only(), true);
+        // let request_config = request
+        //     .extensions()
+        //     .get::<RequestLevelConfig>()
+        //     .cloned()
+        //     .unwrap();
+        //
+        // assert_eq!(request_config.0.https_only(), true);
+
+        todo!();
     }
 
-    #[test]
-    fn set_https_only_to_false_on_get_request() {
-        // Create `http` crate request
-        let request = http::Request::builder()
-            .method(http::Method::GET)
-            .uri("http://foo.bar")
-            .body(())
-            .unwrap();
-
-        // Configure with the trait
-        let request = request.configure().https_only(false).build();
-
-        let request_config = request
-            .extensions()
-            .get::<RequestLevelConfig>()
-            .cloned()
-            .unwrap();
-
-        assert_eq!(request_config.0.https_only(), false);
-    }
-
-    #[test]
-    fn set_http_status_as_error_to_true_on_post_request() {
-        // Create `http` crate request
-        let request = http::Request::builder()
-            .method(http::Method::POST)
-            .uri("http://foo.bar")
-            .body("Some body")
-            .unwrap();
-
-        // Configure with the trait
-        let request = request.configure().http_status_as_error(true).build();
-
-        let request_config = request
-            .extensions()
-            .get::<RequestLevelConfig>()
-            .cloned()
-            .unwrap();
-
-        assert_eq!(request_config.0.http_status_as_error(), true);
-    }
-
-    #[test]
-    fn set_http_status_as_error_to_false_on_post_request() {
-        // Create `http` crate request
-        let request = http::Request::builder()
-            .method(http::Method::GET)
-            .uri("http://foo.bar")
-            .body("Some body")
-            .unwrap();
-
-        // Configure with the trait
-        let request = request.configure().http_status_as_error(false).build();
-
-        let request_config = request
-            .extensions()
-            .get::<RequestLevelConfig>()
-            .cloned()
-            .unwrap();
-
-        assert_eq!(request_config.0.http_status_as_error(), false);
-    }
+    // #[test]
+    // fn set_https_only_to_false_on_get_request() {
+    //     // Create `http` crate request
+    //     let request = http::Request::builder()
+    //         .method(http::Method::GET)
+    //         .uri("http://foo.bar")
+    //         .body(())
+    //         .unwrap();
+    //
+    //     // Configure with the trait
+    //     let request = request.configure().https_only(false).build();
+    //
+    //     let request_config = request
+    //         .extensions()
+    //         .get::<RequestLevelConfig>()
+    //         .cloned()
+    //         .unwrap();
+    //
+    //     assert_eq!(request_config.0.https_only(), false);
+    // }
+    //
+    // #[test]
+    // fn set_http_status_as_error_to_true_on_post_request() {
+    //     // Create `http` crate request
+    //     let request = http::Request::builder()
+    //         .method(http::Method::POST)
+    //         .uri("http://foo.bar")
+    //         .body("Some body")
+    //         .unwrap();
+    //
+    //     // Configure with the trait
+    //     let request = request.configure().http_status_as_error(true).build();
+    //
+    //     let request_config = request
+    //         .extensions()
+    //         .get::<RequestLevelConfig>()
+    //         .cloned()
+    //         .unwrap();
+    //
+    //     assert_eq!(request_config.0.http_status_as_error(), true);
+    // }
+    //
+    // #[test]
+    // fn set_http_status_as_error_to_false_on_post_request() {
+    //     // Create `http` crate request
+    //     let request = http::Request::builder()
+    //         .method(http::Method::GET)
+    //         .uri("http://foo.bar")
+    //         .body("Some body")
+    //         .unwrap();
+    //
+    //     // Configure with the trait
+    //     let request = request.configure().http_status_as_error(false).build();
+    //
+    //     let request_config = request
+    //         .extensions()
+    //         .get::<RequestLevelConfig>()
+    //         .cloned()
+    //         .unwrap();
+    //
+    //     assert_eq!(request_config.0.http_status_as_error(), false);
+    // }
 }

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -181,7 +181,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn set_https_only_to_true_on_get_request_with_default_agent() {
+    fn configure_request_with_default_agent() {
         // Create `http` crate request and configure with trait
         let request = http::Request::builder()
             .method(http::Method::GET)
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    fn set_https_only_to_false_on_get_request_with_default_agent() {
+    fn configure_request_default_agent_2() {
         // Create `http` crate request and configure with trait
         let request = http::Request::builder()
             .method(http::Method::GET)
@@ -225,11 +225,11 @@ mod tests {
             .cloned()
             .unwrap();
 
-        assert_eq!(request_config.0.https_only(), false);
+        assert_eq!(request_config.0.https_only(), true);
     }
 
     #[test]
-    fn set_http_status_as_error_to_true_on_post_request_with_default_agent() {
+    fn configure_request_default_agent_3() {
         // Create `http` crate request
         let request = http::Request::builder()
             .method(http::Method::POST)
@@ -255,7 +255,7 @@ mod tests {
     }
 
     #[test]
-    fn set_http_status_as_error_to_false_on_post_request_with_default_agent() {
+    fn configure_request_default_agent_4() {
         // Create `http` crate request
         let request = http::Request::builder()
             .method(http::Method::POST)
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn set_http_status_as_error_to_false_on_post_request_with_specified_agent() {
+    fn configure_request_specified_agent() {
         // Create `http` crate request
         let request = http::Request::builder()
             .method(http::Method::POST)

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -169,7 +169,7 @@ impl Deref for AgentRef<'_> {
     fn deref(&self) -> &Self::Target {
         match self {
             AgentRef::Owned(agent) => agent,
-            AgentRef::Borrowed(agent) => &*agent,
+            AgentRef::Borrowed(agent) => agent,
         }
     }
 }

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -84,7 +84,7 @@ where
     ///             .uri("http://foo.bar")
     ///             .body(())
     ///             .unwrap()
-    ///             .with_agent(&mut agent)
+    ///             .with_agent(&agent)
     ///             .configure()
     ///             .http_status_as_error(false)
     ///             .run();

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -70,12 +70,6 @@ pub struct WithAgent<'a, S: AsSendBody> {
 impl<'a, S: AsSendBody> WithAgent<'a, S> {
     /// TODO
     pub fn configure(mut self) -> ConfigBuilder<RequestExtScope<'a, S>> {
-        let exts = self.request.extensions_mut();
-
-        if exts.get::<RequestLevelConfig>().is_none() {
-            exts.insert(self.agent.new_request_level_config());
-        }
-
         ConfigBuilder(RequestExtScope(self))
     }
 
@@ -169,7 +163,7 @@ mod tests {
             .unwrap()
             .with_default_agent()
             .configure()
-            .http_status_as_error(true)
+            .http_status_as_error(false)
             .build();
 
         // Configure with the trait

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -1,0 +1,136 @@
+use crate::config::ConfigBuilder;
+use crate::typestate::HttpCrateScope;
+use crate::{http, Agent, AsSendBody};
+
+/// Extension trait for [`http::Request<impl AsSendBody>`].
+///
+/// Adds additional convenience methods to the `Request` that are not available
+/// in the plain http API.
+pub trait RequestExt<S>
+where
+    S: AsSendBody,
+{
+    /// Allows ureq-specific configuration for this request.
+    ///
+    /// This function will return a `ConfigBuilder` that can be used to set ureq-specific options.
+    /// The resulting method can be used with `ureq::run` or with an existing agent.
+    /// Configuration values set on the request takes precedence over configuration values set on the agent.
+    ///
+    /// # Examples
+    /// ```
+    /// use ureq::http;
+    /// use ureq::RequestExt;
+    ///
+    /// // Acquire an `http::Request` somehow
+    /// let request: http::Request<()> = http::Request::builder()
+    ///             .method(http::Method::GET)
+    ///             .uri("http://foo.bar")
+    ///             .body(())
+    ///             .unwrap();
+    ///
+    /// // Use the `configure()` method to set ureq-specific options
+    /// // and call `build()` to get the request back.
+    /// let request: http::Request<()> = request
+    ///     .configure()
+    ///     .https_only(false)
+    ///     .build();
+    /// ```
+    fn configure(self) -> ConfigBuilder<HttpCrateScope<S>>;
+}
+
+impl<S: AsSendBody> RequestExt<S> for http::Request<S> {
+    fn configure(self) -> ConfigBuilder<HttpCrateScope<S>> {
+        let agent = Agent::new_with_defaults();
+        agent.configure_request(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RequestLevelConfig;
+
+    #[test]
+    fn set_https_only_to_true_on_get_request() {
+        // Create `http` crate request
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("http://foo.bar")
+            .body(())
+            .unwrap();
+
+        // Configure with the trait
+        let request = request.configure().https_only(true).build();
+
+        let request_config = request
+            .extensions()
+            .get::<RequestLevelConfig>()
+            .cloned()
+            .unwrap();
+
+        assert_eq!(request_config.0.https_only(), true);
+    }
+
+    #[test]
+    fn set_https_only_to_false_on_get_request() {
+        // Create `http` crate request
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("http://foo.bar")
+            .body(())
+            .unwrap();
+
+        // Configure with the trait
+        let request = request.configure().https_only(false).build();
+
+        let request_config = request
+            .extensions()
+            .get::<RequestLevelConfig>()
+            .cloned()
+            .unwrap();
+
+        assert_eq!(request_config.0.https_only(), false);
+    }
+
+    #[test]
+    fn set_http_status_as_error_to_true_on_post_request() {
+        // Create `http` crate request
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri("http://foo.bar")
+            .body("Some body")
+            .unwrap();
+
+        // Configure with the trait
+        let request = request.configure().http_status_as_error(true).build();
+
+        let request_config = request
+            .extensions()
+            .get::<RequestLevelConfig>()
+            .cloned()
+            .unwrap();
+
+        assert_eq!(request_config.0.http_status_as_error(), true);
+    }
+
+    #[test]
+    fn set_http_status_as_error_to_false_on_post_request() {
+        // Create `http` crate request
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("http://foo.bar")
+            .body("Some body")
+            .unwrap();
+
+        // Configure with the trait
+        let request = request.configure().http_status_as_error(false).build();
+
+        let request_config = request
+            .extensions()
+            .get::<RequestLevelConfig>()
+            .cloned()
+            .unwrap();
+
+        assert_eq!(request_config.0.http_status_as_error(), false);
+    }
+}


### PR DESCRIPTION
Creates a RequestExtension trait that will allow attaching ureq-specific methods to an `http::Request`.

Currently the trait method allows attaching default or specified agents, and configuring and running the request inline.

Fixes #998 