### PR TITLE
Seal RequestExt

### DIFF
--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -2,6 +2,7 @@ use crate::agent::AgentInstance;
 use crate::config::typestate::RequestExtScope;
 use crate::config::{Config, ConfigBuilder, RequestLevelConfig};
 use crate::typestate::HttpCrateScope;
+use crate::util::private::Private;
 use crate::{Agent, AsSendBody, Body, Error, http};
 use std::ops::Deref;
 use ureq_proto::http::{Request, Response};
@@ -10,7 +11,7 @@ use ureq_proto::http::{Request, Response};
 ///
 /// Adds additional convenience methods to the `Request` that are not available
 /// in the plain http API.
-pub trait RequestExt<S>
+pub trait RequestExt<S>: Private
 where
     S: AsSendBody,
 {
@@ -153,6 +154,8 @@ pub enum AgentRef<'a> {
     Owned(Agent),
     Borrowed(&'a Agent),
 }
+
+impl<S: AsSendBody> Private for http::Request<S> {}
 
 impl<S: AsSendBody> RequestExt<S> for http::Request<S> {
     fn with_agent<'a>(self, agent: impl Into<AgentRef<'a>>) -> WithAgent<'a, S> {

--- a/src/request_ext.rs
+++ b/src/request_ext.rs
@@ -2,16 +2,19 @@ use crate::agent::AgentInstance;
 use crate::config::typestate::RequestExtScope;
 use crate::config::{Config, ConfigBuilder, RequestLevelConfig};
 use crate::typestate::HttpCrateScope;
-use crate::util::private::Private;
 use crate::{Agent, AsSendBody, Body, Error, http};
 use std::ops::Deref;
 use ureq_proto::http::{Request, Response};
+
+mod private {
+    pub trait Sealed {}
+}
 
 /// Extension trait for [`http::Request<impl AsSendBody>`].
 ///
 /// Adds additional convenience methods to the `Request` that are not available
 /// in the plain http API.
-pub trait RequestExt<S>: Private
+pub trait RequestExt<S>: private::Sealed
 where
     S: AsSendBody,
 {
@@ -155,7 +158,7 @@ pub enum AgentRef<'a> {
     Borrowed(&'a Agent),
 }
 
-impl<S: AsSendBody> Private for http::Request<S> {}
+impl<S: AsSendBody> private::Sealed for http::Request<S> {}
 
 impl<S: AsSendBody> RequestExt<S> for http::Request<S> {
     fn with_agent<'a>(self, agent: impl Into<AgentRef<'a>>) -> WithAgent<'a, S> {


### PR DESCRIPTION
## Summary

Seal `RequestExt` using ureq’s existing private trait so its implementation remains limited to `http::Request`.