### PR TITLE
Fix aging connection

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -151,7 +151,7 @@ impl Connection {
     }
 
     fn age(&self, now: Instant) -> Duration {
-        now.duration_since(now)
+        now.duration_since(self.last_use)
     }
 
     fn is_open(&mut self) -> bool {


### PR DESCRIPTION
Hi team, IIRC, when we get a pooled connection we need to check its age and decide whether its stale.
For the current implementation, it never expires.