### PR TITLE
Allow `post_file_sends_file_length` test with CRLF line endings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1117,6 +1117,7 @@ pub(crate) mod test {
     fn post_file_sends_file_length() {
         init_test_log();
 
+        let bytes = include_bytes!("../LICENSE-MIT");
         let file = std::fs::File::open("LICENSE-MIT").unwrap();
 
         let mut response = post("http://httpbin.org/post")
@@ -1125,9 +1126,7 @@ pub(crate) mod test {
             .expect("to send correctly");
 
         let ret = response.body_mut().read_to_string().unwrap();
-        let content_length_lf = ret.contains("\"Content-Length\": \"1072\"");
-        let content_length_crlf = ret.contains("\"Content-Length\": \"1093\"");
-        assert!(content_length_lf || content_length_crlf);
+        assert!(ret.contains(&format!("\"Content-Length\": \"{}\"", bytes.len())));
     }
 
     #[test]


### PR DESCRIPTION
Hey 👋
I mainly develop on Windows, so my local git uses CRLF line endings by default. This causes the `cargo test` run to fail on `post_file_sends_file_length`. This PR updates the test to allow both LF and CRLF line endings.
