### PR TITLE
bump `webpki-roots` / `webpki-root-certs` version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Bump webpki-roots/webpki-root-certs to 1.0.0 (#1089)
+* Bump rustls-platform-verifier to 0.6.0 (#1089)
+* Allow the license CDLA-Permissive-2.0 (#1089)
+
 # 3.0.12
 
  * Chunked transfer handle abrupt close after 0\r\n (#1074)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
@@ -787,9 +787,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "litrs"
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
  "libc",
  "log",
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1112,9 +1112,9 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
+checksum = "eda84358ed17f1f354cf4b1909ad346e6c7bc2513e8c40eb08e0157aa13a9070"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
@@ -1127,7 +1127,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs 0.26.8",
+ "webpki-root-certs",
  "windows-sys 0.59.0",
 ]
 
@@ -1139,9 +1139,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1428,7 +1428,7 @@ dependencies = [
  "ureq-proto",
  "url",
  "utf-8",
- "webpki-root-certs 1.0.0",
+ "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -1506,15 +1506,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "webpki-root-certs"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
-dependencies = [
- "rustls-pki-types",
-]
 
 [[package]]
 name = "webpki-root-certs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.8",
  "windows-sys 0.59.0",
 ]
 
@@ -1428,7 +1428,7 @@ dependencies = [
  "ureq-proto",
  "url",
  "utf-8",
- "webpki-root-certs",
+ "webpki-root-certs 1.0.0",
  "webpki-roots",
 ]
 
@@ -1517,10 +1517,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.8"
+name = "webpki-root-certs"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ percent-encoding = "2.3.1"
 rustls-pemfile = { version = "2.1.2", optional = true, default-features = false, features = ["std"] }
 rustls-pki-types = { version = "1.11.0", optional = true, default-features = false, features = ["std"] }
 rustls-platform-verifier = { version = "0.5.1", optional = true, default-features = false }
-webpki-roots = { version = "0.26.8", optional = true, default-features = false }
-webpki-root-certs = { version = "0.26.8", optional = true, default-features = false }
+webpki-roots = { version = "1.0.0", optional = true, default-features = false }
+webpki-root-certs = { version = "1.0.0", optional = true, default-features = false }
 
 rustls = { version = "0.23.22", optional = true, default-features = false, features = ["logging", "std", "tls12"] }
 # held back on 0.2.12 to avoid double dependency on windows-sys (0.59.0, 0.52.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ percent-encoding = "2.3.1"
 # These are used regardless of TLS implementation.
 rustls-pemfile = { version = "2.1.2", optional = true, default-features = false, features = ["std"] }
 rustls-pki-types = { version = "1.11.0", optional = true, default-features = false, features = ["std"] }
-rustls-platform-verifier = { version = "0.5.1", optional = true, default-features = false }
+rustls-platform-verifier = { version = "0.6.0", optional = true, default-features = false }
 webpki-roots = { version = "1.0.0", optional = true, default-features = false }
 webpki-root-certs = { version = "1.0.0", optional = true, default-features = false }
 

--- a/deny.toml
+++ b/deny.toml
@@ -83,6 +83,7 @@ allow = [
   "Unicode-DFS-2016",               # https://spdx.org/licenses/Unicode-DFS-2016.html
   "Unicode-3.0",                    # https://www.unicode.org/license.txt
   "Zlib",                           # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
+  "CDLA-Permissive-2.0",            # https://cdla.dev/permissive-2-0/
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
# Motivation

- `webpki-roots` and `webpki-root-certs` both recently got their versions bumped to `1.0.0`
- some other crates in the broader eco-system like [`hyper-rustls`](https://github.com/rustls/hyper-rustls/blob/main/Cargo.toml#L37) and [`reqwest`](https://github.com/seanmonstar/reqwest/blob/master/Cargo.toml#L147) already make use of this
- I was recently also trying to trim down on some duplicate dependencies in our tree @ $WORK and saw that `ureq` is still using the `0.x.y` version of both crates
- Hence I decided to bump the dependencies

---

# Testing / verification

- I ran all the test and they were still green after the version bumps without any additional adjustments

---

Feel free to let me know if I can approve the pull request somehow :)