### PR TITLE
Send CONNECT Proxy-Authorization scheme as canonical "Basic" (2.12.x backport)

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -170,7 +170,9 @@ impl Proxy {
             ));
 
             match self.proto {
-                Proto::HTTP => format!("Proxy-Authorization: basic {}\r\n", creds),
+                // "Basic" in canonical casing: the scheme is case-insensitive per
+                // RFC 9110, but some proxies reject the lowercase form outright.
+                Proto::HTTP => format!("Proxy-Authorization: Basic {}\r\n", creds),
                 _ => String::new(),
             }
         } else {


### PR DESCRIPTION
Backport of #1185 to the 2.12.x branch — same one-character interop fix in `src/proxy.rs`: commercial proxy CONNECT endpoints (observed: floppydata, Massive) reject the lowercase `basic` scheme with 407 even though RFC 9110 makes the scheme case-insensitive; curl / Go net/http / reqwest all send `Basic`.

If a 2.12.2 patch release is ever cut this would let 2.x users (we've been carrying this as a vendored fork in production) drop their workarounds without migrating to 3.x. Totally understand if the branch is frozen — in that case feel free to close and we'll ride the 3.x fix when we migrate.