### PR TITLE
Transport::await_input not check self.buffers().can_use_input()

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -103,8 +103,8 @@ impl Connection {
         self.transport.transmit_output(amount, timeout)
     }
 
-    pub fn await_input(&mut self, timeout: NextTimeout) -> Result<bool, Error> {
-        self.transport.await_input(timeout)
+    pub fn maybe_await_input(&mut self, timeout: NextTimeout) -> Result<bool, Error> {
+        self.transport.maybe_await_input(timeout)
     }
 
     pub fn consume_input(&mut self, amount: usize) {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -280,7 +280,7 @@ impl<In: Transport> Connector<In> for ConnectProxyConnector {
         let mut transport = w.into_inner();
 
         let response = loop {
-            let made_progress = transport.await_input(details.timeout)?;
+            let made_progress = transport.maybe_await_input(details.timeout)?;
             let buffers = transport.buffers();
             let input = buffers.input();
             let Some((used_input, response)) = try_parse_response::<20>(input)? else {

--- a/src/run.rs
+++ b/src/run.rs
@@ -426,7 +426,7 @@ fn await_100(
             break;
         }
 
-        match connection.await_input(timeout) {
+        match connection.maybe_await_input(timeout) {
             Ok(_) => {
                 let input = connection.buffers().input();
                 if input.is_empty() {
@@ -515,7 +515,7 @@ fn recv_response(
 ) -> Result<(Response<()>, RecvResponseResult), Error> {
     let response = loop {
         let timeout = timings.next_timeout(Timeout::RecvResponse);
-        let made_progress = connection.await_input(timeout)?;
+        let made_progress = connection.maybe_await_input(timeout)?;
 
         let input = connection.buffers().input();
 
@@ -650,7 +650,7 @@ impl BodyHandler {
 
             let timeout = timings.next_timeout(Timeout::RecvBody);
 
-            let made_progress = match connection.await_input(timeout) {
+            let made_progress = match connection.maybe_await_input(timeout) {
                 Ok(v) => v,
                 Err(Error::Io(e)) => match e.kind() {
                     io::ErrorKind::UnexpectedEof
@@ -676,7 +676,7 @@ impl BodyHandler {
                 self.ended()?;
                 return Ok(0);
             } else if made_progress {
-                // The await_input() made progress, but handled amount is 0. This
+                // The maybe_await_input() made progress, but handled amount is 0. This
                 // can for instance happen if we read some data, but not enough for
                 // decoding any gzip.
                 continue;

--- a/src/tls/native_tls.rs
+++ b/src/tls/native_tls.rs
@@ -231,10 +231,6 @@ impl Transport for NativeTlsTransport {
     }
 
     fn await_input(&mut self, timeout: NextTimeout) -> Result<bool, Error> {
-        if self.buffers.can_use_input() {
-            return Ok(true);
-        }
-
         let stream = self.stream.handshaken()?;
         stream.get_mut().set_timeout(timeout);
 

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -242,10 +242,6 @@ impl Transport for RustlsTransport {
     }
 
     fn await_input(&mut self, timeout: NextTimeout) -> Result<bool, Error> {
-        if self.buffers.can_use_input() {
-            return Ok(true);
-        }
-
         self.stream.get_mut().set_timeout(timeout);
 
         let input = self.buffers.input_append_buf();

--- a/src/unversioned/transport/io.rs
+++ b/src/unversioned/transport/io.rs
@@ -56,7 +56,7 @@ impl<T: Transport> TransportAdapter<T> {
 impl<T: Transport> io::Read for TransportAdapter<T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.transport
-            .await_input(self.timeout)
+            .maybe_await_input(self.timeout)
             .map_err(|e| e.into_io())?;
         let input = self.transport.buffers().input();
 

--- a/src/unversioned/transport/tcp.rs
+++ b/src/unversioned/transport/tcp.rs
@@ -157,10 +157,6 @@ impl Transport for TcpTransport {
     }
 
     fn await_input(&mut self, timeout: NextTimeout) -> Result<bool, Error> {
-        if self.buffers.can_use_input() {
-            return Ok(true);
-        }
-
         // Proceed to fill the buffers from the TcpStream
         maybe_update_timeout(
             timeout,


### PR DESCRIPTION
Relates to #1044 