### PR TITLE
error:Translate Error::Timeout into io::ErrorKind::Timedout

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -185,11 +185,14 @@ impl std::error::Error for Error {}
 impl Error {
     /// Convert the error into a [`std::io::Error`].
     ///
-    /// If the error is [`Error::Io`], we unpack the error. In othe cases we make
-    /// an `std::io::ErrorKind::Other`.
+    /// If the error is [`Error::Io`], we unpack the error. If the error is
+    /// [`Error::Timeout`] we translate to `io::ErrorKind::TimedOut`.
+    /// In other cases we make it an `std::io::ErrorKind::Other`.
     pub fn into_io(self) -> io::Error {
         if let Self::Io(e) = self {
             e
+        } else if let Self::Timeout(_) = self {
+            io::Error::new(io::ErrorKind::TimedOut, self)
         } else {
             io::Error::new(io::ErrorKind::Other, self)
         }


### PR DESCRIPTION
This enables better categorization of errors.

In particular, TcpTransport translates `ErrorKind` to `ureq::Error::Timeout` errors on timeout conditions. These should then be re-raised as `ErrorKind::Timedout` errors behind the `io::Error` abstraction.

Omitting this error-structure forces downstream error-handlers to resort to string-matching to distinguish timeout-errors from other errors.