### PR TITLE
Remove redundant clone

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -396,7 +396,7 @@ fn connect(
         request_level,
         now: timings.now(),
         timeout: timings.next_timeout(Timeout::Connect),
-        current_time: timings.current_time().clone(),
+        current_time: timings.current_time(),
         run_connector: agent.run_connector.clone(),
     };
 


### PR DESCRIPTION
If I am not overlooking anything, I believe this clone is redundant and can thus be safely removed.

For reference, this change was found by an optimizer developed as a research project.

CC @nunoplopes
