### PR TITLE
Strip brackets from IPv6-literal hosts before TLS SNI/ServerName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-  * Strip brackets from IPv6-literal hosts before TLS SNI/ServerName #1168
+  * Strip brackets from IPv6-literal hosts before TLS SNI/ServerName #1171
   * RequestExt::middleware_config for conf inside middleware #1169
 
 # 3.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Strip brackets from IPv6-literal hosts before TLS SNI/ServerName #1168
   * RequestExt::middleware_config for conf inside middleware #1169
 
 # 3.3.0

--- a/src/tls/native_tls.rs
+++ b/src/tls/native_tls.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::{fmt, io};
 
 use crate::tls::{RootCerts, TlsProvider};
+use crate::util::AuthorityExt;
 use crate::{Error, transport::time::Duration, transport::*};
 use der::Document;
 use der::pem::LineEnding;
@@ -57,7 +58,7 @@ impl<In: Transport> Connector<In> for NativeTlsConnector {
             .uri
             .authority()
             .expect("uri authority for tls")
-            .host()
+            .host_bare()
             .to_string();
 
         let adapter = ErrorCapture::wrap(TransportAdapter::new(transport.boxed()));

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -14,6 +14,7 @@ use crate::tls::cert::KeyKind;
 use crate::tls::{RootCerts, TlsProvider};
 use crate::transport::{Buffers, ConnectionDetails, Connector, LazyBuffers};
 use crate::transport::{Either, NextTimeout, Transport, TransportAdapter};
+use crate::util::AuthorityExt;
 
 use super::TlsConfig;
 
@@ -62,7 +63,7 @@ impl<In: Transport> Connector<In> for RustlsConnector {
             .uri
             .authority()
             .expect("uri authority for tls")
-            .host()
+            .host_bare()
             .try_into()
             .map_err(|e| {
                 debug!("rustls invalid dns name: {}", e);

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,6 +20,7 @@ pub(crate) trait AuthorityExt {
     fn userinfo(&self) -> Option<&str>;
     fn username(&self) -> Option<&str>;
     fn password(&self) -> Option<&str>;
+    fn host_bare(&self) -> &str;
 }
 
 // NB: Treating &str with direct indexes is OK, since Uri parsed the Authority,
@@ -38,6 +39,17 @@ impl AuthorityExt for Authority {
     fn password(&self) -> Option<&str> {
         self.userinfo()
             .and_then(|a| a.rfind(':').map(|i| &a[i + 1..]))
+    }
+
+    // Per RFC 3986, IPv6 literals in a URI authority are wrapped in square
+    // brackets (e.g. `[::1]`). `Authority::host()` returns that bracketed
+    // form. Consumers like rustls' `ServerName` expect the bare form and
+    // reject the brackets, so strip them here.
+    fn host_bare(&self) -> &str {
+        let host = self.host();
+        host.strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))
+            .unwrap_or(host)
     }
 }
 
@@ -395,5 +407,29 @@ impl HeaderMapExt for HeaderMap {
 
     fn has_location(&self) -> bool {
         self.contains_key(LOCATION)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn authority(uri: &str) -> Authority {
+        uri.parse::<Uri>().unwrap().authority().unwrap().clone()
+    }
+
+    #[test]
+    fn host_bare_strips_ipv6_brackets() {
+        assert_eq!(authority("https://[::1]/").host_bare(), "::1");
+        assert_eq!(
+            authority("https://[fe80::1000:ff:fe00:1234]:8443/").host_bare(),
+            "fe80::1000:ff:fe00:1234"
+        );
+    }
+
+    #[test]
+    fn host_bare_leaves_dns_and_ipv4_untouched() {
+        assert_eq!(authority("https://example.com/").host_bare(), "example.com");
+        assert_eq!(authority("https://127.0.0.1:8443/").host_bare(), "127.0.0.1");
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,6 +20,7 @@ pub(crate) trait AuthorityExt {
     fn userinfo(&self) -> Option<&str>;
     fn username(&self) -> Option<&str>;
     fn password(&self) -> Option<&str>;
+    #[allow(unused)]
     fn host_bare(&self) -> &str;
 }
 
@@ -430,6 +431,9 @@ mod tests {
     #[test]
     fn host_bare_leaves_dns_and_ipv4_untouched() {
         assert_eq!(authority("https://example.com/").host_bare(), "example.com");
-        assert_eq!(authority("https://127.0.0.1:8443/").host_bare(), "127.0.0.1");
+        assert_eq!(
+            authority("https://127.0.0.1:8443/").host_bare(),
+            "127.0.0.1"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `Authority::host()` returns IPv6 literals in their URI-syntax bracketed form (e.g. `[::1]`), per RFC 3986.
- rustls' `ServerName::try_from` rejects the brackets, so HTTPS to an IPv6-literal URL (e.g. `https://[::1]/`, link-local `[fe80::...]`) fails the TLS handshake with "invalid dns name". native-tls has the same problem — brackets aren't valid for SNI.
- Add `AuthorityExt::host_bare()` in `src/util.rs` that strips the surrounding `[` / `]` when present, and use it in both the rustls and native-tls connectors. DNS names and IPv4 literals are unaffected.
- Once the brackets are gone, rustls recognises the string as an IP and hands it to cert verification as `ServerName::IpAddress`, which matches the iPAddress SAN — i.e. no extension to rustls is needed.

Fixes #1168.
