### PR TITLE
Send CONNECT Proxy-Authorization scheme as canonical "Basic"

### DIFF
--- a/src/unversioned/transport/connect.rs
+++ b/src/unversioned/transport/connect.rs
@@ -117,7 +117,9 @@ impl<In: Transport> Connector<In> for ConnectProxyConnector {
             let user = proxy.username().unwrap_or_default();
             let pass = proxy.password().unwrap_or_default();
             let creds = BASE64_STANDARD.encode(format!("{}:{}", user, pass));
-            write!(w, "Proxy-Authorization: basic {}\r\n", creds)?;
+            // "Basic" in canonical casing: the scheme is case-insensitive per
+            // RFC 9110, but some proxies reject the lowercase form outright.
+            write!(w, "Proxy-Authorization: Basic {}\r\n", creds)?;
         }
 
         write!(w, "\r\n")?;


### PR DESCRIPTION
One-character interop fix: the CONNECT tunnel's `Proxy-Authorization` header is written with a lowercase `basic` scheme. The scheme is case-insensitive per RFC 9110 §11.1, but in practice several commercial proxy providers reject the lowercase form outright — we observed live 407 "credentials are incorrect" responses from floppydata and Massive residential proxies that disappeared with `Basic`. curl, Go's net/http, and reqwest all send `Basic`.

It also makes ureq self-consistent: origin-server auth derived from URI credentials already sends `Basic` (asserted by the `username_password_from_uri` test), while the CONNECT path sends `basic`.

We have been shipping exactly this patch as a vendored fork in a production desktop app for several months against authenticated commercial HTTP proxies; this upstreams it. The same line exists on the 2.12.x branch (`src/proxy.rs`); I've opened a matching backport PR in case a 2.12.2 patch release is ever cut.