### PR TITLE
fix: failed to build when enabled `cookie_store/public_suffix`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "idna",
  "indexmap",
  "log",
+ "publicsuffix",
  "serde",
  "serde_derive",
  "serde_json",
@@ -985,6 +986,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ native-tls = ["dep:native-tls", "dep:der", "_tls", "dep:webpki-root-certs"]
 platform-verifier = ["dep:rustls-platform-verifier"]
 socks-proxy = ["dep:socks"]
 cookies = ["dep:cookie_store", "_url"]
+cookies-publicsuffix = ["cookie_store?/public_suffix"]
 gzip = ["dep:flate2"]
 brotli = ["dep:brotli-decompressor"]
 charset = ["dep:encoding_rs"]
@@ -88,7 +89,6 @@ encoding_rs = { version = "0.8.34", optional = true }
 
 serde = { version = "1.0.138", optional = true, default-features = false, features = ["std"] }
 serde_json = { version = "1.0.120", optional = true, default-features = false, features = ["std"] }
-
 [dev-dependencies]
 env_logger = "0.11.7"
 auto-args = "0.3.0"

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -171,7 +171,10 @@ impl<'a> CookieJar<'a> {
 impl SharedCookieJar {
     pub(crate) fn new() -> Self {
         SharedCookieJar {
-            inner: Mutex::new(CookieStore::new()),
+            inner: Mutex::new(CookieStore::new(
+                #[cfg(feature = "cookies-publicsuffix")]
+                None
+            )),
         }
     }
 


### PR DESCRIPTION
This will really fix #836

Once user added both reqwest 0.12 and ureq to their dependencies, ureq will fail to compile, due to the optional argument in `new`.