### PR TITLE
Anchor timeout budgets to phase boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Fix timeout budgets restarting and applying to later phases #1194
   * Complete TLS handshake during connect so timeout_connect covers it #1193
   * Speed up read_json for responses with a known, small body size #1191
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -742,15 +742,25 @@ impl<Scope: private::ConfigScope> ConfigBuilder<Scope> {
 
     /// Max duration for receiving the response headers, but not the body
     ///
+    /// This stops applying once the response headers have been received.
+    /// Reading the body is covered separately by [`timeout_recv_body`].
+    ///
     /// Defaults to `None`.
+    ///
+    /// [`timeout_recv_body`]: ConfigBuilder::timeout_recv_body
     pub fn timeout_recv_response(mut self, v: Option<Duration>) -> Self {
         self.config().timeouts.recv_response = v;
         self
     }
 
-    /// Max duration for receiving the response body.
+    /// Max total duration for receiving the response body.
+    ///
+    /// This starts when the response headers have been received, see
+    /// [`timeout_recv_response`]. The budget is not restarted for each read.
     ///
     /// Defaults to `None`.
+    ///
+    /// [`timeout_recv_response`]: ConfigBuilder::timeout_recv_response
     pub fn timeout_recv_body(mut self, v: Option<Duration>) -> Self {
         self.config().timeouts.recv_body = v;
         self
@@ -860,7 +870,7 @@ pub struct Timeouts {
     /// Max duration for receiving the response headers, but not the body
     pub recv_response: Option<Duration>,
 
-    /// Max duration for receiving the response body.
+    /// Max total duration for receiving the response body.
     pub recv_body: Option<Duration>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1432,34 +1432,50 @@ pub(crate) mod test {
 
     #[test]
     fn recv_body_timeout_is_total() {
-        use std::io::{Read, Write};
-        use std::net::TcpListener;
+        use std::io::Write;
         use std::thread;
         use std::time::Duration;
 
         init_test_log();
 
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut buf = [0u8; 4096];
-            let _ = stream.read(&mut buf);
-            stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n")
-                .unwrap();
-            // Send the body after the recv_body budget has expired.
+        // Server sends the response headers immediately, but the body only
+        // after the recv_body budget has expired.
+        fn respond(w: &mut dyn Write) -> io::Result<()> {
+            w.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n")?;
             thread::sleep(Duration::from_millis(900));
-            let _ = stream.write_all(b"body");
-        });
+            w.write_all(b"body")
+        }
+
+        #[cfg(feature = "_test")]
+        let url = {
+            crate::transport::set_handler_raw("/slow-body", respond);
+            "http://example.org/slow-body".to_string()
+        };
+
+        #[cfg(not(feature = "_test"))]
+        let url = {
+            use std::io::Read;
+            use std::net::TcpListener;
+
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+
+            thread::spawn(move || {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let _ = respond(&mut stream);
+            });
+
+            format!("http://{}/slow-body", addr)
+        };
 
         let agent: Agent = Agent::config_builder()
             .timeout_recv_body(Some(Duration::from_millis(500)))
             .build()
             .into();
 
-        let mut res = agent.get(format!("http://{}/", addr)).call().unwrap();
+        let mut res = agent.get(url).call().unwrap();
 
         // Let the body budget run out before issuing the first read. Transports
         // cannot set a zero socket timeout, so without an explicit expiry check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1429,4 +1429,48 @@ pub(crate) mod test {
         let err = Error::HostNotFound;
         is_sync(err);
     }
+
+    #[test]
+    fn recv_body_timeout_is_total() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+        use std::time::Duration;
+
+        init_test_log();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n")
+                .unwrap();
+            // Send the body after the recv_body budget has expired.
+            thread::sleep(Duration::from_millis(900));
+            let _ = stream.write_all(b"body");
+        });
+
+        let agent: Agent = Agent::config_builder()
+            .timeout_recv_body(Some(Duration::from_millis(500)))
+            .build()
+            .into();
+
+        let mut res = agent.get(format!("http://{}/", addr)).call().unwrap();
+
+        // Let the body budget run out before issuing the first read. Transports
+        // cannot set a zero socket timeout, so without an explicit expiry check
+        // this read would be granted a fresh grace period instead of failing.
+        thread::sleep(Duration::from_millis(700));
+
+        let err = res.body_mut().read_to_string().unwrap_err();
+        assert!(
+            matches!(err, Error::Timeout(Timeout::RecvBody)),
+            "unexpected error: {:?}",
+            err
+        );
+    }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -106,10 +106,18 @@ impl Connection {
     }
 
     pub fn transmit_output(&mut self, amount: usize, timeout: NextTimeout) -> Result<(), Error> {
+        // An already expired budget must fail here. Transports can't set a zero
+        // socket timeout and would instead grant a short grace period per call.
+        if timeout.after.is_zero() {
+            return Err(Error::Timeout(timeout.reason));
+        }
         self.transport.transmit_output(amount, timeout)
     }
 
     pub fn maybe_await_input(&mut self, timeout: NextTimeout) -> Result<bool, Error> {
+        if timeout.after.is_zero() {
+            return Err(Error::Timeout(timeout.reason));
+        }
         self.transport.maybe_await_input(timeout)
     }
 

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -51,7 +51,7 @@ impl Timeout {
             Timeout::SendRequest => &[Timeout::Connect],
             Timeout::Await100 => &[Timeout::SendRequest],
             Timeout::SendBody => &[Timeout::SendRequest, Timeout::Await100],
-            Timeout::RecvResponse => &[Timeout::SendRequest, Timeout::SendBody],
+            Timeout::RecvResponse => &[Timeout::SendRequest, Timeout::Await100, Timeout::SendBody],
             Timeout::RecvBody => &[Timeout::RecvResponse],
             _ => &[],
         };
@@ -62,9 +62,7 @@ impl Timeout {
     /// All timeouts to check
     fn timeouts_to_check(&self) -> impl Iterator<Item = Timeout> {
         // Always check Global and PerCall
-        once(*self)
-            .chain(self.preceeding())
-            .chain([Timeout::Global, Timeout::PerCall])
+        once(*self).chain([Timeout::Global, Timeout::PerCall])
     }
 
     /// Get the corresponding configured timeout
@@ -156,12 +154,17 @@ impl CallTimings {
         let (reason, at) = timeout
             .timeouts_to_check()
             .filter_map(|to_check| {
-                let time = if to_check == timeout {
-                    now
-                } else {
-                    self.time_of(to_check)?
-                };
                 let timeout = to_check.configured_timeout(&self.timeouts)?;
+                // Global and PerCall record their starts. Other timestamps
+                // record completion, which starts the next phase's budget.
+                let time = match to_check {
+                    Timeout::Global | Timeout::PerCall => self.time_of(to_check),
+                    _ => to_check
+                        .preceeding()
+                        .filter_map(|previous| self.time_of(previous))
+                        .max(),
+                }
+                .expect("timeout has no recorded start");
                 Some((to_check, time + timeout))
             })
             .min_by(|a, b| a.1.cmp(&b.1))
@@ -232,5 +235,144 @@ impl fmt::Display for Timeout {
             Timeout::RecvBody => "receive body",
         };
         write!(f, "{}", r)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Mutex;
+    use std::time::Duration as StdDuration;
+
+    use super::*;
+
+    fn with_clock(timeouts: Timeouts) -> (CallTimings, Arc<Mutex<Instant>>) {
+        let clock = Arc::new(Mutex::new(Instant::now()));
+        let current_time = CurrentTime(Arc::new({
+            let clock = Arc::clone(&clock);
+            move || *clock.lock().unwrap()
+        }));
+        (CallTimings::new(timeouts, current_time), clock)
+    }
+
+    #[test]
+    fn response_timeout_does_not_limit_body() {
+        let (mut timings, clock) = with_clock(Timeouts {
+            recv_response: Some(StdDuration::from_secs(10)),
+            ..Timeouts::default()
+        });
+        for phase in [
+            Timeout::Resolve,
+            Timeout::Connect,
+            Timeout::SendRequest,
+            Timeout::RecvResponse,
+        ] {
+            timings.record_time(phase);
+        }
+        let start = timings.now();
+        *clock.lock().unwrap() = start + Duration::from_secs(20);
+        assert_eq!(
+            timings.next_timeout(Timeout::RecvBody),
+            NextTimeout {
+                after: Duration::NotHappening,
+                reason: Timeout::Global
+            }
+        );
+    }
+
+    #[test]
+    fn phase_budget_starts_after_latest_predecessor() {
+        use Timeout::*;
+
+        let cases: &[(Timeout, &[Timeout], u64)] = &[
+            (Resolve, &[], 10),
+            (Connect, &[Resolve], 10),
+            (SendRequest, &[Resolve, Connect], 2),
+            (Await100, &[Resolve, Connect, SendRequest], 3),
+            (SendBody, &[Resolve, Connect, SendRequest], 20),
+            (SendBody, &[Resolve, Connect, SendRequest, Await100], 20),
+            (RecvResponse, &[Resolve, Connect, SendRequest], 30),
+            (RecvResponse, &[Resolve, Connect, SendRequest, SendBody], 30),
+            (RecvResponse, &[Resolve, Connect, SendRequest, Await100], 30),
+            (
+                RecvResponse,
+                &[Resolve, Connect, SendRequest, Await100, SendBody],
+                30,
+            ),
+            (RecvBody, &[Resolve, Connect, SendRequest, RecvResponse], 40),
+        ];
+        for &(phase, predecessors, budget) in cases {
+            let (mut timings, clock) = with_clock(Timeouts {
+                resolve: Some(StdDuration::from_secs(10)),
+                connect: Some(StdDuration::from_secs(10)),
+                send_request: Some(StdDuration::from_secs(2)),
+                await_100: Some(StdDuration::from_secs(3)),
+                send_body: Some(StdDuration::from_secs(20)),
+                recv_response: Some(StdDuration::from_secs(30)),
+                recv_body: Some(StdDuration::from_secs(40)),
+                ..Timeouts::default()
+            });
+            let mut start = timings.now();
+            for &predecessor in predecessors {
+                start = start + Duration::from_secs(1);
+                *clock.lock().unwrap() = start;
+                timings.record_time(predecessor);
+            }
+            for elapsed in [0, 1, budget, budget + 1] {
+                *clock.lock().unwrap() = start + Duration::from_secs(elapsed);
+                assert_eq!(
+                    timings.next_timeout(phase),
+                    NextTimeout {
+                        after: Duration::from_secs(budget.saturating_sub(elapsed)),
+                        reason: phase,
+                    },
+                    "{phase:?} after {predecessors:?}, elapsed {elapsed}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn redirects_reset_per_call_but_not_global_budget() {
+        let (mut timings, clock) = with_clock(Timeouts {
+            global: Some(StdDuration::from_secs(30)),
+            per_call: Some(StdDuration::from_secs(10)),
+            resolve: Some(StdDuration::from_secs(20)),
+            ..Timeouts::default()
+        });
+        let start = timings.now();
+        *clock.lock().unwrap() = start + Duration::from_secs(4);
+        assert_eq!(
+            timings.next_timeout(Timeout::Resolve),
+            NextTimeout {
+                after: Duration::from_secs(6),
+                reason: Timeout::PerCall
+            }
+        );
+        for elapsed in [6, 12, 18, 24] {
+            *clock.lock().unwrap() = start + Duration::from_secs(elapsed);
+            timings = timings.new_call();
+            let remaining = 30 - elapsed;
+            assert_eq!(
+                timings.next_timeout(Timeout::Resolve),
+                NextTimeout {
+                    after: Duration::from_secs(remaining.min(10)),
+                    reason: if remaining < 10 {
+                        Timeout::Global
+                    } else {
+                        Timeout::PerCall
+                    },
+                }
+            );
+        }
+        for elapsed in [27, 30, 31] {
+            *clock.lock().unwrap() = start + Duration::from_secs(elapsed);
+            assert_eq!(
+                timings.next_timeout(Timeout::Global),
+                NextTimeout {
+                    after: Duration::from_secs(30_u64.saturating_sub(elapsed)),
+                    reason: Timeout::Global,
+                }
+            );
+        }
     }
 }

--- a/src/unversioned/transport/mod.rs
+++ b/src/unversioned/transport/mod.rs
@@ -51,7 +51,7 @@ pub use connect::ConnectProxyConnector;
 #[cfg(feature = "_test")]
 mod test;
 #[cfg(feature = "_test")]
-pub use test::{set_handler, set_handler_cb};
+pub use test::{set_handler, set_handler_cb, set_handler_raw};
 
 #[cfg(feature = "socks-proxy")]
 mod socks;

--- a/src/unversioned/transport/test.rs
+++ b/src/unversioned/transport/test.rs
@@ -162,6 +162,18 @@ pub fn set_handler_cb(
     HANDLERS.with(|h| (*h).borrow_mut().push(handler));
 }
 
+/// Helper for **_test** feature tests that need full control over the response bytes.
+#[cfg(feature = "_test")]
+#[doc(hidden)]
+pub fn set_handler_raw(
+    pattern: &'static str,
+    handler: impl Fn(&mut dyn Write) -> io::Result<()> + Send + Sync + 'static,
+) {
+    let handler = TestHandler::new(pattern, move |_uri, _req, w| handler(w));
+
+    HANDLERS.with(|h| (*h).borrow_mut().push(handler));
+}
+
 #[derive(Clone)]
 struct TestHandler {
     pattern: &'static str,


### PR DESCRIPTION
Aya's kernel-package downloads can fail while copying the response body with "timeout: receive response" [1]. timeout_recv_response is documented to exclude the body [2], but its deadline remains a candidate during body reads.

Phase timestamps record completion, yet the scheduler adds each completed phase's own timeout to that timestamp and checks the result in the next phase (650e9c2cc358). The active phase's deadline also restarts at the current time on every lookup (78555734b084), allowing repeated reads to renew the body budget.

Anchor the active phase's budget to its latest completed predecessor and compare only that deadline with the recorded global and per-call deadlines. Completed-phase limits then stop affecting later phases, while repeated lookups preserve the active deadline. Clock-based regression tests cover expiry, optional phase transitions, and global/per-call accounting across redirects.

[1]: https://github.com/aya-rs/aya/actions/runs/32503366233/job/96838036031
[2]: https://github.com/algesten/ureq/blob/5e803fc4ce031a0d667dc6cdb97d1413ac8cdab9/src/config.rs#L734-L751
