### PR TITLE
SendBody to track Content-Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Send Content-Length for File (#1100)
 * native-tls transport capture and surface underlying errors (#1093)
 * Bump webpki-roots/webpki-root-certs to 1.0.0 (#1089)
 * Bump rustls-platform-verifier to 0.6.0 (#1089)

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -213,14 +213,14 @@ impl Agent {
     /// ```
     pub fn run(&self, request: Request<impl AsSendBody>) -> Result<Response<Body>, Error> {
         let (parts, mut body) = request.into_parts();
-        let body = body.as_body();
+        let mut body = body.as_body();
         let mut request = Request::from_parts(parts, ());
 
         // When using the http-crate API we cannot enforce the correctness of
         // Method vs Body combos. This also solves a problem where we can't
         // determine if a non-standard method is supposed to have a body such
         // as for WebDAV PROPFIND.
-        let has_body = !matches!(body.body_mode(), BodyMode::NoBody);
+        let has_body = !matches!(body.body_mode(), Ok(BodyMode::NoBody));
         if has_body {
             request.extensions_mut().insert(ForceSendBody);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,6 +1033,35 @@ pub(crate) mod test {
 
     #[test]
     #[cfg(not(feature = "_test"))]
+    fn post_array_body_sends_content_length() {
+        init_test_log();
+        let mut response = post("http://httpbin.org/post")
+            .content_type("application/octet-stream")
+            .send(vec![42; 123])
+            .expect("to send correctly");
+
+        let ret = response.body_mut().read_to_string().unwrap();
+        assert!(ret.contains("\"Content-Length\": \"123\""));
+    }
+
+    #[test]
+    #[cfg(not(feature = "_test"))]
+    fn post_file_sends_file_length() {
+        init_test_log();
+
+        let file = std::fs::File::open("LICENSE-MIT").unwrap();
+
+        let mut response = post("http://httpbin.org/post")
+            .content_type("application/octet-stream")
+            .send(file)
+            .expect("to send correctly");
+
+        let ret = response.body_mut().read_to_string().unwrap();
+        assert!(ret.contains("\"Content-Length\": \"1072\""));
+    }
+
+    #[test]
+    #[cfg(not(feature = "_test"))]
     fn username_password_from_uri() {
         init_test_log();
         let mut res = get("https://martin:secret@httpbin.org/get").call().unwrap();

--- a/src/run.rs
+++ b/src/run.rs
@@ -251,7 +251,7 @@ fn add_headers(
     call: &mut Call<Prepare>,
     agent: &Agent,
     config: &Config,
-    body: &SendBody,
+    body: &mut SendBody,
     uri: &Uri,
 ) -> Result<(), Error> {
     let headers = call.headers();
@@ -259,7 +259,7 @@ fn add_headers(
     let send_body_mode = if headers.has_send_body_mode() {
         None
     } else {
-        Some(body.body_mode())
+        Some(body.body_mode()?)
     };
     let has_header_accept_enc = headers.has_accept_encoding();
     let has_header_ua = headers.has_user_agent();


### PR DESCRIPTION
Track `Content-Length` in another way. Previously only array-like types would send `Content-Length`. With this change also `File` will send it.

Close #1098 