### PR TITLE
Remove default dependency to ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["rustls", "gzip"]
 
 ######## SUPPORTED FEATURES
 
-rustls = ["rustls-no-provider", "_ring"]
+rustls = ["rustls-no-provider"]
 native-tls = ["dep:native-tls", "dep:der", "_tls", "dep:webpki-root-certs"]
 platform-verifier = ["dep:rustls-platform-verifier"]
 socks-proxy = ["dep:socks"]


### PR DESCRIPTION
A lot of library crates removed the explicit default dependency to "ring". This was done such that binary authors can choose which TLS implementation to choose from.

By having `_ring` in the default options, binary authors no longer have the choice to choose the TLS library based on the dependency setup.

Then it is needed to opt into a provider at runtime:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
See the documentation of the CryptoProvider type for more information.
```

If a binary author depends on ureq like this then ring will be pulled in:

https://github.com/mdrokz/auto_generate_cdp/blob/master/Cargo.toml#L20