### PR TITLE
Fix form urlencoding using `form_urlencoded` crate from servo

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -58,10 +58,14 @@ pub fn form_url_enc(i: &str) -> Cow<str> {
         "%20" => "+",
         _ => part,
     });
+
+    // We try to avoid allocating if we can (returning a Cow).
     match iter.next() {
         None => "".into(),
         Some(first) => match iter.next() {
+            // Case avoids allocation
             None => first.into(),
+            // Following allocates
             Some(second) => {
                 let mut string = first.to_owned();
                 string.push_str(second);

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,7 +9,7 @@ use crate::body::Body;
 use crate::config::typestate::RequestScope;
 use crate::config::{Config, ConfigBuilder, RequestLevelConfig};
 use crate::http;
-use crate::query::url_enc;
+use crate::query::form_url_enc;
 use crate::query::{parse_query_params, QueryParam};
 use crate::send_body::AsSendBody;
 use crate::util::private::Private;
@@ -581,9 +581,9 @@ impl RequestBuilder<WithBody> {
             if !body.is_empty() {
                 body.push('&');
             }
-            body.push_str(&url_enc(k.as_ref()));
+            body.push_str(&form_url_enc(k.as_ref()));
             body.push('=');
-            body.push_str(&url_enc(v.as_ref()));
+            body.push_str(&form_url_enc(v.as_ref()));
         }
 
         let mut request = self.builder.body(())?;


### PR DESCRIPTION
Should fix #1070 under my limited testing.
It is debatable whether this is the best way since it introduces a new dependency. It is possible to hack it in `query.rs` and introduces a `form_url_enc()` to handle this. If you want to minimize dependencies and elect for that instead, let me know and I can get that done relatively quickly as well.