### PR TITLE
Add RequestExt::middleware_config for per-request config inside middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * RequestExt::middleware_config for conf inside middleware #1169
+
 # 3.3.0
 
   * Bump MSRV 1.71 -> 1.85, edition 2024 #1167

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -1,5 +1,7 @@
+use crate::agent::AgentInstance;
 use crate::config::typestate::RequestExtScope;
 use crate::config::{Config, ConfigBuilder, RequestLevelConfig};
+use crate::typestate::HttpCrateScope;
 use crate::{Agent, AsSendBody, Body, Error, http};
 use std::ops::Deref;
 use ureq_proto::http::{Request, Response};
@@ -90,6 +92,16 @@ where
     ///             .run();
     /// ```
     fn with_agent<'a>(self, agent: impl Into<AgentRef<'a>>) -> WithAgent<'a, S>;
+
+    /// Returns a [`ConfigBuilder`] for configuring the request.
+    ///
+    /// This is only to be used from within [`Middleware`](crate::middleware::Middleware).
+    ///
+    /// Returns `None` if not called from within a [`Middleware`](crate::middleware::Middleware).
+    ///
+    /// Any usage beyond from inside a middleware, synchronously with handling the request, is
+    /// incorrect usage and might break without notice.
+    fn middleware_config(self) -> Option<ConfigBuilder<HttpCrateScope<S>>>;
 }
 
 /// Wrapper struct that holds a [`Request`] associated with an [`Agent`].
@@ -149,6 +161,11 @@ impl<S: AsSendBody> RequestExt<S> for http::Request<S> {
             request: self,
         }
     }
+
+    fn middleware_config(self) -> Option<ConfigBuilder<HttpCrateScope<S>>> {
+        let instance = self.extensions().get::<AgentInstance>()?.clone();
+        Some(instance.0.configure_request(self))
+    }
 }
 
 impl From<Agent> for AgentRef<'static> {
@@ -177,7 +194,9 @@ impl Deref for AgentRef<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SendBody;
     use crate::config::RequestLevelConfig;
+    use crate::middleware::MiddlewareNext;
     use std::time::Duration;
 
     #[test]
@@ -314,5 +333,46 @@ mod tests {
             request_config.0.timeouts().per_call,
             Some(Duration::from_secs(60))
         );
+    }
+
+    #[test]
+    fn middleware_config_none() {
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("http://foo.bar")
+            .body(())
+            .unwrap();
+
+        assert!(request.middleware_config().is_none());
+    }
+
+    #[test]
+    fn middleware_config() {
+        fn my_middleware(
+            req: Request<SendBody>,
+            next: MiddlewareNext,
+        ) -> Result<Response<Body>, crate::Error> {
+            let config = req.middleware_config().unwrap();
+            let req = config.build();
+            let mut ret = next.handle(req)?;
+            ret.extensions_mut().insert("worked".to_string());
+            Ok(ret)
+        }
+
+        let agent = Agent::config_builder()
+            .middleware(my_middleware)
+            .build()
+            .new_agent();
+
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("http://httpbin.org/get")
+            .body(())
+            .unwrap();
+
+        let request = request.with_agent(&agent);
+
+        let ret = request.run().unwrap();
+        assert_eq!(ret.extensions().get::<String>().unwrap(), "worked");
     }
 }


### PR DESCRIPTION
Extracted from #1075 (digest auth middleware) so the plumbing can land independently.

Adds `RequestExt::middleware_config()`, returning a `ConfigBuilder<HttpCrateScope>` when called from within a `Middleware`. This lets middleware flip per-request settings (e.g. `http_status_as_error(false)`) on the inner request before passing it down the chain — useful for any middleware that needs to inspect error responses (digest/NTLM/OAuth refresh, custom retry logic, etc.).

Mechanism: `Agent::do_run` now stashes a cloned `AgentInstance(Agent)` (cheap — all Arcs) in request extensions. `middleware_config()` pulls it out and calls `Agent::configure_request`.

With this landed, an out-of-tree digest-auth middleware crate becomes ~100 lines and needs no further ureq changes.

## Summary
- New `AgentInstance` extension type inserted in `do_run`
- New `RequestExt::middleware_config()` trait method
- Tests: one verifying `None` outside middleware, one verifying the happy path from inside middleware