### PR TITLE
Complete TLS handshakes while connecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Complete TLS handshake during connect so timeout_connect covers it #1193
   * Speed up read_json for responses with a known, small body size #1191
 
 # 3.4.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,17 +696,26 @@ impl<Scope: private::ConfigScope> ConfigBuilder<Scope> {
 
     /// Max duration for establishing the connection
     ///
-    /// For a TLS connection this includes opening the socket and doing the TLS handshake.
+    /// This covers opening the socket, negotiating with any proxy, and for a
+    /// TLS connection, completing the TLS handshake. The handshake is done as
+    /// part of connecting, so it is not covered by [`timeout_send_request`].
     ///
     /// Defaults to `None`.
+    ///
+    /// [`timeout_send_request`]: ConfigBuilder::timeout_send_request
     pub fn timeout_connect(mut self, v: Option<Duration>) -> Self {
         self.config().timeouts.connect = v;
         self
     }
 
-    /// Max duration for sending the request, but not the request body.
+    /// Max duration for sending the request headers, but not the request body.
+    ///
+    /// This starts after the connection (including any TLS handshake) is
+    /// established, see [`timeout_connect`].
     ///
     /// Defaults to `None`.
+    ///
+    /// [`timeout_connect`]: ConfigBuilder::timeout_connect
     pub fn timeout_send_request(mut self, v: Option<Duration>) -> Self {
         self.config().timeouts.send_request = v;
         self
@@ -739,7 +748,7 @@ impl<Scope: private::ConfigScope> ConfigBuilder<Scope> {
         self
     }
 
-    /// Max duration for receving the response body.
+    /// Max duration for receiving the response body.
     ///
     /// Defaults to `None`.
     pub fn timeout_recv_body(mut self, v: Option<Duration>) -> Self {
@@ -836,7 +845,7 @@ pub struct Timeouts {
     /// Max duration for doing the DNS lookup when establishing the connection
     pub resolve: Option<Duration>,
 
-    /// Max duration for establishing the connection.
+    /// Max duration for establishing the connection, including any TLS handshake.
     pub connect: Option<Duration>,
 
     /// Max duration for sending the request, but not the request body.
@@ -851,7 +860,7 @@ pub struct Timeouts {
     /// Max duration for receiving the response headers, but not the body
     pub recv_response: Option<Duration>,
 
-    /// Max duration for receving the response body.
+    /// Max duration for receiving the response body.
     pub recv_body: Option<Duration>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1260,20 +1260,29 @@ pub(crate) mod test {
     fn https_connect_proxy_to_https_target() {
         init_test_log();
 
-        let proxy = Proxy::new("https://proxy.test/https-connect-proxy").unwrap();
-        let tls = tls::TlsConfig::builder().disable_verification(true).build();
-        let agent = Agent::config_builder()
-            .proxy(Some(proxy))
-            .tls_config(tls)
-            .build()
-            .new_agent();
+        for provider in [
+            tls::TlsProvider::Rustls,
+            #[cfg(feature = "native-tls")]
+            tls::TlsProvider::NativeTls,
+        ] {
+            let proxy = Proxy::new("https://proxy.test/https-connect-proxy").unwrap();
+            let tls = tls::TlsConfig::builder()
+                .provider(provider)
+                .disable_verification(true)
+                .build();
+            let agent = Agent::config_builder()
+                .proxy(Some(proxy))
+                .tls_config(tls)
+                .build()
+                .new_agent();
 
-        let mut response = agent
-            .get("https://example.com/through-https-proxy")
-            .call()
-            .unwrap();
+            let mut response = agent
+                .get("https://example.com/through-https-proxy")
+                .call()
+                .unwrap();
 
-        assert_eq!(response.body_mut().read_to_string().unwrap(), "ok");
+            assert_eq!(response.body_mut().read_to_string().unwrap(), "ok");
+        }
     }
 
     #[test]

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -21,7 +21,7 @@ pub enum Timeout {
     /// Timeout in the resolver.
     Resolve,
 
-    /// Timeout while opening the connection.
+    /// Timeout while opening the connection, including any TLS handshake.
     Connect,
 
     /// Timeout while sending the request headers.

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -376,4 +376,109 @@ mod test {
         let c = TlsConfig::default();
         assert_no_alloc(|| c.clone());
     }
+
+    #[cfg(any(feature = "_rustls", feature = "native-tls"))]
+    mod handshake {
+        use std::sync::Arc;
+
+        use crate::tls::{TlsConfig, TlsProvider};
+        use crate::transport::time::{Duration, Instant};
+        use crate::transport::{Buffers, ConnectionDetails, Connector, LazyBuffers};
+        use crate::transport::{NextTimeout, Transport};
+        use crate::unversioned::resolver::{DefaultResolver, Resolver};
+        use crate::{Agent, Error, Timeout};
+
+        #[derive(Debug)]
+        struct TimeoutTransport {
+            buffers: LazyBuffers,
+            timeout: NextTimeout,
+        }
+
+        impl Transport for TimeoutTransport {
+            fn buffers(&mut self) -> &mut dyn Buffers {
+                &mut self.buffers
+            }
+
+            fn transmit_output(
+                &mut self,
+                _amount: usize,
+                timeout: NextTimeout,
+            ) -> Result<(), Error> {
+                assert_eq!(timeout, self.timeout);
+                Err(Error::Timeout(timeout.reason))
+            }
+
+            fn await_input(&mut self, timeout: NextTimeout) -> Result<bool, Error> {
+                assert_eq!(timeout, self.timeout);
+                Err(Error::Timeout(timeout.reason))
+            }
+
+            fn is_open(&mut self) -> bool {
+                true
+            }
+        }
+
+        fn check_timeout(connector: impl Connector<TimeoutTransport>, tls_config: TlsConfig) {
+            let config = Agent::config_builder()
+                .proxy(None)
+                .tls_config(tls_config)
+                .build();
+            let uri = "https://example.com/".parse().unwrap();
+            let resolver = DefaultResolver::default();
+
+            for reason in [Timeout::Connect, Timeout::Global] {
+                let timeout = NextTimeout {
+                    after: Duration::from_secs(7),
+                    reason,
+                };
+                let details = ConnectionDetails {
+                    uri: &uri,
+                    addrs: resolver.empty(),
+                    resolver: &resolver,
+                    config: &config,
+                    request_level: false,
+                    now: Instant::now(),
+                    timeout,
+                    current_time: Arc::new(Instant::now),
+                    run_connector: Arc::new(|_| unreachable!("TLS must use the chained transport")),
+                };
+                let transport = TimeoutTransport {
+                    buffers: LazyBuffers::new(1024, 1024),
+                    timeout,
+                };
+
+                let error = connector.connect(&details, Some(transport)).unwrap_err();
+                assert!(
+                    matches!(error, Error::Timeout(actual) if actual == reason),
+                    "{error:?}"
+                );
+            }
+        }
+
+        #[test]
+        #[cfg(feature = "_rustls")]
+        fn rustls_uses_connection_timeout() {
+            let tls_config = TlsConfig::builder()
+                .provider(TlsProvider::Rustls)
+                .disable_verification(true)
+                .unversioned_rustls_crypto_provider(Arc::new(
+                    ::rustls::crypto::aws_lc_rs::default_provider(),
+                ))
+                .build();
+            check_timeout(crate::tls::rustls::RustlsConnector::default(), tls_config);
+        }
+
+        #[test]
+        #[cfg(feature = "native-tls")]
+        fn native_tls_uses_connection_timeout() {
+            let tls_config = TlsConfig::builder()
+                .provider(TlsProvider::NativeTls)
+                .disable_verification(true)
+                .build();
+            check_timeout(
+                crate::tls::native_tls::NativeTlsConnector::default(),
+                tls_config,
+            );
+        }
+    }
 }

--- a/src/tls/native_tls.rs
+++ b/src/tls/native_tls.rs
@@ -5,7 +5,7 @@ use std::{fmt, io};
 
 use crate::tls::{RootCerts, TlsProvider};
 use crate::util::AuthorityExt;
-use crate::{Error, transport::time::Duration, transport::*};
+use crate::{Error, transport::*};
 use der::Document;
 use der::pem::LineEnding;
 use native_tls::{Certificate, HandshakeError, Identity, TlsConnector};
@@ -61,8 +61,28 @@ impl<In: Transport> Connector<In> for NativeTlsConnector {
             .host_bare()
             .to_string();
 
-        let adapter = ErrorCapture::wrap(TransportAdapter::new(transport.boxed()));
-        let stream = LazyStream::Unstarted(Some((connector, domain, adapter)));
+        let mut adapter = ErrorCapture::wrap(TransportAdapter::new(transport.boxed()));
+        adapter.get_mut().set_timeout(details.timeout);
+        let capture = adapter.capture();
+
+        let result = connector.connect(&domain, adapter).map_err(|e| match e {
+            HandshakeError::Failure(e) => e,
+            HandshakeError::WouldBlock(_) => unreachable!(),
+        });
+
+        let stream = match result {
+            Ok(v) => v,
+            Err(e) => {
+                // Preserve the underlying transport error, such as a timeout,
+                // instead of the less specific native-tls error.
+                let mut lock = capture.lock().unwrap();
+                if let Some(error) = lock.take() {
+                    return Err(error);
+                }
+
+                return Err(e.into());
+            }
+        };
 
         let buffers = LazyBuffers::new(
             details.config.input_buffer_size(),
@@ -218,7 +238,7 @@ fn pemify(der: &[u8], label: &'static str) -> Result<String, Error> {
 
 pub struct NativeTlsTransport {
     buffers: LazyBuffers,
-    stream: LazyStream,
+    stream: TlsStream<ErrorCapture<TransportAdapter>>,
 }
 
 impl Transport for NativeTlsTransport {
@@ -227,7 +247,7 @@ impl Transport for NativeTlsTransport {
     }
 
     fn transmit_output(&mut self, amount: usize, timeout: NextTimeout) -> Result<(), Error> {
-        let stream = self.stream.handshaken(timeout)?;
+        let stream = &mut self.stream;
         stream.get_mut().get_mut().set_timeout(timeout);
 
         let output = &self.buffers.output()[..amount];
@@ -243,7 +263,7 @@ impl Transport for NativeTlsTransport {
     }
 
     fn await_input(&mut self, timeout: NextTimeout) -> Result<bool, Error> {
-        let stream = self.stream.handshaken(timeout)?;
+        let stream = &mut self.stream;
         stream.get_mut().get_mut().set_timeout(timeout);
 
         let input = self.buffers.input_append_buf();
@@ -273,15 +293,7 @@ impl Transport for NativeTlsTransport {
     }
 
     fn is_open(&mut self) -> bool {
-        let timeout = NextTimeout {
-            after: Duration::Exact(std::time::Duration::from_secs(1)),
-            reason: crate::Timeout::Global,
-        };
-
-        self.stream
-            .handshaken(timeout)
-            .map(|c| c.get_mut().get_mut().get_mut().is_open())
-            .unwrap_or(false)
+        self.stream.get_mut().get_mut().get_mut().is_open()
     }
 
     fn is_tls(&self) -> bool {
@@ -289,54 +301,6 @@ impl Transport for NativeTlsTransport {
     }
 }
 
-/// Helper to delay the handshake until we are starting IO.
-/// This normalizes native-tls to behave like rustls.
-enum LazyStream {
-    Unstarted(Option<(Arc<TlsConnector>, String, ErrorCapture<TransportAdapter>)>),
-    Started(TlsStream<ErrorCapture<TransportAdapter>>),
-}
-
-impl LazyStream {
-    fn handshaken(
-        &mut self,
-        timeout: NextTimeout,
-    ) -> Result<&mut TlsStream<ErrorCapture<TransportAdapter>>, Error> {
-        match self {
-            LazyStream::Unstarted(v) => {
-                let (conn, domain, mut adapter) = v.take().unwrap();
-
-                // Respect timeout during TLS handshake
-                adapter.get_mut().set_timeout(timeout);
-                let capture = adapter.capture();
-
-                let result = conn.connect(&domain, adapter).map_err(|e| match e {
-                    HandshakeError::Failure(e) => e,
-                    HandshakeError::WouldBlock(_) => unreachable!(),
-                });
-
-                let stream = match result {
-                    Ok(v) => v,
-                    Err(e) => {
-                        // The error might originate in a Error::Timeout in the underlying adapter.
-                        // If so, we receive that error in this mpsc::Receiver. That's a more specific
-                        // error than the NativeTls::Error type.
-                        let mut lock = capture.lock().unwrap();
-                        if let Some(error) = lock.take() {
-                            return Err(error);
-                        }
-
-                        return Err(e.into());
-                    }
-                };
-
-                *self = LazyStream::Started(stream);
-                // Next time we hit the other match arm
-                self.handshaken(timeout)
-            }
-            LazyStream::Started(v) => Ok(v),
-        }
-    }
-}
 impl fmt::Debug for NativeTlsConnector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NativeTlsConnector").finish()

--- a/src/tls/rustls.rs
+++ b/src/tls/rustls.rs
@@ -72,11 +72,11 @@ impl<In: Transport> Connector<In> for RustlsConnector {
 
         let name = name_borrowed.to_owned();
 
-        let conn = ClientConnection::new(config, name)?;
-        let stream = StreamOwned {
-            conn,
-            sock: TransportAdapter::new(transport.boxed()),
-        };
+        let mut conn = ClientConnection::new(config, name)?;
+        let mut sock = TransportAdapter::new(transport.boxed());
+        sock.set_timeout(details.timeout);
+        conn.complete_io(&mut sock)?;
+        let stream = StreamOwned { conn, sock };
 
         let buffers = LazyBuffers::new(
             details.config.input_buffer_size(),


### PR DESCRIPTION
A short send-request timeout can abort TLS establishment despite a longer connection timeout. The connection timeout is documented to cover TLS [1], but both rustls and native-tls defer handshaking until the first request write. The request loop has already marked Connect complete by then, so handshake I/O receives the timeout selected for SendRequest.

Connect-only configurations retain some handshake protection because the scheduler incorrectly checks completed-phase timeouts during later phases [2]. Correcting that accounting without moving the handshake would remove this accidental protection.

Complete each handshake inside its TLS connector, using the connection-phase timeout, before returning the transport. The Connect completion timestamp then follows TLS establishment, and a short send-request timeout no longer interrupts handshake I/O. The connector tests check that handshaking happens before return and that underlying timeout errors keep their original reason.

[1]: https://github.com/algesten/ureq/blob/5e803fc4ce031a0d667dc6cdb97d1413ac8cdab9/src/config.rs#L697-L711
[2]: https://github.com/algesten/ureq/blob/5e803fc4ce031a0d667dc6cdb97d1413ac8cdab9/src/timings.rs#L45-L175
