### PR TITLE
Introduce SOCKS5h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+  * Make socks5:// locally resolve before calling proxy #1138
+  * Add socks5h:// which DOESN'T locally resolve before calling proxy #1138
+
 # 3.1.4
 
   * Set content-type with new Multipart form #1133

--- a/src/unversioned/transport/socks.rs
+++ b/src/unversioned/transport/socks.rs
@@ -175,7 +175,8 @@ fn connect_proxy<'a, T: ToTargetAddr + 'a>(
 
             Socks4Stream::connect(proxy_addr, target_addr, "")?.into_inner()
         }
-        ProxyProtocol::Socks5 => {
+
+        ProxyProtocol::Socks5 | ProxyProtocol::Socks5h => {
             if let Some(username) = proxy.username() {
                 // Connect with authentication.
                 let password = proxy.password().unwrap_or("");
@@ -186,6 +187,7 @@ fn connect_proxy<'a, T: ToTargetAddr + 'a>(
             }
             .into_inner()
         }
+
         _ => unreachable!(), // HTTP(s) proxies.
     };
 


### PR DESCRIPTION
resolves algesten/ureq#639

Commonly, when using SOCKS proxies, the scheme "socks5h" is used to mean domain resolution should happen on the proxy server and "socks5" means resolution should happen locally. CURL is one of many tools to do things this way.

I've introduced `ProxyProtocol::SOCKS5h` which defaults to resolving on the proxy server and reverted `ProxyProtocol::SOCKS5` to resolve locally. I've added tests to ensure this is set properly when constructing SOCKS proxies.