### PR TITLE
Bump rustls-webpki to fix RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,9 +1079,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
PR #1172's cargo-deny jobs are failing on an advisory unrelated to that PR's code change. The cause is RUSTSEC-2026-0104 (reachable panic in CRL parsing) in `rustls-webpki 0.103.12`, picked up transitively via `rustls` / `rustls-platform-verifier`.

Fix is a lockfile-only bump to `rustls-webpki 0.103.13`, matching the pattern of 88dd8d7 ("Bump rustls-webpki to fix RUSTSEC-2026-0098/0099").

Once this lands on `main`, rebasing #1172 should clear its cargo-deny failures.

## Test plan
- [ ] CI cargo-deny jobs go green across all target triples