### PR TITLE
Implement digest auth middleware behind a feature flag (on v3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
           - json
           - multipart
           - native-tls
+          - digest-auth
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -55,9 +55,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -155,6 +155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brotli-decompressor"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,9 +187,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -202,9 +211,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -271,12 +280,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -296,6 +324,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "digest_auth"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3054f4e81d395e50822796c5e99ca522e6ba7be98947d6d4b0e5e61640bdb894"
+dependencies = [
+ "digest",
+ "hex",
+ "md-5",
+ "rand",
+ "sha2",
 ]
 
 [[package]]
@@ -335,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -345,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -431,6 +482,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +547,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -668,7 +735,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror",
  "walkdir",
@@ -677,9 +744,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -699,9 +788,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -711,9 +800,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -726,6 +815,16 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -886,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -898,6 +997,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -956,6 +1064,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "regex"
@@ -1180,6 +1318,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,9 +1336,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -1319,13 +1468,19 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicase"
@@ -1367,6 +1522,7 @@ dependencies = [
  "brotli-decompressor",
  "cookie_store",
  "der",
+ "digest_auth",
  "encoding_rs",
  "env_logger",
  "flate2",
@@ -1826,9 +1982,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1837,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -1848,19 +2004,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
+name = "zerocopy"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -1876,9 +2052,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1887,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1898,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 rust-version = "1.85"
 
 [package.metadata.docs.rs]
-features = ["rustls", "platform-verifier", "native-tls", "socks-proxy", "cookies", "gzip", "brotli", "charset", "json", "multipart", "_test", "_doc"]
+features = ["rustls", "platform-verifier", "native-tls", "socks-proxy", "cookies", "gzip", "brotli", "charset", "json", "multipart", "digest-auth", "_test", "_doc"]
 
 [features]
 default = ["rustls", "gzip"]
@@ -33,6 +33,7 @@ brotli = ["dep:brotli-decompressor"]
 charset = ["dep:encoding_rs"]
 json = ["dep:serde", "dep:serde_json", "cookie_store?/serde_json"]
 multipart = ["dep:mime_guess", "dep:getrandom"]
+digest-auth = ["digest_auth"]
 rustls-webpki-roots = ["dep:webpki-roots"]
 native-tls-webpki-roots = ["dep:webpki-root-certs"]
 
@@ -99,6 +100,7 @@ serde_json = { version = "1.0.120", optional = true, default-features = false, f
 
 mime_guess = { version = "2.0.5", optional = true }
 getrandom = { version = "0.4", optional = true }
+digest_auth = { version = "0.3.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = { version = "0.56", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,6 +570,9 @@ use unversioned::transport;
 
 pub mod middleware;
 
+#[cfg(feature = "digest-auth")]
+pub use middleware::digest::DigestAuthMiddleware;
+
 #[cfg(feature = "_tls")]
 pub mod tls;
 
@@ -719,6 +722,9 @@ where
 #[cfg(test)]
 pub(crate) mod test {
     use std::{io, sync::OnceLock};
+
+    #[cfg(feature = "digest-auth")]
+    use std::time::Duration;
 
     use assert_no_alloc::AllocDisabler;
     use config::{Config, ConfigBuilder};
@@ -1215,6 +1221,51 @@ pub(crate) mod test {
         jar.release();
 
         let _ = agent.get("http://cookie.test/cookie-test").call().unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "digest-auth")]
+    fn valid_credentials() {
+        let arbitrary_username = "MyUsername";
+        let arbitrary_password = "MyPassword";
+        let digest_auth_middleware = crate::middleware::digest::DigestAuthMiddleware::new(
+            arbitrary_username,
+            arbitrary_password,
+        );
+        let test_url = format!(
+            "http://httpbin.org/digest-auth/auth/{}/{}",
+            arbitrary_username, arbitrary_password
+        );
+        let agent: Agent = crate::config::Config::builder()
+            .timeout_global(Some(Duration::from_secs(5)))
+            .http_status_as_error(false)
+            .middleware(digest_auth_middleware)
+            .build()
+            .into();
+        let result = agent.get(&test_url).call();
+        assert_eq!(result.unwrap().status(), 200);
+    }
+
+    #[test]
+    #[cfg(feature = "digest-auth")]
+    fn invalid_credentials() {
+        let arbitrary_username = "MyUsername";
+        let arbitrary_password = "MyPassword";
+        let bad_password = "BadPassword";
+        let digest_auth_middleware =
+            crate::middleware::digest::DigestAuthMiddleware::new(arbitrary_username, bad_password);
+        let test_url = format!(
+            "http://httpbin.org/digest-auth/auth/{}/{}",
+            arbitrary_username, arbitrary_password
+        );
+        let agent: Agent = crate::config::Config::builder()
+            .timeout_global(Some(Duration::from_secs(5)))
+            .http_status_as_error(false)
+            .middleware(digest_auth_middleware)
+            .build()
+            .into();
+        let result = agent.get(&test_url).call();
+        assert_eq!(result.unwrap().status(), 401);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1238,7 +1238,6 @@ pub(crate) mod test {
         );
         let agent: Agent = crate::config::Config::builder()
             .timeout_global(Some(Duration::from_secs(5)))
-            .http_status_as_error(false)
             .middleware(digest_auth_middleware)
             .build()
             .into();
@@ -1262,7 +1261,6 @@ pub(crate) mod test {
         );
         let agent: Agent = crate::config::Config::builder()
             .timeout_global(Some(Duration::from_secs(5)))
-            .http_status_as_error(false)
             .middleware(digest_auth_middleware)
             .build()
             .into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1229,8 +1229,8 @@ pub(crate) mod test {
         let arbitrary_username = "MyUsername";
         let arbitrary_password = "MyPassword";
         let digest_auth_middleware = crate::middleware::digest::DigestAuthMiddleware::new(
-            arbitrary_username,
-            arbitrary_password,
+            arbitrary_username.to_string(),
+            arbitrary_password.to_string(),
         );
         let test_url = format!(
             "http://httpbin.org/digest-auth/auth/{}/{}",
@@ -1252,8 +1252,10 @@ pub(crate) mod test {
         let arbitrary_username = "MyUsername";
         let arbitrary_password = "MyPassword";
         let bad_password = "BadPassword";
-        let digest_auth_middleware =
-            crate::middleware::digest::DigestAuthMiddleware::new(arbitrary_username, bad_password);
+        let digest_auth_middleware = crate::middleware::digest::DigestAuthMiddleware::new(
+            arbitrary_username.to_string(),
+            bad_password.to_string(),
+        );
         let test_url = format!(
             "http://httpbin.org/digest-auth/auth/{}/{}",
             arbitrary_username, arbitrary_password

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -83,6 +83,8 @@ impl Middleware for DigestAuthMiddleware {
         let request = http::Request::from_parts(parts.clone(), body);
         let agent = next.agent;
 
+        // TODO (jacksongoode): Should be able to catch 401 without http_status_as_error(false)
+        // but headers are lost in the returned error.
         let response = next.handle(request)?;
 
         if response.status() == http::StatusCode::UNAUTHORIZED {
@@ -93,6 +95,7 @@ impl Middleware for DigestAuthMiddleware {
                     .headers
                     .insert(http::header::AUTHORIZATION, challenge_answer_header);
 
+                // TODO (jacksongoode): Should preserve and send original body.
                 let retry_request = http::Request::from_parts(parts, SendBody::none());
                 return agent.run(retry_request);
             }

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -41,10 +41,7 @@ pub struct DigestAuthMiddleware {
 impl DigestAuthMiddleware {
     /// Create a new digest authentication middleware.
     pub fn new(username: String, password: String) -> Self {
-        Self {
-            username: username,
-            password: password,
-        }
+        Self { username, password }
     }
 
     fn construct_answer_to_challenge(

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -22,8 +22,8 @@ use std::str::FromStr;
 /// ```
 /// let arbitrary_username = "MyUsername";
 /// let arbitrary_password = "MyPassword";
-/// let digest_auth_middleware =
-///     ureq::DigestAuthMiddleware::new(arbitrary_username, arbitrary_password);
+/// let digest_auth_middleware = ureq::DigestAuthMiddleware::new(
+///     arbitrary_username.to_string(), arbitrary_password.to_string());
 /// # let url = String::new();
 ///
 /// let agent: ureq::Agent = ureq::config::Config::builder()
@@ -40,10 +40,10 @@ pub struct DigestAuthMiddleware {
 
 impl DigestAuthMiddleware {
     /// Create a new digest authentication middleware.
-    pub fn new(username: &str, password: &str) -> Self {
+    pub fn new(username: String, password: String) -> Self {
         Self {
-            username: username.into(),
-            password: password.into(),
+            username: username,
+            password: password,
         }
     }
 

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -1,0 +1,105 @@
+use crate::middleware::{Middleware, MiddlewareNext};
+use crate::{http, Body, Error, SendBody};
+use digest_auth::{AuthContext, WwwAuthenticateHeader};
+use std::str::FromStr;
+
+/// Provides simple digest authentication powered by the `digest_auth` crate.
+///
+/// Requests that receive a HTTP 401 response are retried once by this middleware with the
+/// credentials provided on construction. The retry only happens under these conditions:
+/// - there is no prior "authorization" header on the request set by the caller or other
+///   middleware, and;
+/// - the server provides HTTP Digest auth challenge in the "www-authenticate" header.
+/// - the request body is empty (limitation to avoid body consumption issues)
+///
+/// In other cases, this middleware acts as a no-op forwarder of requests and responses.
+///
+/// **Note**: This middleware requires [`http_status_as_error(false)`] to be configured
+/// on the agent, as it needs to respond to 401's rather than treat them as errors.
+///
+/// [`http_status_as_error(false)`]: crate::config::ConfigBuilder::http_status_as_error
+///
+/// ```
+/// let arbitrary_username = "MyUsername";
+/// let arbitrary_password = "MyPassword";
+/// let digest_auth_middleware =
+///     ureq::DigestAuthMiddleware::new(arbitrary_username, arbitrary_password);
+/// # let url = String::new();
+///
+/// let agent = ureq::config::Config::builder()
+///     .http_status_as_error(false)  // Required for digest auth
+///     .middleware(digest_auth_middleware)
+///     .build()
+///     .into();
+/// agent.get(&url).call();
+/// ```
+pub struct DigestAuthMiddleware {
+    username: String,
+    password: String,
+}
+
+impl DigestAuthMiddleware {
+    /// Create a new digest authentication middleware.
+    pub fn new(username: &str, password: &str) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+
+    fn respond_to_challenge(
+        &self,
+        uri: &http::Uri,
+        response: &http::Response<Body>,
+    ) -> Option<String> {
+        let challenge_string = response.headers().get("www-authenticate")?.to_str().ok()?;
+        let mut challenge = WwwAuthenticateHeader::from_str(challenge_string).ok()?;
+        let path = uri.path();
+        let context = AuthContext::new(&self.username, &self.password, path);
+        challenge
+            .respond(&context)
+            .as_ref()
+            .map(ToString::to_string)
+            .ok()
+    }
+}
+
+impl Middleware for DigestAuthMiddleware {
+    fn handle(
+        &self,
+        request: http::Request<SendBody>,
+        next: MiddlewareNext,
+    ) -> Result<http::Response<Body>, Error> {
+        // Prevent infinite recursion when doing a nested request below.
+        if request.headers().get("authorization").is_some() {
+            return next.handle(request);
+        }
+
+        // Clone for the authentication challenge response.
+        let (parts, body) = request.into_parts();
+        let request = http::Request::from_parts(parts.clone(), body);
+        let agent = next.agent;
+
+        let response = next.handle(request)?;
+
+        if response.status() == 401 {
+            if let Some(challenge_answer) = self.respond_to_challenge(&parts.uri, &response) {
+                let mut retry_parts = parts;
+                retry_parts.headers.insert(
+                    "authorization",
+                    challenge_answer.parse().map_err(|_| {
+                        Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            "Invalid authorization header",
+                        ))
+                    })?,
+                );
+
+                let retry_request = http::Request::from_parts(retry_parts, SendBody::none());
+                return agent.run(retry_request);
+            }
+        }
+
+        Ok(response)
+    }
+}

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -80,8 +80,15 @@ impl Middleware for DigestAuthMiddleware {
         let request = http::Request::from_parts(parts.clone(), body);
         let agent = next.agent;
 
-        // TODO (jacksongoode): Should be able to catch 401 without http_status_as_error(false)
-        // but headers are lost in the returned error.
+        // Use middleware_config to set http_status_as_error(false) on this request
+        // so we can inspect the 401 response body and headers.
+        // This is always Some when called from within middleware.
+        let request = request
+            .middleware_config()
+            .expect("middleware_config requires AgentInstance in request extensions")
+            .http_status_as_error(false)
+            .build();
+
         let response = next.handle(request)?;
 
         if response.status() == http::StatusCode::UNAUTHORIZED {
@@ -94,6 +101,11 @@ impl Middleware for DigestAuthMiddleware {
 
                 // TODO (jacksongoode): Should preserve and send original body.
                 let retry_request = http::Request::from_parts(parts, SendBody::none());
+                // Also set http_status_as_error(false) on retry in case credentials are invalid
+                let retry_request = agent
+                    .configure_request(retry_request)
+                    .http_status_as_error(false)
+                    .build();
                 return agent.run(retry_request);
             }
         }

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -1,4 +1,5 @@
 use crate::middleware::{Middleware, MiddlewareNext};
+use crate::request_ext::RequestExt;
 use crate::{http, http::HeaderValue, Body, Error, SendBody};
 use digest_auth::{AuthContext, AuthorizationHeader, WwwAuthenticateHeader};
 use std::str::FromStr;
@@ -14,11 +15,6 @@ use std::str::FromStr;
 ///
 /// In other cases, this middleware acts as a no-op forwarder of requests and responses.
 ///
-/// **Note**: This middleware requires [`http_status_as_error(false)`] to be configured
-/// on the agent, as it needs to respond to 401's rather than treat them as errors.
-///
-/// [`http_status_as_error(false)`]: crate::config::ConfigBuilder::http_status_as_error
-///
 /// ```
 /// let arbitrary_username = "MyUsername";
 /// let arbitrary_password = "MyPassword";
@@ -27,7 +23,6 @@ use std::str::FromStr;
 /// # let url = String::new();
 ///
 /// let agent: ureq::Agent = ureq::config::Config::builder()
-///     .http_status_as_error(false)  // Required for digest auth
 ///     .middleware(digest_auth_middleware)
 ///     .build()
 ///     .into();
@@ -99,7 +94,7 @@ impl Middleware for DigestAuthMiddleware {
                     .headers
                     .insert(http::header::AUTHORIZATION, challenge_answer_header);
 
-                // TODO (jacksongoode): Should preserve and send original body.
+                // TODO: Preserve and send original body on retry
                 let retry_request = http::Request::from_parts(parts, SendBody::none());
                 // Also set http_status_as_error(false) on retry in case credentials are invalid
                 let retry_request = agent

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -51,7 +51,10 @@ impl DigestAuthMiddleware {
             .ok()?;
         let mut challenge = WwwAuthenticateHeader::from_str(challenge_string).ok()?;
 
-        let path = uri.path();
+        let path = uri
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or_else(|| uri.path());
         let context = AuthContext::new(&self.username, &self.password, path);
         let auth_header: AuthorizationHeader = challenge.respond(&context).ok()?;
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -7,6 +7,10 @@ use crate::http;
 use crate::run::run;
 use crate::{Agent, Body, Error, SendBody};
 
+#[cfg(feature = "digest-auth")]
+/// Digest authentication middleware.
+pub mod digest;
+
 /// Chained processing of request (and response).
 ///
 /// # Middleware as `fn`

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -1,5 +1,7 @@
+use crate::agent::AgentInstance;
 use crate::config::typestate::RequestExtScope;
 use crate::config::{Config, ConfigBuilder, RequestLevelConfig};
+use crate::typestate::HttpCrateScope;
 use crate::{Agent, AsSendBody, Body, Error, http};
 use std::ops::Deref;
 use ureq_proto::http::{Request, Response};
@@ -90,6 +92,16 @@ where
     ///             .run();
     /// ```
     fn with_agent<'a>(self, agent: impl Into<AgentRef<'a>>) -> WithAgent<'a, S>;
+
+    /// Returns a [`ConfigBuilder`] for configuring the request.
+    ///
+    /// This is only to be used from within [`Middleware`](crate::middleware::Middleware).
+    ///
+    /// Returns `None` if not called from within a [`Middleware`](crate::middleware::Middleware).
+    ///
+    /// Any usage beyond from inside a middleware, synchronously with handling the request, is
+    /// incorrect usage and might break without notice.
+    fn middleware_config(self) -> Option<ConfigBuilder<HttpCrateScope<S>>>;
 }
 
 /// Wrapper struct that holds a [`Request`] associated with an [`Agent`].
@@ -149,6 +161,11 @@ impl<S: AsSendBody> RequestExt<S> for http::Request<S> {
             request: self,
         }
     }
+
+    fn middleware_config(self) -> Option<ConfigBuilder<HttpCrateScope<S>>> {
+        let instance = self.extensions().get::<AgentInstance>()?.clone();
+        Some(instance.0.configure_request(self))
+    }
 }
 
 impl From<Agent> for AgentRef<'static> {
@@ -178,6 +195,8 @@ impl Deref for AgentRef<'_> {
 mod tests {
     use super::*;
     use crate::config::RequestLevelConfig;
+    use crate::middleware::MiddlewareNext;
+    use crate::SendBody;
     use std::time::Duration;
 
     #[test]
@@ -314,5 +333,46 @@ mod tests {
             request_config.0.timeouts().per_call,
             Some(Duration::from_secs(60))
         );
+    }
+
+    #[test]
+    fn middleware_config_none() {
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("http://foo.bar")
+            .body(())
+            .unwrap();
+
+        assert!(request.middleware_config().is_none());
+    }
+
+    #[test]
+    fn middleware_config() {
+        fn my_middleware(
+            req: Request<SendBody>,
+            next: MiddlewareNext,
+        ) -> Result<Response<Body>, crate::Error> {
+            let config = req.middleware_config().unwrap();
+            let req = config.build();
+            let mut ret = next.handle(req)?;
+            ret.extensions_mut().insert("worked".to_string());
+            Ok(ret)
+        }
+
+        let agent = Agent::config_builder()
+            .middleware(my_middleware)
+            .build()
+            .new_agent();
+
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("http://httpbin.org/get")
+            .body(())
+            .unwrap();
+
+        let request = request.with_agent(&agent);
+
+        let ret = request.run().unwrap();
+        assert_eq!(ret.extensions().get::<String>().unwrap(), "worked");
     }
 }


### PR DESCRIPTION
See #468 for the original PR and discussion.

This supports the middleware digest authentication under a feature `digest-auth`.

Presently, in order to use this feature we have to catch the authentication status code (401) and respond to it. However, with v3 this means that we now need to pass `http_status_as_error(false)` in order to propagate the authentication header into the middleware.

See the `TODO`s in code for places of discussion.

@strohel @mbernat

