### PR TITLE
Serde interface for query params for consideration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,6 +1120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1423,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "getrandom 0.4.2",
+ "itoa",
  "log",
  "mime_guess",
  "native-tls",
@@ -1424,6 +1431,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "ryu",
  "serde",
  "serde_json",
  "socks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1395,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "getrandom 0.4.3",
+ "itoa",
  "log",
  "mime_guess",
  "native-tls",
@@ -1396,6 +1403,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "ryu",
  "serde",
  "serde_json",
  "socks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ json = ["dep:serde", "dep:serde_json", "cookie_store?/serde_json"]
 multipart = ["dep:mime_guess", "dep:getrandom"]
 rustls-webpki-roots = ["dep:webpki-roots"]
 native-tls-webpki-roots = ["dep:webpki-root-certs"]
+serde-query = ["dep:serde", "dep:itoa", "dep:ryu"]
 
 ######## UNSTABLE FEATURES.
 # Might be removed or changed in a minor version.
@@ -96,6 +97,8 @@ encoding_rs = { version = "0.8.34", optional = true }
 
 serde = { version = "1.0.138", optional = true, default-features = false, features = ["std"] }
 serde_json = { version = "1.0.120", optional = true, default-features = false, features = ["std"] }
+itoa = { version = "1", optional = true }
+ryu = { version = "1", optional = true }
 
 mime_guess = { version = "2.0.5", optional = true }
 getrandom = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ json = ["dep:serde", "dep:serde_json", "cookie_store?/serde_json"]
 multipart = ["dep:mime_guess", "dep:getrandom"]
 rustls-webpki-roots = ["dep:webpki-roots"]
 native-tls-webpki-roots = ["dep:webpki-root-certs"]
+serde-query = ["dep:serde", "dep:itoa", "dep:ryu"]
 
 ######## UNSTABLE FEATURES.
 # Might be removed or changed in a minor version.
@@ -97,6 +98,8 @@ encoding_rs = { version = "0.8.34", optional = true }
 
 serde = { version = "1.0.138", optional = true, default-features = false, features = ["std"] }
 serde_json = { version = "1.0.120", optional = true, default-features = false, features = ["std"] }
+itoa = { version = "1", optional = true }
+ryu = { version = "1", optional = true }
 
 mime_guess = { version = "2.0.5", optional = true }
 getrandom = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,7 @@ mod request;
 mod response;
 mod run;
 mod send_body;
+mod serde;
 mod timings;
 mod util;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -96,7 +96,7 @@ impl<'a> QueryParam<'a> {
         }
     }
 
-    fn as_str(&self) -> &str {
+    pub(crate) fn as_str(&self) -> &str {
         match &self.source {
             Source::Borrowed(v) => v,
             Source::Owned(v) => v.as_str(),

--- a/src/request.rs
+++ b/src/request.rs
@@ -251,6 +251,27 @@ impl<Any> RequestBuilder<Any> {
         );
         self
     }
+
+    #[cfg(feature = "serde-query")]
+    /// Sets multi query parameters from serde compatible object.
+    pub fn query_serde<T: serde::Serialize>(mut self, object: T) -> Self {
+        let serializer = crate::serde::query::QueryVisitor::escaped(&mut self.query_extra);
+        object
+            .serialize(serializer)
+            .expect("serialize query params from object");
+        self
+    }
+
+    #[cfg(feature = "serde-query")]
+    /// Sets multi query parameters from serde compatible object.
+    pub fn query_serde_raw<T: serde::Serialize>(mut self, object: T) -> Self {
+        let serializer = crate::serde::query::QueryVisitor::raw(&mut self.query_extra);
+        object
+            .serialize(serializer)
+            .expect("serialize query params from object");
+        self
+    }
+
     /// Overrides the URI for this request.
     ///
     /// Typically this is set via `ureq::get(<uri>)` or `Agent::get(<uri>)`. This

--- a/src/request.rs
+++ b/src/request.rs
@@ -254,6 +254,18 @@ impl<Any> RequestBuilder<Any> {
 
     #[cfg(feature = "serde-query")]
     /// Sets multi query parameters from serde compatible object.
+    ///
+    /// For example, to set `?format=json&dest=%2Flogin`
+    /// ```
+    /// let query = [
+    ///     ("format", "json"),
+    ///     ("dest", "/login"),
+    /// ];
+    ///
+    /// let request = ureq::get("http://httpbin.org/get")
+    ///    .query_serde(query)
+    ///    .call()?;
+    /// # Ok::<_, ureq::Error>(())
     pub fn query_serde<T: serde::Serialize>(mut self, object: T) -> Self {
         let serializer = crate::serde::query::QueryVisitor::escaped(&mut self.query_extra);
         object
@@ -264,6 +276,20 @@ impl<Any> RequestBuilder<Any> {
 
     #[cfg(feature = "serde-query")]
     /// Sets multi query parameters from serde compatible object.
+    ///
+    /// For example, to set `?format=json&dest=/login` without encoding:
+    ///
+    /// ```
+    /// let query = [
+    ///     ("format", "json"),
+    ///     ("dest", "/login"),
+    /// ];
+    ///
+    /// let response = ureq::get("http://httpbin.org/get")
+    ///    .query_serde_raw(query)
+    ///    .call()?;
+    /// # Ok::<_, ureq::Error>(())
+    /// ```
     pub fn query_serde_raw<T: serde::Serialize>(mut self, object: T) -> Self {
         let serializer = crate::serde::query::QueryVisitor::raw(&mut self.query_extra);
         object

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "serde-query")]
+pub mod query;

--- a/src/serde/query.rs
+++ b/src/serde/query.rs
@@ -1,0 +1,486 @@
+use core::{fmt, marker};
+use std::borrow::Cow;
+
+use crate::query::QueryParam;
+
+use serde::ser;
+
+pub trait Type {
+    fn new_key_value(key: &str, value: &str) -> QueryParam<'static>;
+}
+
+pub struct Escaped;
+
+impl Type for Escaped {
+    #[inline]
+    fn new_key_value(key: &str, value: &str) -> QueryParam<'static> {
+        QueryParam::new_key_value(key, value)
+    }
+}
+
+pub struct Raw;
+
+impl Type for Raw {
+    #[inline]
+    fn new_key_value(key: &str, value: &str) -> QueryParam<'static> {
+        QueryParam::new_key_value_raw(key, value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Error {
+    msg: Cow<'static, str>,
+}
+
+impl Error {
+    const fn expected_struct_like() -> Self {
+        Self {
+            msg: Cow::Borrowed("Query params expect struct/map"),
+        }
+    }
+
+    const fn expected_string_like_value() -> Self {
+        Self {
+            msg: Cow::Borrowed("Query value must be string or number"),
+        }
+    }
+
+    const fn expected_value() -> Self {
+        Self {
+            msg: Cow::Borrowed("Query value cannot be struct/map/sequence/tuple"),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str(self.msg.as_ref())
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl ser::Error for Error {
+    #[inline]
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self {
+            msg: msg.to_string().into(),
+        }
+    }
+}
+
+pub struct QueryVisitor<'a, T> {
+    output: &'a mut Vec<QueryParam<'static>>,
+    _typ: marker::PhantomData<T>,
+}
+
+impl<'a> QueryVisitor<'a, Escaped> {
+    pub fn escaped(output: &'a mut Vec<QueryParam<'static>>) -> Self {
+        Self {
+            output,
+            _typ: marker::PhantomData,
+        }
+    }
+}
+
+impl<'a> QueryVisitor<'a, Raw> {
+    pub fn raw(output: &'a mut Vec<QueryParam<'static>>) -> Self {
+        Self {
+            output,
+            _typ: marker::PhantomData,
+        }
+    }
+}
+
+impl<'output, T: Type> ser::Serializer for QueryVisitor<'output, T> {
+    type Ok = ();
+    type Error = Error;
+    type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = QueryVisitor<'output, T>;
+    type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = QueryVisitor<'output, T>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_str(self, _value: &str) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    /// Returns `Ok`.
+    fn serialize_unit(self) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    /// Returns `Ok`.
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    /// Serializes the inner value, ignoring the newtype name.
+    fn serialize_newtype_struct<V: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        value: &V,
+    ) -> Result<Self::Ok, Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<V: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &V,
+    ) -> Result<Self::Ok, Error> {
+        Err(Error::expected_struct_like())
+    }
+
+    /// Returns `Ok`.
+    fn serialize_none(self) -> Result<Self::Ok, Error> {
+        Ok(())
+    }
+
+    /// Serializes the given value.
+    fn serialize_some<V: ?Sized + ser::Serialize>(self, value: &V) -> Result<Self::Ok, Error> {
+        value.serialize(self)
+    }
+
+    /// Serialize a sequence, given length (if any) is ignored.
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+        todo!();
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Error> {
+        todo!();
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Error> {
+        todo!();
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Error> {
+        todo!();
+    }
+
+    /// Serializes a map, given length is ignored.
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Error> {
+        todo!();
+    }
+
+    /// Serializes a struct, given length is ignored.
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Error> {
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Error> {
+        Ok(self)
+    }
+}
+
+impl<'output, T: Type> ser::SerializeStructVariant for QueryVisitor<'output, T> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<V: ?Sized + ser::Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &V,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(QueryFieldVisitor::<T>::new(key, self.output))
+    }
+
+    fn skip_field(&mut self, _key: &'static str) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'output, T: Type> ser::SerializeStruct for QueryVisitor<'output, T> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<V: ?Sized + ser::Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &V,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(QueryFieldVisitor::<T>::new(key, self.output))
+    }
+
+    fn skip_field(&mut self, _key: &'static str) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+struct QueryFieldVisitor<'a, T> {
+    params: &'a mut Vec<QueryParam<'static>>,
+    key: &'a str,
+    _typ: marker::PhantomData<T>,
+}
+
+impl<'a, T: Type> QueryFieldVisitor<'a, T> {
+    fn new(key: &'a str, params: &'a mut Vec<QueryParam<'static>>) -> Self {
+        Self {
+            params,
+            key,
+            _typ: marker::PhantomData,
+        }
+    }
+}
+
+impl<T: Type> ser::Serializer for QueryFieldVisitor<'_, T> {
+    type Ok = ();
+    type Error = Error;
+    type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Error> {
+        let value = if value { "true" } else { "false" };
+        self.serialize_str(value)
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Self::Ok, Error> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Self::Ok, Error> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Self::Ok, Error> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Self::Ok, Error> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Self::Ok, Error> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Self::Ok, Error> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Self::Ok, Error> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Self::Ok, Error> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok, Error> {
+        self.serialize_str(ryu::Buffer::new().format(value))
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok, Error> {
+        self.serialize_str(ryu::Buffer::new().format(value))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Error> {
+        //unicode max length is 4 bytes
+        let mut buffer = [0u8; 4];
+        let value = value.encode_utf8(&mut buffer);
+        self.serialize_str(value)
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Error> {
+        self.params.push(T::new_key_value(self.key, value));
+        Ok(())
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Error> {
+        Err(Error::expected_string_like_value())
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Error> {
+        Err(Error::expected_value())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Error> {
+        Err(Error::expected_value())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Error> {
+        Err(Error::expected_value())
+    }
+
+    /// Serializes the inner value, ignoring the newtype name.
+    fn serialize_newtype_struct<V: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        value: &V,
+    ) -> Result<Self::Ok, Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<V: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &V,
+    ) -> Result<Self::Ok, Error> {
+        Err(Error::expected_value())
+    }
+
+    /// Skip field if it is None
+    fn serialize_none(self) -> Result<Self::Ok, Error> {
+        Ok(())
+    }
+
+    /// Serializes the given value.
+    fn serialize_some<V: ?Sized + ser::Serialize>(self, value: &V) -> Result<Self::Ok, Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+        Err(Error::expected_value())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Error> {
+        Err(Error::expected_value())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Error> {
+        Err(Error::expected_value())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Error> {
+        Err(Error::expected_value())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Error> {
+        Err(Error::expected_value())
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Error> {
+        Err(Error::expected_value())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Error> {
+        Err(Error::expected_value())
+    }
+}

--- a/src/serde/query.rs
+++ b/src/serde/query.rs
@@ -1051,3 +1051,73 @@ impl<'output, T: Type> ser::SerializeSeq for QueryFieldPairSeqVisitor<'output, T
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::QueryVisitor;
+    use std::collections::BTreeMap;
+
+    use serde::Serialize;
+
+    #[test]
+    fn should_serde_encode_query_from_map() {
+        let mut query = BTreeMap::new();
+        query.insert("key 1", "value 1");
+        query.insert("key 2", "value 2");
+
+        let mut output = Vec::new();
+        query
+            .serialize(QueryVisitor::escaped(&mut output))
+            .expect("to serialize");
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0].as_str(), "key%201=value%201");
+        assert_eq!(output[1].as_str(), "key%202=value%202");
+
+        output.clear();
+        query
+            .serialize(QueryVisitor::raw(&mut output))
+            .expect("to serialize");
+        assert_eq!(output[0].as_str(), "key 1=value 1");
+        assert_eq!(output[1].as_str(), "key 2=value 2");
+    }
+
+    #[test]
+    fn should_serde_encode_query_from_seq() {
+        let query = [("key 1", "value 1"), ("key 2", "value 2")];
+
+        let mut output = Vec::new();
+        query
+            .serialize(QueryVisitor::escaped(&mut output))
+            .expect("to serialize");
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0].as_str(), "key%201=value%201");
+        assert_eq!(output[1].as_str(), "key%202=value%202");
+
+        output.clear();
+        query
+            .serialize(QueryVisitor::raw(&mut output))
+            .expect("to serialize");
+        assert_eq!(output[0].as_str(), "key 1=value 1");
+        assert_eq!(output[1].as_str(), "key 2=value 2");
+    }
+
+    #[test]
+    fn should_serde_encode_query_from_tuple() {
+        let query = (("key 1", "value 1"), ("key 2", "value 2"));
+
+        let mut output = Vec::new();
+        query
+            .serialize(QueryVisitor::escaped(&mut output))
+            .expect("to serialize");
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0].as_str(), "key%201=value%201");
+        assert_eq!(output[1].as_str(), "key%202=value%202");
+
+        output.clear();
+        query
+            .serialize(QueryVisitor::raw(&mut output))
+            .expect("to serialize");
+        assert_eq!(output[0].as_str(), "key 1=value 1");
+        assert_eq!(output[1].as_str(), "key 2=value 2");
+    }
+}

--- a/src/serde/query.rs
+++ b/src/serde/query.rs
@@ -1,4 +1,4 @@
-use core::{fmt, marker};
+use core::{fmt, marker, mem};
 use std::borrow::Cow;
 
 use crate::query::QueryParam;
@@ -64,6 +64,22 @@ impl Error {
             msg: Cow::Borrowed("Query value cannot be struct/map/sequence/tuple"),
         }
     }
+
+    const fn expected_pair() -> Self {
+        Self {
+            msg: Cow::Borrowed("Element in sequence must be pair of key and value"),
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    const fn unexpected_pair_serde_error() -> Self {
+        Self {
+            msg: Cow::Borrowed(
+                "Internal error: Pair was supposed to have 2 elements but it is not the case",
+            ),
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -111,9 +127,9 @@ impl<'a> QueryVisitor<'a, Raw> {
 impl<'output, T: Type> ser::Serializer for QueryVisitor<'output, T> {
     type Ok = ();
     type Error = Error;
-    type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeSeq = QueryFieldPairSeqVisitor<'output, T>;
     type SerializeMap = QueryFieldMapVisitor<'output, T>;
-    type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = QueryFieldPairSeqVisitor<'output, T>;
     type SerializeStruct = QueryVisitor<'output, T>;
     type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
     type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
@@ -225,11 +241,11 @@ impl<'output, T: Type> ser::Serializer for QueryVisitor<'output, T> {
 
     /// Serialize a sequence, given length (if any) is ignored.
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
-        todo!();
+        Ok(QueryFieldPairSeqVisitor::new(self.output))
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Error> {
-        todo!();
+        Ok(QueryFieldPairSeqVisitor::new(self.output))
     }
 
     fn serialize_tuple_struct(
@@ -734,6 +750,301 @@ impl<'output, T: Type> ser::SerializeMap for QueryFieldMapVisitor<'output, T> {
         let result = value.serialize(ser);
         self.key.clear();
         result
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+enum QueryPairState {
+    Empty,
+    HasKey,
+    Done,
+}
+
+///Pair visitor that expects tuple with 2 elements
+struct QueryPairVisitor<'a, T> {
+    params: &'a mut Vec<QueryParam<'static>>,
+    key: &'a mut String,
+    state: QueryPairState,
+    _typ: marker::PhantomData<T>,
+}
+
+impl<'output, T: Type> ser::Serializer for QueryPairVisitor<'output, T> {
+    type Ok = ();
+    type Error = Error;
+    type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = QueryPairVisitor<'output, T>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_str(self, _: &str) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn collect_str<V: ?Sized + fmt::Display>(self, _: &V) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_some<V: ?Sized + ser::Serialize>(
+        self,
+        value: &V,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        if len == 2 {
+            Ok(self)
+        } else {
+            Err(Error::expected_pair())
+        }
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+
+    fn serialize_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_newtype_struct<V: ?Sized + ser::Serialize>(
+        self,
+        _: &'static str,
+        _: &V,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_newtype_variant<V: ?Sized + ser::Serialize>(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &V,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_i128(self, _: i128) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_u128(self, _: u128) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_pair())
+    }
+
+    fn collect_seq<I: IntoIterator>(self, _: I) -> Result<Self::Ok, Self::Error>
+    where
+        <I as IntoIterator>::Item: ser::Serialize,
+    {
+        Err(Error::expected_pair())
+    }
+
+    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(Error::expected_pair())
+    }
+}
+
+impl<'output, T: Type> ser::SerializeTuple for QueryPairVisitor<'output, T> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<V: ?Sized + ser::Serialize>(
+        &mut self,
+        value: &V,
+    ) -> Result<(), Self::Error> {
+        match mem::replace(&mut self.state, QueryPairState::Done) {
+            QueryPairState::Empty => {
+                let dest = KeyField { key: self.key };
+                value.serialize(dest)?;
+                self.state = QueryPairState::HasKey;
+                Ok(())
+            }
+            QueryPairState::HasKey => {
+                if self.key.is_empty() {
+                    return Err(Error::expected_non_empty_string_value());
+                }
+                let params = &mut *self.params;
+                let ser = QueryFieldVisitor::<T>::new(self.key, params);
+                value.serialize(ser)
+            }
+            //Unreachable unless bug in code
+            QueryPairState::Done => Err(Error::unexpected_pair_serde_error()),
+        }
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        match self.state {
+            QueryPairState::Done => Ok(()),
+            _ => Err(Error::unexpected_pair_serde_error()),
+        }
+    }
+}
+
+///Pair Sequence visitor
+pub struct QueryFieldPairSeqVisitor<'a, T> {
+    params: &'a mut Vec<QueryParam<'static>>,
+    key: String,
+    _typ: marker::PhantomData<T>,
+}
+
+impl<'a, T: Type> QueryFieldPairSeqVisitor<'a, T> {
+    fn new(params: &'a mut Vec<QueryParam<'static>>) -> Self {
+        Self {
+            params,
+            key: String::new(),
+            _typ: marker::PhantomData,
+        }
+    }
+
+    fn get_visitor(&mut self) -> QueryPairVisitor<'_, T> {
+        //Clear key storage for new pair
+        self.key.clear();
+        QueryPairVisitor::<T> {
+            params: &mut *self.params,
+            key: &mut self.key,
+            state: QueryPairState::Empty,
+            _typ: marker::PhantomData,
+        }
+    }
+}
+
+impl<'output, T: Type> ser::SerializeTuple for QueryFieldPairSeqVisitor<'output, T> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<E: ?Sized + ser::Serialize>(
+        &mut self,
+        value: &E,
+    ) -> Result<(), Self::Error> {
+        value.serialize(self.get_visitor())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'output, T: Type> ser::SerializeSeq for QueryFieldPairSeqVisitor<'output, T> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<E: ?Sized + ser::Serialize>(
+        &mut self,
+        value: &E,
+    ) -> Result<(), Self::Error> {
+        value.serialize(self.get_visitor())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {

--- a/src/serde/query.rs
+++ b/src/serde/query.rs
@@ -33,6 +33,20 @@ pub struct Error {
 }
 
 impl Error {
+    const fn expected_string_key() -> Self {
+        Self {
+            msg: Cow::Borrowed("Query key must be string"),
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    const fn expected_non_empty_string_value() -> Self {
+        Self {
+            msg: Cow::Borrowed("Query key cannot be empty string"),
+        }
+    }
+
     const fn expected_struct_like() -> Self {
         Self {
             msg: Cow::Borrowed("Query params expect struct/map"),
@@ -70,6 +84,7 @@ impl ser::Error for Error {
     }
 }
 
+///QueryParam serializer
 pub struct QueryVisitor<'a, T> {
     output: &'a mut Vec<QueryParam<'static>>,
     _typ: marker::PhantomData<T>,
@@ -97,7 +112,7 @@ impl<'output, T: Type> ser::Serializer for QueryVisitor<'output, T> {
     type Ok = ();
     type Error = Error;
     type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
-    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = QueryFieldMapVisitor<'output, T>;
     type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
     type SerializeStruct = QueryVisitor<'output, T>;
     type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
@@ -162,12 +177,12 @@ impl<'output, T: Type> ser::Serializer for QueryVisitor<'output, T> {
 
     /// Returns `Ok`.
     fn serialize_unit(self) -> Result<Self::Ok, Error> {
-        Err(Error::expected_struct_like())
+        Ok(())
     }
 
     /// Returns `Ok`.
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Error> {
-        Err(Error::expected_struct_like())
+        Ok(())
     }
 
     fn serialize_unit_variant(
@@ -222,7 +237,7 @@ impl<'output, T: Type> ser::Serializer for QueryVisitor<'output, T> {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Error> {
-        todo!();
+        Err(Error::expected_struct_like())
     }
 
     fn serialize_tuple_variant(
@@ -232,12 +247,12 @@ impl<'output, T: Type> ser::Serializer for QueryVisitor<'output, T> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Error> {
-        todo!();
+        Err(Error::expected_struct_like())
     }
 
     /// Serializes a map, given length is ignored.
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Error> {
-        todo!();
+        Ok(QueryFieldMapVisitor::new(self.output))
     }
 
     /// Serializes a struct, given length is ignored.
@@ -302,6 +317,7 @@ impl<'output, T: Type> ser::SerializeStruct for QueryVisitor<'output, T> {
     }
 }
 
+///Struct field's value visitor
 struct QueryFieldVisitor<'a, T> {
     params: &'a mut Vec<QueryParam<'static>>,
     key: &'a str,
@@ -482,5 +498,245 @@ impl<T: Type> ser::Serializer for QueryFieldVisitor<'_, T> {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Error> {
         Err(Error::expected_value())
+    }
+}
+
+//Serializer for dynamic key field.
+//
+//Key field must be string or string like type
+struct KeyField<'output> {
+    key: &'output mut String,
+}
+
+impl<'output> ser::Serializer for KeyField<'output> {
+    type Ok = ();
+    type Error = Error;
+    type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeSeq = ser::Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        self.key.push_str(value);
+        Ok(())
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        self.key.push(value);
+        Ok(())
+    }
+
+    fn collect_str<T: ?Sized + fmt::Display>(self, value: &T) -> Result<Self::Ok, Self::Error> {
+        use fmt::Write;
+
+        //Cannot fail
+        let _ = write!(self.key, "{value}");
+        Ok(())
+    }
+
+    fn serialize_some<T: ?Sized + ser::Serialize>(
+        self,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(
+        self,
+        _: &'static str,
+        _: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &T,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_i128(self, _: i128) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_u128(self, _: u128) -> Result<Self::Ok, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+
+    fn collect_seq<I: IntoIterator>(self, _: I) -> Result<Self::Ok, Self::Error>
+    where
+        <I as IntoIterator>::Item: ser::Serialize,
+    {
+        Err(Error::expected_string_key())
+    }
+
+    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(Error::expected_string_key())
+    }
+}
+
+///Map visitor
+pub struct QueryFieldMapVisitor<'a, T> {
+    params: &'a mut Vec<QueryParam<'static>>,
+    key: String,
+    _typ: marker::PhantomData<T>,
+}
+
+impl<'a, T: Type> QueryFieldMapVisitor<'a, T> {
+    fn new(params: &'a mut Vec<QueryParam<'static>>) -> Self {
+        Self {
+            params,
+            key: String::new(),
+            _typ: marker::PhantomData,
+        }
+    }
+}
+
+impl<'output, T: Type> ser::SerializeMap for QueryFieldMapVisitor<'output, T> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<K: ?Sized + ser::Serialize>(&mut self, key: &K) -> Result<(), Self::Error> {
+        let dest = KeyField { key: &mut self.key };
+        key.serialize(dest)
+    }
+
+    fn serialize_value<V: ?Sized + ser::Serialize>(
+        &mut self,
+        value: &V,
+    ) -> Result<(), Self::Error> {
+        if self.key.is_empty() {
+            return Err(Error::expected_non_empty_string_value());
+        }
+
+        let params = &mut *self.params;
+        let ser = QueryFieldVisitor::<T>::new(&self.key, params);
+        let result = value.serialize(ser);
+        self.key.clear();
+        result
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
     }
 }


### PR DESCRIPTION
I would like to propose serde based interface for query parameters similar to that of [reqwest](https://docs.rs/reqwest/latest/reqwest/struct.RequestBuilder.html#method.query)

While I prefer simplicity of ureq, this piece of interface is pretty nice feature in reqwest as it allows you to have statically typed query parameters.

Of course there is problem with serde interface is that you cannot validate it fully at compile time, but I think accidental panic should be minimal impact as otherwise user is most likely to use well defined structs.

This PR introduces interface with struct based implementation for review and consideration
@algesten, if you think this complexity is ok, I will add map/sequence/tuple serializers which has more complexity due to dynamic nature of `key` in these objects to finalise PR

The entry point to this interface is hidden behind `serde-query` which requires to include serde, itoa and ryu dependencies.
All serde implementation is defined in `src/serde/query.rs`