### PR TITLE
Chunked transfer handle abrupt abort after 0\r\n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+ * Chunked transfer handle abrupt close after 0\r\n (#1074)
  * Fix incorrect DNS resolving when using proxies (#1081)
  * Use + instead of %20 for url encoded form bodies (#1071)
  * Fix problem with double-quotes in cookie values (#1068)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadf18427d33828c311234884b7ba2afb57143e6e7e69fda7ee883b624661e36"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
 dependencies = [
  "base64",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ _doc = ["rustls?/aws-lc-rs"]
 
 [dependencies]
 base64 = "0.22.1"
-ureq-proto = { version = "0.4.1", default-features = false, features = ["client"] }
+ureq-proto = { version = "0.4.2", default-features = false, features = ["client"] }
 # ureq-proto = { path = "../ureq-proto", default-features = false, features = ["client"] }
 log = "0.4.25"
 utf-8 = "0.7.6"

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -212,8 +212,6 @@ impl Body {
     ///   To set a limit use [`Body::into_with_config()`].
     /// * Reader will error if `Content-Length` is set, but the connection is closed
     ///   before all bytes are received.
-    /// * Reader will error if `Transfer-Encoding: chunked` is set, but the connection
-    ///   is closed without a FIN message (graceful connection shutdown) from the server.
     ///
     /// # Example
     ///
@@ -244,8 +242,6 @@ impl Body {
     ///   To set a limit use [`Body::into_with_config()`].
     /// * Reader will error if `Content-Length` is set, but the connection is closed
     ///   before all bytes are received.
-    /// * Reader will error if `Transfer-Encoding: chunked` is set, but the connection
-    ///   is closed without a FIN message (graceful connection shutdown) from the server.
     ///
     /// ```
     /// use std::io::Read;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1018,6 +1018,7 @@ pub(crate) mod test {
 
     #[test]
     fn post_big_body_chunked() {
+        init_test_log();
         // https://github.com/algesten/ureq/issues/879
         let mut data = io::Cursor::new(vec![42; 153_600]);
         post("http://httpbin.org/post")
@@ -1189,6 +1190,24 @@ pub(crate) mod test {
             .build();
 
         agent.run(req).unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "_test")]
+    fn chunk_abort() {
+        init_test_log();
+        let mut res = get("http://my-fine-server/1chunk-abort").call().unwrap();
+        let body = res.body_mut().read_to_string().unwrap();
+        assert_eq!(body, "OK");
+        let mut res = get("http://my-fine-server/2chunk-abort").call().unwrap();
+        let body = res.body_mut().read_to_string().unwrap();
+        assert_eq!(body, "OK");
+        let mut res = get("http://my-fine-server/3chunk-abort").call().unwrap();
+        let body = res.body_mut().read_to_string().unwrap();
+        assert_eq!(body, "OK");
+        let mut res = get("http://my-fine-server/4chunk-abort").call().unwrap();
+        let body = res.body_mut().read_to_string().unwrap();
+        assert_eq!(body, "OK");
     }
 
     // This doesn't need to run, just compile.


### PR DESCRIPTION
## Problem

I was under the mistaken impression that the reader returned by the `into_reader` didn't perform checks for Content-Length. It does, but even after consulting the documentation in several places, I moved forward with adding my own check in https://github.com/heroku/libcnb.rs/pull/947. A co-worker corrected my implementation, which led me to discover it wasn't needed. Neither of us came to the conclusion that we were already protected via documentation alone.

One of the doc locations that I checked was `into_reader`.

## Fix

I added two error cases to the docs where the reader can (and should) make errors: when a connection is closed before Content-Length bytes are received ~and if an ungraceful close of the TCP connection occurs~.

At the same time, the subject of the bullet point on the reader not being "limited" wasn't clear to me. To help, I added some more details.

I understand the documents weren't written for me personally, and we cannot add every possible caveat to every possible source of documentation. Feel free to take this feedback and run with it if you like. Thanks for this library!

----

Addition. ureq can now handled a server sending `0\r\n` to end a transfer and then abruptly aborting the connection.