### PR TITLE
feat: respect `NO_PROXY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Support for env NO_PROXY and proxy config #1118
+
 # 3.1.2
 
   * Fix bug when query is after host "example.com?query" #1115

--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ The default enabled features are: **rustls** and **gzip**.
 * **platform-verifier** enables verifying the server certificates using a method native to the
   platform ureq is executing on. See [rustls-platform-verifier] crate
 * **socks-proxy** enables proxy config using the `socks4://`, `socks4a://`, `socks5://`
-   and `socks://` (equal to `socks5://`) prefix
+  and `socks://` (equal to `socks5://`) prefix
 * **cookies** enables cookies
 * **gzip** enables requests of gzip-compressed responses and decompresses them
 * **brotli** enables requests brotli-compressed responses and decompresses them
 * **charset** enables interpreting the charset part of the Content-Type header
-   (e.g.  `Content-Type: text/plain; charset=iso-8859-1`). Without this, the
-   library defaults to Rust's built in `utf-8`
+  (e.g.  `Content-Type: text/plain; charset=iso-8859-1`). Without this, the
+  library defaults to Rust's built in `utf-8`
 * **json** enables JSON sending and receiving via serde_json
 
 #### Unstable
@@ -371,6 +371,15 @@ the former is always available while the latter must be enabled using the featur
 **socks-proxy**.
 
 Proxies settings are configured on an [`Agent`]. All request sent through the agent will be proxied.
+
+### Environment Variables
+
+ureq automatically reads proxy configuration from environment variables when creating
+a default [`Agent`]. Proxy variables are checked in order: `ALL_PROXY`, `HTTPS_PROXY`,
+then `HTTP_PROXY` (with lowercase variants).
+
+`NO_PROXY` specifies hosts that bypass the proxy, supporting exact hosts, wildcard
+suffixes (`*.example.com`), dot suffixes (`.example.com`), and match-all (`*`).
 
 ### Example using HTTP
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,13 +208,6 @@ impl Config {
         c.proxy = None;
         c
     }
-
-    pub(crate) fn should_proxy(&self, uri: &Uri) -> bool {
-        match (self.proxy.as_ref(), uri.host()) {
-            (Some(proxy), Some(host)) => proxy.should_proxy(host),
-            _ => true,
-        }
-    }
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,9 +210,9 @@ impl Config {
     }
 
     pub(crate) fn should_proxy(&self, uri: &Uri) -> bool {
-        match (self.proxy.as_ref(),uri.host()) {
+        match (self.proxy.as_ref(), uri.host()) {
             (Some(proxy), Some(host)) => proxy.should_proxy(host),
-            _ => true
+            _ => true,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -208,6 +208,13 @@ impl Config {
         c.proxy = None;
         c
     }
+
+    pub(crate) fn should_proxy(&self, uri: &Uri) -> bool {
+        match (self.proxy.as_ref(),uri.host()) {
+            (Some(proxy), Some(host)) => proxy.should_proxy(host),
+            _ => true
+        }
+    }
 }
 
 impl Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,15 @@
 //!
 //! Proxies settings are configured on an [`Agent`]. All request sent through the agent will be proxied.
 //!
+//! ## Environment Variables
+//!
+//! ureq automatically reads proxy configuration from environment variables when creating
+//! a default [`Agent`]. Proxy variables are checked in order: `ALL_PROXY`, `HTTPS_PROXY`,
+//! then `HTTP_PROXY` (with lowercase variants).
+//!
+//! `NO_PROXY` specifies hosts that bypass the proxy, supporting exact hosts, wildcard
+//! suffixes (`*.example.com`), dot suffixes (`.example.com`), and match-all (`*`).
+//!
 //! ## Example using HTTP
 //!
 //! ```rust

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -202,6 +202,10 @@ impl Proxy {
     /// * `HTTPS_PROXY`
     /// * `HTTP_PROXY`
     ///
+    /// Additionally, the `NO_PROXY` environment variable is automatically read to determine
+    /// which hosts should bypass the proxy. This supports various pattern types including
+    /// exact hostnames, wildcard suffixes, and dot suffixes.
+    ///
     /// Returns `None` if no environment variable is set or the URI is invalid.
     pub fn try_from_env() -> Option<Self> {
         const TRY_ENV: &[&str] = &[
@@ -472,6 +476,26 @@ impl NoProxy {
     ///
     /// * `NO_PROXY`
     /// * `no_proxy`
+    ///
+    /// ## Supported Pattern Types
+    ///
+    /// * **Exact match**: `localhost`, `127.0.0.1` - matches the exact hostname (case-insensitive)
+    /// * **Wildcard suffix**: `*.example.com` - matches any subdomain of example.com
+    /// * **Dot suffix**: `.example.com` - matches any subdomain of example.com (but not example.com itself)
+    /// * **Match all**: `*` - bypasses proxy for all requests
+    ///
+    /// ## Examples
+    ///
+    /// ```bash
+    /// # Bypass proxy for localhost and internal domains
+    /// export NO_PROXY=localhost,127.0.0.1,*.internal.com
+    ///
+    /// # Bypass proxy for staging subdomains but not staging itself
+    /// export NO_PROXY=.staging
+    ///
+    /// # Bypass proxy for everything
+    /// export NO_PROXY=*
+    /// ```
     ///
     /// Returns `None` if no environment variable is set
     pub fn try_from_env() -> Option<Self> {

--- a/src/run.rs
+++ b/src/run.rs
@@ -356,11 +356,11 @@ fn connect(
     // For most proxy configs, the proxy itself should resolve the host name we are connecting to.
     // However for SOCKS4, we must do it and pass the resolved IP to the proxy.
     let is_proxy_local_resolve = config.proxy().map(|p| p.resolve_target()).unwrap_or(false);
-    // This determines if we should proxy the request.
-    // This respects the environment variable `NO_PROXY`.
-    let should_proxy = config.should_proxy(uri);
 
-    let addrs = if !should_proxy || !is_proxy || is_proxy_local_resolve {
+    // Tells if this host matches NO_PROXY
+    let is_no_proxy = config.proxy().map(|p| p.is_no_proxy(&uri)).unwrap_or(false);
+
+    let addrs = if is_no_proxy || !is_proxy || is_proxy_local_resolve {
         agent
             .resolver
             .resolve(uri, config, timings.next_timeout(Timeout::Resolve))?

--- a/src/run.rs
+++ b/src/run.rs
@@ -356,8 +356,11 @@ fn connect(
     // For most proxy configs, the proxy itself should resolve the host name we are connecting to.
     // However for SOCKS4, we must do it and pass the resolved IP to the proxy.
     let is_proxy_local_resolve = config.proxy().map(|p| p.resolve_target()).unwrap_or(false);
+    // This determines if we should proxy the request.
+    // This respects the environment variable `NO_PROXY`.
+    let should_proxy = config.should_proxy(uri);
 
-    let addrs = if !is_proxy || is_proxy_local_resolve {
+    let addrs = if !should_proxy || !is_proxy || is_proxy_local_resolve {
         agent
             .resolver
             .resolve(uri, config, timings.next_timeout(Timeout::Resolve))?

--- a/src/run.rs
+++ b/src/run.rs
@@ -358,7 +358,7 @@ fn connect(
     let is_proxy_local_resolve = config.proxy().map(|p| p.resolve_target()).unwrap_or(false);
 
     // Tells if this host matches NO_PROXY
-    let is_no_proxy = config.proxy().map(|p| p.is_no_proxy(&uri)).unwrap_or(false);
+    let is_no_proxy = config.proxy().map(|p| p.is_no_proxy(uri)).unwrap_or(false);
 
     let addrs = if is_no_proxy || !is_proxy || is_proxy_local_resolve {
         agent

--- a/src/unversioned/transport/connect.rs
+++ b/src/unversioned/transport/connect.rs
@@ -40,12 +40,20 @@ impl<In: Transport> Connector<In> for ConnectProxyConnector {
             // Not using CONNECT
             return Ok(None);
         };
-        if !details.config.should_proxy(details.uri) {
-            return Ok(None);
-        }
 
         let target = details.uri;
         let target_addrs = &details.addrs;
+
+        // Check if this host matches NO_PROXY
+        let is_no_proxy = details
+            .config
+            .proxy()
+            .map(|p| p.is_no_proxy(target))
+            .unwrap_or(false);
+
+        if is_no_proxy {
+            return Ok(None);
+        }
 
         // TODO(martin): it's a bit weird to put the CONNECT proxy
         // resolver timeout as part of Timeout::Connect, but we don't

--- a/src/unversioned/transport/connect.rs
+++ b/src/unversioned/transport/connect.rs
@@ -40,6 +40,9 @@ impl<In: Transport> Connector<In> for ConnectProxyConnector {
             // Not using CONNECT
             return Ok(None);
         };
+        if !details.config.should_proxy(details.uri) {
+            return Ok(None);
+        }
 
         let target = details.uri;
         let target_addrs = &details.addrs;

--- a/src/unversioned/transport/socks.rs
+++ b/src/unversioned/transport/socks.rs
@@ -51,6 +51,10 @@ impl<In: Transport> Connector<In> for SocksConnector {
             .resolver
             .resolve(proxy.uri(), details.config, details.timeout)?;
 
+        if !details.config.should_proxy(details.uri) {
+            return Ok(None);
+        }
+
         let stream = if proxy.resolve_target() {
             // The target is already resolved by run().
             let resolved = details.addrs.iter().cloned();

--- a/src/unversioned/transport/socks.rs
+++ b/src/unversioned/transport/socks.rs
@@ -51,7 +51,14 @@ impl<In: Transport> Connector<In> for SocksConnector {
             .resolver
             .resolve(proxy.uri(), details.config, details.timeout)?;
 
-        if !details.config.should_proxy(details.uri) {
+        // Check if this host is not supposed to be proxied.
+        let is_no_proxy = details
+            .config
+            .proxy()
+            .map(|p| p.is_no_proxy(&details.uri))
+            .unwrap_or(false);
+
+        if is_no_proxy {
             return Ok(None);
         }
 

--- a/src/unversioned/transport/socks.rs
+++ b/src/unversioned/transport/socks.rs
@@ -55,7 +55,7 @@ impl<In: Transport> Connector<In> for SocksConnector {
         let is_no_proxy = details
             .config
             .proxy()
-            .map(|p| p.is_no_proxy(&details.uri))
+            .map(|p| p.is_no_proxy(details.uri))
             .unwrap_or(false);
 
         if is_no_proxy {


### PR DESCRIPTION
A bit of backstory, we ran into a issue in production where [nushell](https://github.com/nushell/nushell) was ignoring the `NO_PROXY` environment variable. Then after diving a bit deep it turns out that it depends on `ureq` which seems to not parse the the environment value.

This PR implements minimal pattern matching for `NO_PROXY` environment variable values to ensure proper proxy bypass behavior.

## Supported Patterns

| Pattern       | example.com | api.example.com | sub.domain.example.com |
|---------------|-------------|-----------------|------------------------|
| *.example.com | ❌ No match | ✅ Match        | ✅ Match               |
| .example.com  | ❌ No match | ✅ Match        | ✅ Match               |
| example.com   | ✅ Match    | ❌ No match     | ❌ No match            |
| *             | ✅ Match    | ✅ Match        | ✅ Match               |


> [!NOTE]
> IP address & CIDR (e.g., `192.168.1.1`, `192.168.1.1/24`) matching is not supported.

Multiple hosts can be specified in the `NO_PROXY` variable separated by commas.

## Related Issues
- [http get not using $env.no_proxy](https://github.com/nushell/nushell/issues/15244)

