### PR TITLE
tls: replace rustls-pemfile usage with rustls-pki-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,15 +1096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,7 +1413,6 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ vendored = ["native-tls?/vendored"]
 # Supported as long as rustls supports this.
 _ring = ["rustls?/ring"]
 _url = ["dep:url"]
-_tls = ["dep:rustls-pemfile", "dep:rustls-pki-types"]
+_tls = ["dep:rustls-pki-types"]
 _test = []
 _rustls = []
 _doc = ["rustls?/aws-lc-rs"]
@@ -63,7 +63,6 @@ utf-8 = "0.7.6"
 percent-encoding = "2.3.1"
 
 # These are used regardless of TLS implementation.
-rustls-pemfile = { version = "2.1.2", optional = true, default-features = false, features = ["std"] }
 rustls-pki-types = { version = "1.11.0", optional = true, default-features = false, features = ["std"] }
 rustls-platform-verifier = { version = "0.6.0", optional = true, default-features = false }
 webpki-roots = { version = "1.0.0", optional = true, default-features = false }

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,7 @@ pub enum Error {
     /// Breaking changes in that struct will not be reflected in ureq
     /// major versions.
     #[cfg(feature = "_tls")]
-    Pem(rustls_pemfile::Error),
+    Pem(rustls_pki_types::pem::Error),
 
     /// An error originating in Rustls.
     ///


### PR DESCRIPTION
[rusts-pemfile](https://github.com/rustls/pemfile) has been archived and won't see future updates. The [rustls-pki-types](https://github.com/rustls/pki-types) crate has supported PEM parsing since [v1.9.0](https://github.com/rustls/pki-types/releases/tag/v%2F1.9.0).

This commit converts the existing parsing while maintaining semver compatibility, with the exception of the `Error::Pem()` enum variant. This variant previously exposed a `rustls-pemfile` error type, and now switches to a similar `rustls-pki-types` error type. This breaking change is **not** considered in-scope for `ureq`'s semver policy based on the pre-existing rustdoc comment:

> *Note:* The wrapped error struct is not considered part of ureq API. Breaking changes in that struct will not be reflected in ureq major versions.

Resolves https://github.com/algesten/ureq/issues/1120