### PR TITLE
Proxy resolve target host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+ * Fix incorrect DNS resolving when using proxies (#1081)
  * Use + instead of %20 for url encoded form bodies (#1071)
  * Fix problem with double-quotes in cookie values (#1068)
  * Reduce Body size (#1065)

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,7 +192,7 @@ impl Config {
     pub(crate) fn connect_proxy_uri(&self) -> Option<&Uri> {
         let proxy = self.proxy.as_ref()?;
 
-        if !proxy.proto().is_connect() {
+        if !proxy.protocol().is_connect() {
             return None;
         }
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,0 +1,136 @@
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
+use std::fmt;
+use std::io::Write;
+use ureq_proto::parser::try_parse_response;
+
+use http::StatusCode;
+
+use crate::config::DEFAULT_USER_AGENT;
+use crate::http;
+use crate::transport::{ConnectionDetails, Connector, Either, Transport, TransportAdapter};
+use crate::util::{SchemeExt, UriExt};
+use crate::Error;
+
+/// Connector for CONNECT proxy settings.
+///
+/// This operates on the previous chained transport typically a TcpConnector optionally
+/// wrapped in TLS.
+#[derive(Default)]
+pub struct ConnectProxyConnector(());
+
+impl<In: Transport> Connector<In> for ConnectProxyConnector {
+    type Out = Either<In, Box<dyn Transport>>;
+
+    fn connect(
+        &self,
+        details: &ConnectionDetails,
+        chained: Option<In>,
+    ) -> Result<Option<Self::Out>, Error> {
+        // If there is already a connection, do nothing.
+        if let Some(transport) = chained {
+            return Ok(Some(Either::A(transport)));
+        }
+
+        // If we're using a CONNECT proxy, we need to resolve that hostname.
+        let maybe_connect_uri = details.config.connect_proxy_uri();
+
+        let Some(connect_uri) = maybe_connect_uri else {
+            // Not using CONNECT
+            return Ok(None);
+        };
+
+        let target = details.uri;
+
+        // TODO(martin): it's a bit weird to put the CONNECT proxy
+        // resolver timeout as part of Timeout::Connect, but we don't
+        // have anything more granular for now.
+        let addrs = details
+            .resolver
+            .resolve(connect_uri, details.config, details.timeout)?;
+
+        let proxy_config = details.config.clone_without_proxy();
+
+        // ConnectionDetails to establish a connection to the CONNECT
+        // proxy itself.
+        let proxy_details = ConnectionDetails {
+            uri: connect_uri,
+            addrs,
+            config: &proxy_config,
+            request_level: details.request_level,
+            resolver: details.resolver,
+            now: details.now,
+            timeout: details.timeout,
+            run_connector: details.run_connector.clone(),
+        };
+
+        let transport = (details.run_connector)(&proxy_details)?;
+
+        // unwrap is ok because connect_proxy_uri() above checks it.
+        let proxy = details.config.proxy().unwrap();
+
+        let mut w = TransportAdapter::new(transport);
+
+        target.ensure_valid_url()?;
+
+        // unwraps are ok because ensure_valid_url() checks it.
+        let target_host = target.host().unwrap();
+        let target_port = target
+            .port_u16()
+            .unwrap_or(target.scheme().unwrap().default_port().unwrap());
+
+        write!(w, "CONNECT {}:{} HTTP/1.1\r\n", target_host, target_port)?;
+        write!(w, "Host: {}:{}\r\n", target_host, target_port)?;
+        if let Some(v) = details.config.user_agent().as_str(DEFAULT_USER_AGENT) {
+            write!(w, "User-Agent: {}\r\n", v)?;
+        }
+        write!(w, "Proxy-Connection: Keep-Alive\r\n")?;
+
+        let use_creds = proxy.username().is_some() || proxy.password().is_some();
+
+        if use_creds {
+            let user = proxy.username().unwrap_or_default();
+            let pass = proxy.password().unwrap_or_default();
+            let creds = BASE64_STANDARD.encode(format!("{}:{}", user, pass));
+            write!(w, "Proxy-Authorization: basic {}\r\n", creds)?;
+        }
+
+        write!(w, "\r\n")?;
+        w.flush()?;
+
+        let mut transport = w.into_inner();
+
+        let response = loop {
+            let made_progress = transport.maybe_await_input(details.timeout)?;
+            let buffers = transport.buffers();
+            let input = buffers.input();
+            let Some((used_input, response)) = try_parse_response::<20>(input)? else {
+                if !made_progress {
+                    let reason = "proxy server did not respond".to_string();
+                    return Err(Error::ConnectProxyFailed(reason));
+                }
+                continue;
+            };
+            buffers.input_consume(used_input);
+            break response;
+        };
+
+        match response.status() {
+            StatusCode::OK => {
+                trace!("CONNECT proxy connected");
+            }
+            x => {
+                let reason = format!("proxy server responded {}/{}", x.as_u16(), x.as_str());
+                return Err(Error::ConnectProxyFailed(reason));
+            }
+        }
+
+        Ok(Some(Either::B(transport)))
+    }
+}
+
+impl fmt::Debug for ConnectProxyConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProxyConnector").finish()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,6 +532,7 @@ pub use send_body::AsSendBody;
 mod agent;
 mod body;
 pub mod config;
+mod connect;
 mod error;
 mod pool;
 mod proxy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,7 +522,7 @@ pub use ureq_proto::http;
 pub use body::{Body, BodyBuilder, BodyReader, BodyWithConfig};
 use http::Method;
 use http::{Request, Response, Uri};
-pub use proxy::{Proxy, ProxyProtocol};
+pub use proxy::{Proxy, ProxyBuilder, ProxyProtocol};
 pub use request::RequestBuilder;
 use request::{WithBody, WithoutBody};
 pub use request_ext::RequestExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,7 +522,7 @@ pub use ureq_proto::http;
 pub use body::{Body, BodyBuilder, BodyReader, BodyWithConfig};
 use http::Method;
 use http::{Request, Response, Uri};
-pub use proxy::Proxy;
+pub use proxy::{Proxy, ProxyProtocol};
 pub use request::RequestBuilder;
 use request::{WithBody, WithoutBody};
 pub use request_ext::RequestExt;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -54,6 +54,54 @@ impl ProxyProtocol {
 }
 
 /// Proxy server settings
+///
+/// This struct represents a proxy server configuration that can be used to route HTTP/HTTPS
+/// requests through a proxy server. It supports various proxy protocols including HTTP CONNECT,
+/// HTTPS CONNECT, SOCKS4, SOCKS4A, and SOCKS5.
+///
+/// # Protocol Support
+///
+/// * `HTTP`: HTTP CONNECT proxy
+/// * `HTTPS`: HTTPS CONNECT proxy (requires a TLS provider)
+/// * `SOCKS4`: SOCKS4 proxy (requires **socks-proxy** feature)
+/// * `SOCKS4A`: SOCKS4A proxy (requires **socks-proxy** feature)
+/// * `SOCKS5`: SOCKS5 proxy (requires **socks-proxy** feature)
+///
+/// # DNS Resolution
+///
+/// The `resolve_target` setting controls where DNS resolution happens:
+///
+/// * When `true`: DNS resolution happens locally before connecting to the proxy.
+///   The resolved IP address is sent to the proxy.
+/// * When `false`: The hostname is sent to the proxy, which performs DNS resolution.
+///
+/// Default behavior:
+/// * For SOCKS4: `true` (local resolution required)
+/// * For all other protocols: `false` (proxy performs resolution)
+///
+/// # Examples
+///
+/// ```rust
+/// use ureq::{Proxy, ProxyProtocol};
+///
+/// // Create a proxy from a URI string
+/// let proxy = Proxy::new("http://localhost:8080").unwrap();
+///
+/// // Create a proxy using the builder pattern
+/// let proxy = Proxy::builder(ProxyProtocol::Socks5)
+///     .host("proxy.example.com")
+///     .port(1080)
+///     .username("user")
+///     .password("pass")
+///     .resolve_target(true)  // Force local DNS resolution
+///     .build()
+///     .unwrap();
+///
+/// // Read proxy settings from environment variables
+/// if let Some(proxy) = Proxy::try_from_env() {
+///     // Use proxy from environment
+/// }
+/// ```
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct Proxy {
     inner: Arc<ProxyInner>,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,18 +1,12 @@
-use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
-use std::io::Write;
 use std::sync::Arc;
 use ureq_proto::http::uri::{PathAndQuery, Scheme};
-use ureq_proto::parser::try_parse_response;
 
-use http::{StatusCode, Uri};
+use http::Uri;
 
-use crate::config::DEFAULT_USER_AGENT;
 use crate::http;
-use crate::transport::{ConnectionDetails, Connector, Either, Transport, TransportAdapter};
-use crate::util::{AuthorityExt, DebugUri, SchemeExt, UriExt};
+use crate::util::{AuthorityExt, DebugUri};
 use crate::Error;
 
 /// Proxy protocol
@@ -331,122 +325,6 @@ impl ProxyBuilder {
     }
 }
 
-/// Connector for CONNECT proxy settings.
-///
-/// This operates on the previous chained transport typically a TcpConnector optionally
-/// wrapped in TLS.
-#[derive(Default)]
-pub struct ConnectProxyConnector(());
-
-impl<In: Transport> Connector<In> for ConnectProxyConnector {
-    type Out = Either<In, Box<dyn Transport>>;
-
-    fn connect(
-        &self,
-        details: &ConnectionDetails,
-        chained: Option<In>,
-    ) -> Result<Option<Self::Out>, Error> {
-        // If there is already a connection, do nothing.
-        if let Some(transport) = chained {
-            return Ok(Some(Either::A(transport)));
-        }
-
-        // If we're using a CONNECT proxy, we need to resolve that hostname.
-        let maybe_connect_uri = details.config.connect_proxy_uri();
-
-        let Some(connect_uri) = maybe_connect_uri else {
-            // Not using CONNECT
-            return Ok(None);
-        };
-
-        let proxied = details.uri;
-
-        // TODO(martin): it's a bit weird to put the CONNECT proxy
-        // resolver timeout as part of Timeout::Connect, but we don't
-        // have anything more granular for now.
-        let addrs = details
-            .resolver
-            .resolve(connect_uri, details.config, details.timeout)?;
-
-        let proxy_config = details.config.clone_without_proxy();
-
-        // ConnectionDetails to establish a connection to the CONNECT
-        // proxy itself.
-        let proxy_details = ConnectionDetails {
-            uri: connect_uri,
-            addrs,
-            config: &proxy_config,
-            request_level: details.request_level,
-            resolver: details.resolver,
-            now: details.now,
-            timeout: details.timeout,
-            run_connector: details.run_connector.clone(),
-        };
-
-        let transport = (details.run_connector)(&proxy_details)?;
-
-        // unwrap is ok because connect_proxy_uri() above checks it.
-        let proxy = details.config.proxy().unwrap();
-
-        let mut w = TransportAdapter::new(transport);
-
-        proxied.ensure_valid_url()?;
-
-        let proxied_host = proxied.host().unwrap();
-        let proxied_port = proxied
-            .port_u16()
-            .unwrap_or(proxied.scheme().unwrap().default_port().unwrap());
-
-        write!(w, "CONNECT {}:{} HTTP/1.1\r\n", proxied_host, proxied_port)?;
-        write!(w, "Host: {}:{}\r\n", proxied_host, proxied_port)?;
-        if let Some(v) = details.config.user_agent().as_str(DEFAULT_USER_AGENT) {
-            write!(w, "User-Agent: {}\r\n", v)?;
-        }
-        write!(w, "Proxy-Connection: Keep-Alive\r\n")?;
-
-        let use_creds = proxy.username().is_some() || proxy.password().is_some();
-
-        if use_creds {
-            let user = proxy.username().unwrap_or_default();
-            let pass = proxy.password().unwrap_or_default();
-            let creds = BASE64_STANDARD.encode(format!("{}:{}", user, pass));
-            write!(w, "Proxy-Authorization: basic {}\r\n", creds)?;
-        }
-
-        write!(w, "\r\n")?;
-        w.flush()?;
-
-        let mut transport = w.into_inner();
-
-        let response = loop {
-            let made_progress = transport.maybe_await_input(details.timeout)?;
-            let buffers = transport.buffers();
-            let input = buffers.input();
-            let Some((used_input, response)) = try_parse_response::<20>(input)? else {
-                if !made_progress {
-                    let reason = "proxy server did not respond".to_string();
-                    return Err(Error::ConnectProxyFailed(reason));
-                }
-                continue;
-            };
-            buffers.input_consume(used_input);
-            break response;
-        };
-
-        match response.status() {
-            StatusCode::OK => {
-                trace!("CONNECT proxy connected");
-            }
-            x => {
-                let reason = format!("proxy server responded {}/{}", x.as_u16(), x.as_str());
-                return Err(Error::ConnectProxyFailed(reason));
-            }
-        }
-
-        Ok(Some(Either::B(transport)))
-    }
-}
-
 impl TryFrom<&str> for ProxyProtocol {
     type Error = Error;
 
@@ -482,12 +360,6 @@ impl fmt::Display for ProxyProtocol {
             ProxyProtocol::Socks4A => write!(f, "SOCKS4a"),
             ProxyProtocol::Socks5 => write!(f, "SOCKS5"),
         }
-    }
-}
-
-impl fmt::Debug for ConnectProxyConnector {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ProxyConnector").finish()
     }
 }
 

--- a/src/unversioned/transport/mod.rs
+++ b/src/unversioned/transport/mod.rs
@@ -57,7 +57,7 @@ mod socks;
 #[cfg(feature = "socks-proxy")]
 pub use self::socks::SocksConnector;
 
-pub use crate::proxy::ConnectProxyConnector;
+pub use crate::connect::ConnectProxyConnector;
 
 #[cfg(feature = "_rustls")]
 pub use crate::tls::rustls::RustlsConnector;

--- a/src/unversioned/transport/mod.rs
+++ b/src/unversioned/transport/mod.rs
@@ -189,7 +189,8 @@ pub struct ConnectionDetails<'a> {
 
     /// The resolved IP address + port for the uri being requested. See [`Resolver`].
     ///
-    /// For CONNECT proxy, this is the address of the proxy server.
+    /// For proxies, whetherh this holds real addresses depends on
+    /// [`Proxy::resolve_target()`](crate::Proxy::resolve_target).
     pub addrs: ResolvedSocketAddrs,
 
     /// The configuration.

--- a/src/unversioned/transport/mod.rs
+++ b/src/unversioned/transport/mod.rs
@@ -424,7 +424,7 @@ mod no_proxy {
         ) -> Result<Option<Self::Out>, Error> {
             if chained.is_none() {
                 if let Some(proxy) = details.config.proxy() {
-                    if proxy.proto().is_socks() {
+                    if proxy.protocol().is_socks() {
                         if proxy.is_from_env() {
                             warn!(
                                 "Enable feature socks-proxy to use proxy

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,7 @@ use http::uri::{Authority, Scheme};
 use http::{HeaderMap, HeaderName, HeaderValue, Method, Response, Uri, Version};
 
 use crate::http;
-use crate::proxy::Proto;
+use crate::proxy::ProxyProtocol;
 use crate::Error;
 
 pub(crate) mod private {
@@ -51,7 +51,7 @@ impl SchemeExt for Scheme {
             Some(443)
         } else if *self == Scheme::HTTP {
             Some(80)
-        } else if let Ok(proxy) = Proto::try_from(self.as_str()) {
+        } else if let Ok(proxy) = ProxyProtocol::try_from(self.as_str()) {
             Some(proxy.default_port())
         } else {
             debug!("Unknown scheme: {}", self);

--- a/src/util.rs
+++ b/src/util.rs
@@ -305,6 +305,9 @@ pub(crate) trait UriExt {
 
     #[cfg(feature = "_url")]
     fn try_into_url(&self) -> Result<url::Url, Error>;
+
+    #[allow(unused)]
+    fn host_port(&self) -> (&str, u16);
 }
 
 impl UriExt for Uri {
@@ -332,6 +335,14 @@ impl UriExt for Uri {
         let url = url::Url::parse(&uri).expect("parsed url");
 
         Ok(url)
+    }
+
+    fn host_port(&self) -> (&str, u16) {
+        (
+            self.host().unwrap(),
+            self.port_u16()
+                .unwrap_or(self.scheme().unwrap().default_port().unwrap_or(80)),
+        )
     }
 }
 


### PR DESCRIPTION
This is a behavioral change for ureq. However the previous behavior is considered a bug, thus we are correcting that bug without bumping major versions.

Before this PR, we always resolved the target host, even if we didn't use the resolved IP. 

# Before

* CONNECT – resolved target host, but didn't use it. The `host:port` passed in the `CONNECT` string.
* SOCKS – resolved target host and used it unconditionally for all types for SOCKS proxy.

# After

* CONNECT when `resolve_target` is `true` – resolves the target, _and use it_ in `CONNECT`.
* CONNECT when `resolve_target` is `false` -  does not resolve target, pass `host:port` in `CONNECT`.
* SOCKS when `resolve_target` is `true` – resolve target and use it. Same as previous behavior.
* SOCKS when `resolve_target` is `false` – do not resolve target, pass `host:port` to proxy.

SOCKS4 defaults to `resolve_target: true` all other to `false`.

NB: The previous behavior where CONNECT proxy could resolve the target, and then not use it, is not possible anymore. This behavior is considered a bug, and we are not supporting it going forward.

Close #1081 