### PR TITLE
Fix main CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,9 +1079,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,7 @@
 
 # Note: running just `cargo deny check` without a `--target` can result in
 # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
+[graph]
 targets = [
   { triple = "aarch64-apple-darwin" },
   { triple = "i686-pc-windows-gnu" },


### PR DESCRIPTION
## Summary

cargo-deny on `main` is currently red, which blocks every downstream PR from going green. Fixing it out-of-band here so unrelated work can rebase onto a clean base.

### Investigation

Running `cargo deny --all-features --target x86_64-pc-windows-gnu check` on main produced:

**Two RUSTSEC vulnerabilities against `rustls-webpki 0.103.10`:**
- [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098) — name constraints for URI names were ignored (GHSA-965h-392x-2mh5)
- [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) — permitted-subtree DNS name constraints accepted for certs with a wildcard name (GHSA-xgp8-3hg3-c2mh; analogous to CVE-2025-61727)

Both are post-signature-verification bugs that require misissuance to exploit, but cargo-deny fails the check regardless. The fix per the advisories is `cargo update -p rustls-webpki` to get >=0.103.12 (still MSRV 1.85 compatible; 0.103.13+ needs 1.86+).

**Two deprecation warnings** on `deny.toml`: `targets` and `exclude` at the document root have moved under `[graph]` in newer cargo-deny.

**One item investigated and kept as-is:** `RUSTSEC-2026-0009` (stack exhaustion in `time`'s RFC 2822 parser). Without `--all-features`, cargo-deny reports `advisory-not-detected` for the existing ignore and it looks stale — but with `--all-features` the `cookies` feature pulls `cookie_store 0.22.0 -> cookie 0.18.1 -> time 0.3.45` and the advisory does match. Upgrading `time` to 0.3.47 requires Rust 1.88, above our current MSRV of 1.85, so the ignore and its rationale stay.
